### PR TITLE
Prepare for 8.0.0.Alpha1 release of quickstarts

### DIFF
--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>bean-validation</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
 
     <name>JBoss AS Quickstarts: Bean Validation</name>

--- a/bmt/pom.xml
+++ b/bmt/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-bmt</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Bean Managed Transactions</name>
     <description>JBoss AS Quickstarts: Bean Managed Transactions</description>

--- a/carmart-tx/pom.xml
+++ b/carmart-tx/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.jboss.datagrid.quickstart</groupId>
     <artifactId>jboss-as-carmart-tx</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>Transactional CarMart</name>
 

--- a/carmart/pom.xml
+++ b/carmart/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.jboss.datagrid.quickstart</groupId>
     <artifactId>jboss-as-carmart</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>CarMart Single Node (No Cluster)</name>
 

--- a/cdi-add-interceptor-binding/pom.xml
+++ b/cdi-add-interceptor-binding/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-cdi-add-interceptor-binding</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: CDI Portable Extension, add an interceptor binding</name>
     <description>CDI Portable Extension, add an interceptor binding: An example of a Portable Extension and some of the APIs / SPIs of CDI</description>

--- a/cdi-alternative/pom.xml
+++ b/cdi-alternative/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>cdi-alternative</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: CDI Alternative</name>
     <description>JBoss AS Quickstarts: CDI Alternative</description>

--- a/cdi-injection/pom.xml
+++ b/cdi-injection/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-cdi-injection</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: CDI Injection</name>
     <description>JBoss AS Quickstarts: CDI Injection</description>

--- a/cdi-portable-extension/pom.xml
+++ b/cdi-portable-extension/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-cdi-portable-extension</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: CDI Portable Extension</name>
     <description>CDI Portable Extension: An example of a Portable Extension and some of the APIs / SPIs of CDI</description>

--- a/cdi-veto/pom.xml
+++ b/cdi-veto/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-cdi-veto</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: CDI Veto</name>
     <description>CDI Veto: An example of a Portable Extension and some of the APIs / SPIs of CDI demonstrating veto</description>

--- a/cluster-ha-singleton/client/pom.xml
+++ b/cluster-ha-singleton/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-cluster-ha-singleton</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <name>JBoss AS Quickstarts: SingletonService (client)</name>

--- a/cluster-ha-singleton/pom.xml
+++ b/cluster-ha-singleton/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-cluster-ha-singleton</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>pom</packaging>
     <name>JBoss AS Quickstarts: SingletonService</name>
     <description>JBoss AS Quickstarts: A SingletonService deployed in a JAR started by SingletonStartup and accessed by an EJB</description>

--- a/cluster-ha-singleton/service/pom.xml
+++ b/cluster-ha-singleton/service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-cluster-ha-singleton</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <name>JBoss AS Quickstarts: SingletonService (service)</name>

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-cmt</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <name>JBoss AS Quickstarts: Container Managed Transactions</name>
     <description>CMT: Using transactions managed by the container</description>
     <packaging>war</packaging>

--- a/deltaspike-authorization/pom.xml
+++ b/deltaspike-authorization/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-deltaspike-authorization</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: DeltaSpike Authorization</name>
     <description>DeltaSpike Authorization: shows a custom authorization example using security binding types from DeltaSpike</description>

--- a/deltaspike-beanbuilder/pom.xml
+++ b/deltaspike-beanbuilder/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-deltaspike-beanbuilder</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: DeltaSpike BeanBuilder</name>
     <description>DeltaSpike BeanBuilder: show how to create new beans using DeltaSpike utilities</description>

--- a/deltaspike-beanmanagerprovider/pom.xml
+++ b/deltaspike-beanmanagerprovider/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-deltaspike-beanmanagerprovider</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: DeltaSpike Beanmanagerprovider</name>
     <description>DeltaSpike Beanmanagerprovider: shows how to use DeltaSpike BeanManagerProvider to access CDI in a EntityListener</description>

--- a/deltaspike-deactivatable/pom.xml
+++ b/deltaspike-deactivatable/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-deltaspike-deactivatable</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: DeltaSpike Deactivatable</name>
     <description>DeltaSpike Deactivatable: Demonstrate usage of Deactivatable</description>

--- a/deltaspike-exception-handling/pom.xml
+++ b/deltaspike-exception-handling/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ds-exception-handling</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: DeltaSpike Exception Handling</name>
     <description>DeltaSpike Exception Handling: Exception being handled by different handlers and purpose</description>

--- a/deltaspike-helloworld-jms/pom.xml
+++ b/deltaspike-helloworld-jms/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-deltaspike-helloworld-jms</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: deltaspike-helloworld-jms</name>
     <description>deltaspike-helloworld-jms: Helloworld JMS producer/consumer client with DeltaSpike property configuration</description>

--- a/deltaspike-projectstage/pom.xml
+++ b/deltaspike-projectstage/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-deltaspike-projectstage</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: DeltaSpike Project Stage</name>
     <description>DeltaSpike Project Stage: shows how to use DeltaSpike ProjectStage that allows to use implementations depending on the current environment</description>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-quickstarts-dist</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>pom</packaging>
     <name>JBoss AS Quickstarts Distribution</name>
     <description>JBoss AS Quickstarts Distribution</description>

--- a/ejb-asynchronous/client/pom.xml
+++ b/ejb-asynchronous/client/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-ejb-asynchronous</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <licenses>

--- a/ejb-asynchronous/ejb/pom.xml
+++ b/ejb-asynchronous/ejb/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-ejb-asynchronous</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <licenses>

--- a/ejb-asynchronous/pom.xml
+++ b/ejb-asynchronous/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-asynchronous</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>pom</packaging>
     <name>JBoss AS Quickstarts: Asynchronous method invocations</name>
     <description>ejb-asynchronous: Demonstrates asynchronous method invocations on an EJB</description>

--- a/ejb-in-ear/ear/pom.xml
+++ b/ejb-in-ear/ear/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>jboss-as-ejb-in-ear</artifactId>
         <groupId>org.jboss.as.quickstarts</groupId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-ejb-in-ear-ear</artifactId>

--- a/ejb-in-ear/ejb/pom.xml
+++ b/ejb-in-ear/ejb/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>jboss-as-ejb-in-ear</artifactId>
         <groupId>org.jboss.as.quickstarts</groupId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-ejb-in-ear-ejb</artifactId>

--- a/ejb-in-ear/pom.xml
+++ b/ejb-in-ear/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-in-ear</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <name>JBoss AS Quickstarts: EJB and War in an Ear - Root pom</name>
     <description>JBoss AS Quickstarts: EJB and War in an Root pom</description>
     <packaging>pom</packaging>

--- a/ejb-in-ear/web/pom.xml
+++ b/ejb-in-ear/web/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>jboss-as-ejb-in-ear</artifactId>
         <groupId>org.jboss.as.quickstarts</groupId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-ejb-in-ear-web</artifactId>

--- a/ejb-in-war/pom.xml
+++ b/ejb-in-war/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-in-war</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: EJB in a War</name>
     <description>JBoss AS Quickstarts: EJB in War</description>

--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -21,7 +21,7 @@
 
    <groupId>org.jboss.as.quickstarts</groupId>
    <artifactId>jboss-as-ejb-remote-client</artifactId>
-   <version>7.1.2-SNAPSHOT</version>
+   <version>8.0.0.Alpha1</version>
    <packaging>jar</packaging>
    <name>JBoss AS Quickstarts: EJB Remote Client</name>
    <description>JBoss AS Quickstarts: Java client for remote EJB</description>

--- a/ejb-remote/pom.xml
+++ b/ejb-remote/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-remote-parent</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>pom</packaging>
     <name>JBoss AS Quickstarts: Parent for remote EJB and Java client</name>
 

--- a/ejb-remote/server-side/pom.xml
+++ b/ejb-remote/server-side/pom.xml
@@ -21,7 +21,7 @@
  
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-remote-server-side</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>ejb</packaging>
     <name>JBoss AS Quickstarts: Server side of remote EJB</name>
 

--- a/ejb-security-interceptors/pom.xml
+++ b/ejb-security-interceptors/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-security-interceptors</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>jar</packaging>
     <name>JBoss AS Quickstarts: EJB Security Interceptors</name>
     <description>JBoss AS Quickstarts: EJB Security Interceptors</description>

--- a/ejb-security-plus/pom.xml
+++ b/ejb-security-plus/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-security-plus</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>jar</packaging>
     <name>JBoss AS Quickstarts: EJB Security Plus</name>
     <description>JBoss AS Quickstarts: EJB Security Plus</description>

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-security</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: EJB Security</name>
     <description>JBoss AS Quickstarts: EJB Security</description>

--- a/ejb-throws-exception/ear/pom.xml
+++ b/ejb-throws-exception/ear/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-ejb-throws-exception</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>ejb-throws-exception-ear</artifactId>

--- a/ejb-throws-exception/ejb-api/pom.xml
+++ b/ejb-throws-exception/ejb-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-ejb-throws-exception</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-ejb-throws-exception-ejb-api</artifactId>

--- a/ejb-throws-exception/ejb/pom.xml
+++ b/ejb-throws-exception/ejb/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>jboss-as-ejb-throws-exception</artifactId>
         <groupId>org.jboss.as.quickstarts</groupId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-ejb-throws-exception-ejb</artifactId>

--- a/ejb-throws-exception/pom.xml
+++ b/ejb-throws-exception/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-ejb-throws-exception</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>pom</packaging>
     <name>JBoss AS Quickstarts: EJB throws exception</name>
     <description>JBoss AS Quickstarts: EJB throws exception, caught by web layer</description>

--- a/ejb-throws-exception/web/pom.xml
+++ b/ejb-throws-exception/web/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-ejb-throws-exception</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-ejb-throws-exception-web</artifactId>

--- a/greeter-spring/pom.xml
+++ b/greeter-spring/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-greeter-spring</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Greeter Spring</name>
     <description>JBoss AS Quickstarts: Greeter Spring</description>

--- a/greeter/pom.xml
+++ b/greeter/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-greeter</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Greeter</name>
     <description>JBoss AS Quickstarts: Greeter</description>

--- a/helloworld-errai/pom.xml
+++ b/helloworld-errai/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-helloworld-errai</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Errai Hello World</name>
 

--- a/helloworld-gwt/pom.xml
+++ b/helloworld-gwt/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-helloworld-gwt</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Hello World with GWT front-end client</name>
 

--- a/helloworld-html5/pom.xml
+++ b/helloworld-html5/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-helloworld-html5</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: HTML5 + REST Helloworld</name>
 

--- a/helloworld-jdg/pom.xml
+++ b/helloworld-jdg/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.jboss.datagrid.quickstart</groupId>
     <artifactId>jboss-as-helloworld-jdg</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: JBoss Data Grid HelloWorld</name>
 

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-helloworld-jms</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>jar</packaging>
     <name>JBoss AS Quickstarts: helloworld-jms</name>
     <description>helloworld-jms: Helloworld JMS external producer/consumer client</description>

--- a/helloworld-mdb/pom.xml
+++ b/helloworld-mdb/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-helloworld-mdb</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Helloworld Message-Driven Bean with Servlet 3.0 as client</name>
 

--- a/helloworld-osgi/pom.xml
+++ b/helloworld-osgi/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-helloworld-osgi</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>bundle</packaging>
     <name>JBoss AS Quickstarts: OSGi Helloworld</name>
     <description>JBoss AS Quickstarts: OSGi Helloworld</description>

--- a/helloworld-rf/pom.xml
+++ b/helloworld-rf/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-helloworld-rf</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Hello world with JSF front end</name>
     <description>JBoss AS Quickstarts: Hello world JSF</description>

--- a/helloworld-rs/pom.xml
+++ b/helloworld-rs/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-helloworld-rs</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: JAX-RS Helloworld</name>
     <description>JBoss AS Quickstarts: Helloworld using JAX-RS</description>

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-helloworld-singleton</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Helloworld Singleton Session Bean with JSF 2.0 as client</name>
 

--- a/helloworld-ws/pom.xml
+++ b/helloworld-ws/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-helloworld-ws</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Hello World JAX-WS Web service</name>
     <description>JBoss AS Quickstarts: Hello World JAX-WS Web service</description>

--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-helloworld</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Helloworld</name>
     <description>JBoss AS Quickstarts: Helloworld</description>

--- a/hibernate3/pom.xml
+++ b/hibernate3/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-hibernate3</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Hibernate 3</name>
     <description>JBoss AS Quickstarts: Hibernate 3</description>

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstart</groupId>
     <artifactId>jboss-as-hibernate4</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Hibernate 4</name>
     <description>hibernate4: Application that uses Hibernate 4</description>

--- a/hotrod-endpoint/pom.xml
+++ b/hotrod-endpoint/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.jboss.datagrid.quickstart</groupId>
     <artifactId>hotrod-endpoint-quickstart</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <name>HotRod Endpoint Example</name>
 
     <licenses>

--- a/inter-app/appA/pom.xml
+++ b/inter-app/appA/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-inter-app-parent</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <licenses>

--- a/inter-app/appB/pom.xml
+++ b/inter-app/appB/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-inter-app-parent</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <licenses>

--- a/inter-app/pom.xml
+++ b/inter-app/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-inter-app-parent</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>pom</packaging>
     <name>JBoss AS Quickstarts: Inter-application</name>
     <description>Inter-application: Shows how to communicate between two applications using EJB and CDI</description>

--- a/inter-app/shared/pom.xml
+++ b/inter-app/shared/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-inter-app-parent</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <licenses>

--- a/jax-rs-client/pom.xml
+++ b/jax-rs-client/pom.xml
@@ -23,7 +23,7 @@
     <name>JBoss AS Quickstarts: JAX-RS Client</name>
     <description>jax-rs-client: Demonstrates the use an external JAX-RS RestEasy client</description>
     <artifactId>jboss-as-jax-rs-client</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
 
 
     <url>http://jboss.org/jbossas</url>

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-jta-crash-rec</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: XA and JTA Crash Recovery</name>
 

--- a/jts/application-component-1/pom.xml
+++ b/jts/application-component-1/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-jts-parent</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <url>http://jboss.org/jbossas</url>

--- a/jts/application-component-2/pom.xml
+++ b/jts/application-component-2/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-jts-parent</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <url>http://jboss.org/jbossas</url>

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-jts-parent</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <name>JBoss AS Quickstarts: Java Transaction Service</name>
     <description>Using CMT with JTS</description>
     <packaging>pom</packaging>

--- a/kitchensink-angularjs/pom.xml
+++ b/kitchensink-angularjs/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-kitchensink-angularjs</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Kitchensink with AngularJS</name>
     <description>A starter Java EE 6 webapp project for use on JBoss AS 7 / EAP 6, generated from the jboss-javaee6-webapp archetype, using AngularJS for the view</description>

--- a/kitchensink-deltaspike/pom.xml
+++ b/kitchensink-deltaspike/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-kitchensink-deltaspike</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Kitchensink DeltaSpike</name>
     <description>A starter Java EE 6 webapp project for use on JBoss AS 7 / EAP 6, generated from the jboss-javaee6-webapp archetype</description>

--- a/kitchensink-ear/jboss-as-kitchensink-ear-ear/pom.xml
+++ b/kitchensink-ear/jboss-as-kitchensink-ear-ear/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>jboss-as-kitchensink-ear</artifactId>
         <groupId>org.jboss.as.quickstarts</groupId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-kitchensink-ear-ear</artifactId>

--- a/kitchensink-ear/jboss-as-kitchensink-ear-ejb/pom.xml
+++ b/kitchensink-ear/jboss-as-kitchensink-ear-ejb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>jboss-as-kitchensink-ear</artifactId>
         <groupId>org.jboss.as.quickstarts</groupId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-kitchensink-ear-ejb</artifactId>

--- a/kitchensink-ear/jboss-as-kitchensink-ear-web/pom.xml
+++ b/kitchensink-ear/jboss-as-kitchensink-ear-web/pom.xml
@@ -22,7 +22,7 @@
    <parent>
       <artifactId>jboss-as-kitchensink-ear</artifactId>
       <groupId>org.jboss.as.quickstarts</groupId>
-      <version>7.1.2-SNAPSHOT</version>
+      <version>8.0.0.Alpha1</version>
    </parent>
 
    <artifactId>jboss-as-kitchensink-ear-web</artifactId>

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-kitchensink-ear</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>pom</packaging>
 
     <url>http://jboss.org/jbossas</url>

--- a/kitchensink-html5-mobile/pom.xml
+++ b/kitchensink-html5-mobile/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-kitchensink-html5-mobile</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
 
     <name>JBoss AS Quickstarts: HTML5/Mobile</name>

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.kitchensink-jsp</groupId>
     <artifactId>jboss-as-kitchensink-jsp</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Kitchensink JSP</name>
     <description>kitchensink-jsp: Kitchensink with JSP front end</description>

--- a/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-ear/pom.xml
+++ b/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-ear/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>jboss-as-kitchensink-ml-ear</artifactId>
         <groupId>org.jboss.as.quickstarts</groupId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-kitchensink-ml-ear-ear</artifactId>

--- a/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-ejb/pom.xml
+++ b/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-ejb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>jboss-as-kitchensink-ml-ear</artifactId>
         <groupId>org.jboss.as.quickstarts</groupId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-kitchensink-ml-ear-ejb</artifactId>

--- a/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-web/pom.xml
+++ b/kitchensink-ml-ear/jboss-as-kitchensink-ml-ear-web/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>jboss-as-kitchensink-ml-ear</artifactId>
         <groupId>org.jboss.as.quickstarts</groupId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-kitchensink-ml-ear-web</artifactId>

--- a/kitchensink-ml-ear/pom.xml
+++ b/kitchensink-ml-ear/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-kitchensink-ml-ear</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>pom</packaging>
 
     <url>http://jboss.org/jbossas</url>

--- a/kitchensink-ml/pom.xml
+++ b/kitchensink-ml/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-kitchensink-ml</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Localized Kitchensink (Multiple-Language)</name>
     <description>A localized starter Java EE 6 webapp project for use on JBoss AS 7 / EAP 6, generated from the jboss-javaee6-webapp archetype</description>

--- a/kitchensink-rf/pom.xml
+++ b/kitchensink-rf/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-kitchensink-rf</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Kitchensink-rf</name>
     <description>A starter Java EE 6 webapp project for use on JBoss AS 7 / EAP 6, generated from the jboss-javaee6-webapp archetype</description>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-kitchensink</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Kitchensink</name>
     <description>A starter Java EE 6 webapp project for use on JBoss AS 7 / EAP 6, generated from the jboss-javaee6-webapp archetype</description>

--- a/log4j/pom.xml
+++ b/log4j/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-log4j</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Log4j</name>
     <description>JBoss AS Quickstarts: Logging using Log4j</description>

--- a/logging-tools/pom.xml
+++ b/logging-tools/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-logging-tools</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: jboss-as-logging-tools</name>
     <description>JBoss AS Quickstarts: Demonstration of jboss-logging-tools using JAX-RS</description>

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-mail</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Mail</name>
     <description>JBoss AS Quickstarts: Mail</description>

--- a/memcached-endpoint/pom.xml
+++ b/memcached-endpoint/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.jboss.datagrid.quickstart</groupId>
     <artifactId>memcached-endpoint-quickstart</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <name>Memcached Endpoint Example</name>
 
     <licenses>

--- a/numberguess/pom.xml
+++ b/numberguess/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-numberguess</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Numberguess</name>
     <description>JBoss AS Quickstarts: Numberguess</description>

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-payment-cdi-event</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: CDI Event</name>
     <description>JBoss AS Quickstarts: CDI Event</description>

--- a/picketlink-authentication-idm-jsf/pom.xml
+++ b/picketlink-authentication-idm-jsf/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.jboss.as.quickstarts</groupId>
 	<artifactId>jboss-as-picketlink-authentication-idm-jsf</artifactId>
-	<version>7.1.2-SNAPSHOT</version>
+	<version>8.0.0.Alpha1</version>
 	<packaging>war</packaging>
 	<name>JBoss AS Quickstarts: PicketLink IDM Simple Authentication with JSF</name>
 	<description>JBoss AS Quickstarts: PicketLink IDM Simple Authentication with JSF</description>

--- a/picketlink-authentication-jsf/pom.xml
+++ b/picketlink-authentication-jsf/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-picketlink-authentication-jsf</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: PicketLink Authentication with JSF</name>
     <description>JBoss AS Quickstarts: PicketLink Authentication with JSF</description>

--- a/picketlink-authorization-idm-jpa/pom.xml
+++ b/picketlink-authorization-idm-jpa/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.jboss.as.quickstarts</groupId>
 	<artifactId>jboss-as-picketlink-authorization-idm-jpa</artifactId>
-	<version>7.1.2-SNAPSHOT</version>
+	<version>8.0.0.Alpha1</version>
 	<packaging>war</packaging>
 	<name>JBoss AS Quickstarts: PicketLink IDM Authorization using JPA</name>
 	<description>JBoss AS Quickstarts: PicketLink IDM Authorization using JPA</description>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-quickstarts-parent</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>pom</packaging>
     <name>JBoss AS Quickstarts Parent</name>
     <description>JBoss AS Quickstarts Parent</description>

--- a/rest-endpoint/pom.xml
+++ b/rest-endpoint/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.jboss.datagrid.quickstart</groupId>
     <artifactId>rest-endpoint-quickstart</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <name>REST Endpoint Example</name>
 
     <licenses>

--- a/richfaces-validation/pom.xml
+++ b/richfaces-validation/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-richfaces-validation</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
 
     <name>JBoss AS Quickstarts: RichFaces Bean Validation</name>

--- a/servlet-async/pom.xml
+++ b/servlet-async/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-servlet-async</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Asynchronous Servlet</name>
     <description>JBoss AS Quickstarts: Asynchronous Servlet</description>

--- a/servlet-filterlistener/pom.xml
+++ b/servlet-filterlistener/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-servlet-filterlistener</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Servlet Filter and Listener</name>
     <description>JBoss AS Quickstarts: Servlet Filter and Listener</description>

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-servlet-security</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Servlet Security</name>
     <description>JBoss AS Quickstarts: Servlet Security</description>

--- a/shopping-cart/client/pom.xml
+++ b/shopping-cart/client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-shoppingcart-parent</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-shoppingcart-client</artifactId>

--- a/shopping-cart/pom.xml
+++ b/shopping-cart/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-shoppingcart-parent</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>pom</packaging>
     <name>JBoss AS Quickstarts: EJB Stateful Session Bean Quickstart Parent</name>
 

--- a/shopping-cart/server/pom.xml
+++ b/shopping-cart/server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-shoppingcart-parent</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-shoppingcart-server</artifactId>

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-tasks-jsf</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Tasks JSF</name>
     <description>JBoss AS Quickstarts: Tasks JSF</description>

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-tasks-rs</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Tasks JAX-RS</name>
     <description>JBoss AS Quickstarts: Tasks JSFJAX-RS</description>

--- a/tasks/pom.xml
+++ b/tasks/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-tasks</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Tasks</name>
     <description>JBoss AS Quickstarts: Tasks</description>

--- a/temperature-converter/pom.xml
+++ b/temperature-converter/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-temperature-converter</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Temperature Converter</name>
     <description>JBoss AS Quickstarts: Temperature Converter. Given Celsius return Fahrenheit; Given Fahrenheit return Celsius</description>

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-QUICKSTART_NAME</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: QUICKSTART_NAME</name>
     <description>QUICKSTART_NAME: A short description of this quickstart</description>

--- a/wicket-ear/ear/pom.xml
+++ b/wicket-ear/ear/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-wicket-ear-parent</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-wicket-ear-ear</artifactId>

--- a/wicket-ear/ejb/pom.xml
+++ b/wicket-ear/ejb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-wicket-ear-parent</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-wicket-ear-ejb</artifactId>

--- a/wicket-ear/pom.xml
+++ b/wicket-ear/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-wicket-ear-parent</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>pom</packaging>
 
     <name>JBoss AS Quickstarts: Wicket EAR parent</name>

--- a/wicket-ear/war/pom.xml
+++ b/wicket-ear/war/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.as.quickstarts</groupId>
         <artifactId>jboss-as-wicket-ear-parent</artifactId>
-        <version>7.1.2-SNAPSHOT</version>
+        <version>8.0.0.Alpha1</version>
     </parent>
 
     <artifactId>jboss-as-wicket-ear-war</artifactId>

--- a/wicket-war/pom.xml
+++ b/wicket-war/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-wicket-war</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
 
     <name>JBoss AS Quickstarts: Wicket: WAR</name>

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-wsat-simple</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: Simple WS-AT Web service</name>
     <description>JBoss AS Quickstarts: Simple WS-AT Web service</description>

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-wsba-coordinator-completion-simple</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>jar</packaging>
     <name>JBoss AS Quickstarts: Simple WS-BA with Coordinator Driven Completion</name>
     <description>JBoss AS Quickstarts: Simple WS-BA with Coordinator Driven Completion</description>

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-wsba-participant-completion-simple</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>jar</packaging>
     <name>JBoss AS Quickstarts: Simple WS-BA with Participant Driven Completion</name>
     <description>JBoss AS Quickstarts: Simple WS-BA with Participant Driven Completion</description>

--- a/xml-dom4j/pom.xml
+++ b/xml-dom4j/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-xml-dom4j</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: XML DOM4J</name>
     <description>JBoss AS Quickstarts: XML DOM4J</description>

--- a/xml-jaxp/pom.xml
+++ b/xml-jaxp/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-as-xml-jaxp</artifactId>
-    <version>7.1.2-SNAPSHOT</version>
+    <version>8.0.0.Alpha1</version>
     <packaging>war</packaging>
     <name>JBoss AS Quickstarts: XML JAXP</name>
     <description>JBoss AS Quickstarts: XML JAXP</description>


### PR DESCRIPTION
The commits here do 2 things:

1) Update the snapshot dependencies on Arquillian container to 8.0.0.Alpha1
2) Update the project version from 7.1.2-SNAPSHOT to 8.0.0.Alpha1 and make it ready to be released to Maven repository.
