### PR TITLE
Migrate the ejb-multi-server quickstart for WildFly

### DIFF
--- a/ejb-multi-server/README.md
+++ b/ejb-multi-server/README.md
@@ -1,0 +1,239 @@
+ejb-multi-server: EJB Communication Across Servers
+======================================================
+Author: Wolf-Dieter Fink  
+Level: Advanced  
+Technologies: EJB, EAR  
+Summary: EJB applications deployed to different servers that communicate via EJB remote calls  
+Target Product: WildFly
+Product Versions: 8.0.0
+Source: <https://github.com/wildfly/quickstart/>  
+
+
+What is it?
+-----------
+
+This quickstart demonstrates communication between applications deployed to different servers. Each application is deployed as an EAR and contains a simple EJB3.1 bean. The only function of each bean is to log the invocation.
+
+This example consists of the following Maven projects, each with a shared parent:
+
+| **Sub-project** | **Description** |
+|:-----------|:-----------|
+| `app-main` | An application that can be called by the `client`. It can also call the different sub-applications. |
+| `app-one` and `app-two` | These are simple applications that contain an EJB sub-project to build the `ejb.jar` file and an EAR sub-project to build the `app.ear` file. Each application contains only one EJB that logs a statement on a method call and returns the `jboss.node.name` and credentials. |
+| `app-web` |  A simple WAR application. It consists of one Servlet that demonstrates how to invoke EJBs on a different server. | 
+| `client` | This project builds the standalone client and executes it.|
+
+The root `pom.xml` builds each of the subprojects in an appropriate order.
+
+The server configuration is done using CLI batch scripts located in the root of the quickstart folder.
+
+
+
+System requirements
+-------------------
+
+The application this project produces is designed to be run on JBoss WildFly.
+
+All you need to build this project is Java 7.0 (Java SDK 1.7) or later, Maven 3.1 or later.
+
+
+Configure Maven
+---------------
+
+If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
+
+
+Add the Application Users
+---------------
+
+The following users must be added to the `ApplicationRealm` to run this quickstart. Be sure to use the names and passwords specified in the table as they are required to run this example.
+
+| **UserName** | **Realm** | **Password** | **Roles** |
+|:-----------|:-----------|:-----------|:-----------|
+| quickuser| ApplicationRealm | quick-123 | _leave blank for none_ |
+| quickuser1 | ApplicationRealm | quick123+ | _leave blank for none_ |
+| quickuser2 | ApplicationRealm | quick+123 | _leave blank for none_ |
+
+Add the users using the following commands:
+
+        bin/add-user.sh -a -u quickuser -p quick-123 --silent
+        bin/add-user.sh -a -u quickuser1 -p quick123+ --silent
+        bin/add-user.sh -a -u quickuser2 -p quick+123 --silent
+
+If you prefer, you can use the add-user utility interactively. For an example of how to use the add-user utility, see instructions in the root README file located here: [Add User](../README.md#addapplicationuser).
+
+
+Back Up the JBoss Server Configuration Files
+-----------------------------
+_NOTE - Before you begin:_
+
+1. If it is running, stop the WildFly server.
+2. Backup the following files, replacing WILDFLY_HOME with the path to your server: 
+
+        WILDFLY_HOME/domain/configuration/domain.xml
+        WILDFLY_HOME/domain/configuration/host.xml
+        
+3. After you have completed testing and undeployed this quickstart, you can replace these files to restore the server to its original configuration.
+
+
+Start JBoss Server
+---------------------------
+
+
+1. Unzip or install a fresh JBoss instance.
+2. Open a command line and navigate to the root of the server directory. Start the server using the following command:
+
+        bin/domain.sh    
+
+Configure the JBoss Server
+---------------------------
+
+   Open a new command line, navigate to the root directory of this quickstart, and run the following command:
+ 
+        WILDFLY_HOME/bin/jboss-cli.sh --connect --file=install-domain.cli
+        
+   This script configures and starts multiple servers needed to run this quickstart. You should see "outcome" => "success" for all of the commands. 
+
+
+Build and Deploy the Quickstart
+-------------------------
+
+_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See [Build and Deploy the Quickstarts](../README.md#buildanddeploy) for complete instructions and additional options._
+
+1. Make sure you have started and configured the JBoss Server successful as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. Type this command to build the artifacts:
+
+        mvn clean install
+        
+4. Open a new command line and navigate to the root directory of this quickstart. Deploy the applications using the provided CLI batch script by typing the following command:
+
+        WILDFLY_HOME/bin/jboss-cli.sh --connect --file=deploy-domain.cli
+       
+    This will deploy the app-*.ear files to different server-groups of the running domain.
+
+ 
+_NOTE: If ERRORs appear in the server.log when the installing or deploying the quickstart, please stop the domain and restart it. This should ensure further steps run correctly._
+
+
+Access the Remote Client Application
+---------------------
+
+This example shows how to invoke an EJB from a remote standalone application. 
+It also demonstrates how to invoke an EJB from a client using a scoped-context rather than a properties file containing the parameters required by the InitialContext. 
+
+1. Make sure that the deployments are successful as described above.
+2. Navigate to the quickstart `client/` subdirectory.
+3. Type this command to run the application:
+
+        mvn exec:java
+
+    The client will output the following information provided by the applications:
+        
+        InvokeAll succeed: MainApp[anonymous]@master:app-main  >  [ app1[anonymous]@master:app-oneA > app2[quickuser2]@master:app-twoA ; app2[quickuser2]@master:app-twoA ]
+
+    This output shows that the `MainApp` is called with the user `anonymous` at node `master:app-main` and the sub-call is proceeded by the `master:app-oneA` node and `master:app-twoA` node as `quickuser2`. 
+    
+    Review the server log files to see the bean invocations on the servers.
+
+4. To invoke the bean that uses the `scoped-client-context`, you must pass a property. Type the following command
+
+        mvn exec:java -DUseScopedContext=true
+    
+    The invocation of `appTwo` throws a  `java.lang.reflect.InvocationTargetException` since the secured method is called and there is no Role for the user defined.  You get a `BUILD FAILURE` and the client outputs the following information:
+
+        [ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.2.1:java (default-cli) on project jboss-ejb-multi-server-client: An exception occured while executing the Java class. null: InvocationTargetException: JBAS014502: Invocation on method: public abstract java.lang.String org.jboss.as.quickstarts.ejb.multi.server.app.AppTwo.invokeSecured(java.lang.String) of bean: AppTwoBean is not allowed -> [Help 1]
+
+    Update the user `quickuser1` and `quickuser2` and give them one of the Roles `AppTwo` or `Intern`. 
+
+              bin/add-user.sh -a -u quickuser1 -p quick123+ --silent --role Intern
+              bin/add-user.sh -a -u quickuser2 -p quick+123 --silent --role AppTwo
+
+    If the connection was established before changing the roles it might be necessary to restart the main server, or even the whole domain.
+    After that the invocation will be successful. The log output of the `appTwo` servers shows which Role is applied to the user. The output of the client will show you a simple line with the information provided by the different applications:
+        
+          InvokeAll succeed: MainAppSContext[anonymous]@master:app-main  >  [ {app1[quickuser1]@master:app-oneA, app1[quickuser2]@master:app-oneB, app1[quickuser2]@master:app-oneB, app1[quickuser1]@master:app-oneA, app1[quickuser1]@master:app-oneA, app1[quickuser1]@master:app-oneA, app1[quickuser2]@master:app-oneB, app1[quickuser1]@master:app-oneA} >  appTwo loop(7 time A-B expected){app2[quickuser1]@master:app-twoA, app2[quickuser2]@master:app-twoB, app2[quickuser1]@master:app-twoA, app2[quickuser2]@master:app-twoB, app2[quickuser1]@master:app-twoA, app2[quickuser2]@master:app-twoB, app2[quickuser1]@master:app-twoA, app2[quickuser2]@master:app-twoB, app2[quickuser1]@master:app-twoA, app2[quickuser2]@master:app-twoB, app2[quickuser1]@master:app-twoA, app2[quickuser2]@master:app-twoB, app2[quickuser1]@master:app-twoA, app2[quickuser2]@master:app-twoB, app2[quickuser1]@master:app-twoA, app2[quickuser2]@master:app-twoB} ]
+         
+    The line shows that the bean `MainAppSContext` is not secured and called at `app-main` server. The sub-calls to `app-one#` are using the scoped-context and the cluster view needs a time to be established. This is shown as the cluster-view call the `appOne` with the user `quickuser2`. `AppTwo` is called with two different scoped-context settings. Both are used alternately 7 times.
+
+5. If it is necessary to invoke the client with a different JBoss version the main class can be invoked by using the following command from the root directory of this quickstart. Replace $WILDFLY_HOME with your current installation path. The output should be similar to the previous mvn executions.
+
+      java -cp $WILDFLY_HOME/bin/client/jboss-client.jar:app-main/ejb/target/jboss-ejb-multi-server-app-main-ejb-client.jar:app-two/ejb/target/jboss-ejb-multi-server-app-two-ejb-client.jar:client/target/jboss-ejb-multi-server-client.jar org.jboss.as.quickstarts.ejb.multi.server.Client
+
+
+_NOTE:_
+ 
+* _If exec is called multiple times, the invocation for `app1` might use `app-oneA` and `app-oneB` node due to cluster loadbalancing._
+
+
+Access the JSF application inside the main-application
+---------------------
+
+The JSF example shows different annotations to inject the EJB. Also how to handle the annotation if different beans implement the same interface and therefore the container is not able to decide which bean needs to be injected without additional informations.
+
+1. Make sure that the deployments are successful as described above.
+2. Use a browser to access the JSF application at the following URL: <http://localhost:8080/jboss-ejb-multi-server-app-main-web/>
+3. Insert a message in the Text input and invoke the different methods. The result is shown in the browser.
+4. See server logfiles and find your given message logged as INFO.
+
+_NOTE :_
+
+* _If you try to invoke `MainAppSContext` you need to update the user `quickuser1` and `quickuser2` and give them one of the Roles `AppTwo` or `Intern`._
+
+Access the Servlet application deployed as a WAR inside a minimal server
+---------------------
+
+An example how to access EJB's from a separate instance which only contains a web application.
+
+1. Make sure that the deployments are successful as described above.
+2. Use a browser to access the Servlet at the following URL: <http://localhost:8380/jboss-ejb-multi-server-app-web/>
+3. The Servlet will invoke the remote EJBs directly and show the results, compare that the invocation is successful
+
+
+
+Undeploy the Archives
+--------------------
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. When you are finished testing, type this command to undeploy the archive:
+
+        WILDFLY_HOME/bin/jboss-cli.sh --connect --file=undeploy-domain.cli
+
+
+Remove the Server Domain Configuration
+--------------------
+
+You can remove the domain configuration by manually restoring the back-up copies the configuration files or by running the JBoss CLI Script. 
+
+### Remove the Server Domain Configuration Manually           
+1. If it is running, stop the WildFly server.
+2. Restore the `WILDFLY_HOME/domain/configuration/domain.xml` and `WILDFLY_HOME/domain/configuration/host.xml` files with the back-up copies of the files. Be sure to replace WILDFLY_HOME with the path to your server.
+
+### Remove the Security Domain Configuration by Running the JBoss CLI Script
+
+_Note: This script returns the server to a default configuration and the result may not match the server configuration prior to testing this quickstart. If you were not running with the default configuration before testing this quickstart, you should follow the intructions above to manually restore the configuration to its previous state._
+
+1. Start the WildFly server by typing the following: 
+
+        For Linux:   WILDFLY_HOME/bin/domain.sh
+        For Windows: WILDFLY_HOME\bin\domain.bat
+2. Open a new command line, navigate to the root directory of this quickstart, and run the following command, replacing WILDFLY_HOME with the path to your server.
+
+        WILDFLY_HOME/bin/jboss-cli.sh --connect --file=remove-configuration.cli 
+This script removes the server configuration that was done by the `install-domain.cli` script. You should see the following result following the script commands:
+
+        The batch executed successfully.
+
+Run the Quickstart in JBoss Developer Studio or Eclipse
+-------------------------------------
+You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see [Use JBoss Developer Studio or Eclipse to Run the Quickstarts](../README.md#useeclipse) 
+
+Debug the Application
+------------------------------------
+
+If you want to debug the source code or look at the Javadocs of any library in the project, run either of the following commands to pull them into your local repository. The IDE should then detect them.
+
+    mvn dependency:sources
+    mvn dependency:resolve -Dclassifier=javadoc
+

--- a/ejb-multi-server/app-main/ear/pom.xml
+++ b/ejb-multi-server/app-main/ear/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server-app-main</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>jboss-ejb-multi-server-app-main-ear</artifactId>
+    <packaging>ear</packaging>
+    <name>JBoss EAP Quickstart: ejb-multi-server - app-main - ear</name>
+    <description>Create the deployable main-app archive
+     Include the EJB and WEB application together with the necessary API libraries
+     of the sub applications app-one and app-two.
+  </description>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <dependencies>
+  <!-- add the EJB and WEB project as dependency to include it in the EAR -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-main-ejb</artifactId>
+            <type>ejb</type>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-main-web</artifactId>
+            <type>war</type>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ejb-client-bom</artifactId>
+            <scope>provided</scope>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- define the name for the deployable archive instead of using the default name with the version -->
+        <finalName>${project.parent.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>${version.ear.plugin}</version>
+                <configuration>
+                    <displayName>Application Main</displayName>
+                    <description>A simple quickstart application to demonstrate the
+                        server-server communication</description>
+                    <version>6</version>
+                    <generateApplicationXml>true</generateApplicationXml>
+          <!-- must start in order to ensure that the reference to MainApp is found in the JsfController -->
+                    <initializeInOrder>true</initializeInOrder>
+                    <modules>
+                        <ejbModule>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>jboss-ejb-multi-server-app-main-ejb</artifactId>
+                            <bundleFileName>ejb.jar</bundleFileName>
+                        </ejbModule>
+                        <webModule>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>jboss-ejb-multi-server-app-main-web</artifactId>
+                            <bundleFileName>jsf.war</bundleFileName>
+                        </webModule>
+            <!-- add the necessary EJB client interfaces of AppOne and AppTwo to the lib directory of the EAR -->
+                        <ejbClientModule>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
+                            <bundleDir>lib</bundleDir>
+                        </ejbClientModule>
+                        <ejbClientModule>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
+                            <bundleDir>lib</bundleDir>
+                        </ejbClientModule>
+                    </modules>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources/META-INF</directory>
+        <!--  add the client configuration containing the remote-connections and cluster definition
+              which is used by the MainApp bean.
+         -->
+                <includes>
+                    <include>jboss-ejb-client.xml</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/ejb-multi-server/app-main/ear/src/main/application/META-INF/jboss-ejb-client.xml
+++ b/ejb-multi-server/app-main/ear/src/main/application/META-INF/jboss-ejb-client.xml
@@ -1,0 +1,39 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<jboss-ejb-client xmlns:xsi="urn:jboss:ejb-client:1.2" xsi:noNamespaceSchemaLocation="jboss-ejb-client_1_2.xsd">
+    <client-context>
+        <ejb-receivers>
+            <!-- this is the connection to access the app-one -->
+            <remoting-ejb-receiver outbound-connection-ref="remote-ejb-connection-1" />
+            <!-- this is the connection to access the app-two -->
+            <remoting-ejb-receiver outbound-connection-ref="remote-ejb-connection-2" />
+        </ejb-receivers>
+        
+        <!-- if an outbound connection connect to a cluster a list of members is provided after successful connection.
+             To connect to this node this cluster element must be defined.
+          -->
+        <clusters>
+          <!-- cluster of remote-ejb-connection-1 -->
+            <cluster name="ejb" security-realm="ejb-security-realm-1" username="quickuser1">
+                <connection-creation-options>
+                    <property name="org.xnio.Options.SSL_ENABLED" value="false" />
+                    <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false" />
+                </connection-creation-options>
+            </cluster>
+        </clusters>
+    </client-context>
+</jboss-ejb-client>

--- a/ejb-multi-server/app-main/ejb/pom.xml
+++ b/ejb-multi-server/app-main/ejb/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server-app-main</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <artifactId>jboss-ejb-multi-server-app-main-ejb</artifactId>
+
+    <name>JBoss EAP Quickstart: ejb-multi-server - app-main - ejb</name>
+    <url>http://maven.apache.org</url>
+    <packaging>ejb</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ejb-client-bom</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>  <!-- must include ejb-plugin to change the EJB version from 2.1 to 3.1 -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ejb-plugin</artifactId>
+                <version>${version.ejb.plugin}</version>
+                <configuration>
+                    <ejbVersion>3.1</ejbVersion>
+                    <generateClient>true</generateClient>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                        <!-- this dependency must be set because of the access to the scoped context inside the MainAppSContextBean -->
+                        <manifestEntries>
+                            <Dependencies>org.jboss.xnio</Dependencies>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/ejb-multi-server/app-main/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/MainApp.java
+++ b/ejb-multi-server/app-main/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/MainApp.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb.multi.server.app;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface MainApp {
+
+  /**
+   * Invoke the sub applications with the recommended lookup names. Return informations about the called beans.
+   * 
+   * @param text This text will be logged in the main-application
+   * @return A simple text representation of the call stack and the destination servers
+   */
+    String invokeAll(String text);
+
+    String getJBossNodeName();
+
+}

--- a/ejb-multi-server/app-main/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/MainAppBean.java
+++ b/ejb-multi-server/app-main/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/MainAppBean.java
@@ -1,0 +1,158 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb.multi.server.app;
+
+import java.security.Principal;
+import java.util.Hashtable;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.logging.Logger;
+
+/**
+ * <p>The main bean called by the standalone client.</p>
+ * <p>The sub applications, deployed in different servers are called direct or via indirect naming to hide the lookup name and use
+ * a configured name via comp/env environment.</p>
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@Stateless
+public class MainAppBean implements MainApp {
+    private static final Logger LOGGER = Logger.getLogger(MainAppBean.class);
+    @Resource
+    SessionContext context;
+
+  /**
+   * The context to invoke foreign EJB's as the SessionContext can not be used for that.
+   */
+    private InitialContext iCtx;
+
+    @EJB(lookup = "ejb:jboss-ejb-multi-server-app-one/ejb//AppOneBean!org.jboss.as.quickstarts.ejb.multi.server.app.AppOne")
+    AppOne appOneProxy;
+    @EJB(lookup = "ejb:jboss-ejb-multi-server-app-two/ejb//AppTwoBean!org.jboss.as.quickstarts.ejb.multi.server.app.AppTwo")
+    AppTwo appTwoProxy;
+
+  /**
+   * Initialize and store the context for the EJB invocations.
+   */
+    @PostConstruct
+    public void init() {
+        try {
+            final Hashtable<String, String> p = new Hashtable<String, String>();
+            p.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+            this.iCtx = new InitialContext(p);
+        }catch (NamingException e) {
+            throw new RuntimeException("Could not initialize context", e);
+        }
+    }
+
+    @Override
+    public String getJBossNodeName() {
+        return System.getProperty("jboss.node.name");
+    }
+
+    @Override
+    public String invokeAll(String text) {
+        Principal caller = context.getCallerPrincipal();
+        LOGGER.info("[" + caller.getName() + "] " + text);
+        final StringBuilder result = new StringBuilder("MainApp[" + caller.getName() + "]@" + System.getProperty("jboss.node.name"));
+
+    // Call AppOne with the direct ejb: naming
+        try {
+            result.append("  >  [ " + invokeAppOne(text));
+        }catch (Exception e) {
+            LOGGER.error("Could not invoke AppOne", e);
+        }
+
+        String lookup = "";
+       // Call AppTwo with the direct ejb: naming
+        try {
+            lookup = "ejb:jboss-ejb-multi-server-app-two/ejb//AppTwoBean!" + AppTwo.class.getName();
+            result.append(" > " + invokeAppTwo(lookup, text));
+            LOGGER.info("Invoke '" + lookup + " OK");
+        }catch (Exception e) {
+            LOGGER.error("Could not invoke apptwo '" + lookup + "'", e);
+        }
+
+        // Call AppTwo by using the local alias configured in
+        // META-INF/ejb-jar.xml
+        try {
+            lookup = "java:comp/env/AppTwoAlias";
+            result.append(" ; " + invokeAppTwo(lookup, text));
+            LOGGER.info("Invoke '" + lookup + " OK");
+        }catch (Exception e) {
+            LOGGER.error("Could not invoke apptwo '" + lookup + "'", e);
+        }
+
+        result.append(" ]");
+
+        return result.toString();
+    }
+
+     /**
+     * The application one can only be called with the standard naming, there is
+     * no alias.
+     * 
+     * @param text
+     *            Simple text for logging in the target servers logfile
+     * @return A text with server details for demonstration
+     */
+    private String invokeAppOne(String text) {
+        try {
+            // invoke on the bean
+            final String appOneResult = this.appOneProxy.invoke(text);
+
+            LOGGER.info("AppOne return : " + appOneResult);
+            return appOneResult;
+        }catch (Exception e) {
+            throw new RuntimeException("Could not invoke appOne", e);
+        }
+    }
+
+    /**
+    * The application two can be called via lookup.
+    * <ul>
+    * <li>with the standard naming
+    * <i>ejb:jboss-ejb-multi-server-app-two/ejb//AppTwoBean!org.jboss.as.quickstarts
+    * .ejb.multi.server.app.AppTwo</i></li>
+    * <li><i>java:global/AliasAppTwo</i> the alias provided by the server
+    * configuration <b>this is not recommended</b></li>
+    * <li><i>java:comp/env/AppTwoAlias</i> the local alias provided by the
+    * ejb-jar.xml configuration</li>
+    * </ul>
+    * 
+    * @param text
+    *            Simple text for logging in the target servers logfile
+    * @return A text with server details for demonstration
+    */
+    private String invokeAppTwo(String lookup, String text) throws NamingException {
+        final AppTwo bean = (AppTwo) iCtx.lookup(lookup);
+
+        // invoke on the bean
+        final String appTwoResult = bean.invoke(text);
+
+        LOGGER.info("AppTwo return : " + appTwoResult);
+        return appTwoResult;
+    }
+}

--- a/ejb-multi-server/app-main/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/MainAppSContextBean.java
+++ b/ejb-multi-server/app-main/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/MainAppSContextBean.java
@@ -1,0 +1,361 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb.multi.server.app;
+
+import java.security.Principal;
+import java.util.Properties;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.logging.Logger;
+
+/**
+ * <p>
+ * An example how to use the new features 'scoped client' introduced with
+ * EJBCLIENT-34 in AS7.2.0 or EAP6.1.<br/>
+ * If this feature is used the outbound-connection of the remoting subsystem
+ * will not be used and the behavior is different.
+ * </p>
+ * <p>
+ * The functionality will be the same as MainAppBean provide, the interface
+ * @{link MainApp} will be shared to use both.<br/>
+ * The sub applications, deployed in different servers are called direct by
+ * using the ejb-client scoped context properties.
+ * </p>
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@Stateless
+public class MainAppSContextBean implements MainApp {
+    private static final Logger LOGGER = Logger.getLogger(MainAppSContextBean.class);
+    
+    private static Integer activeInstances = 0;
+    private static Context appOneScopedEjbContext;
+    private static Context appTwoScopedEjbContextA;
+    private static Context appTwoScopedEjbContextB;
+    
+    @Resource
+    SessionContext context;
+
+    private void createAppOneContext() {
+        final Properties ejbClientContextProps = new Properties();
+        ejbClientContextProps.put("endpoint.name", "appMain->appOne_endpoint");
+        // --- Property to enable scoped EJB client context which will be tied
+        // to the JNDI context ---
+        ejbClientContextProps.put("org.jboss.ejb.client.scoped.context", true);
+        // Property which will handle the ejb: namespace during JNDI lookup
+        ejbClientContextProps.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        ejbClientContextProps.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED","false");
+        // add a property which lists the connections that we are configuring.
+        // In this example, we are just configuring a single connection.
+        final String connectionName = "appOneConnection";
+        ejbClientContextProps.put("remote.connections", connectionName);
+        // add the properties to connect the app-one host 
+        ejbClientContextProps.put("remote.connection." + connectionName + ".host", "localhost");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".port", "8180");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".username", "quickuser1");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".password", "quick123+");
+        ejbClientContextProps.put("remote.clusters", "ejb");
+        ejbClientContextProps.put("remote.cluster.ejb.username", "quickuser2");
+        ejbClientContextProps.put("remote.cluster.ejb.password", "quick+123");
+
+        try {
+            appOneScopedEjbContext = (Context)new InitialContext(ejbClientContextProps).lookup("ejb:");
+        } catch (NamingException e) {LOGGER.error("Could not create InitialContext('appOne')", e);}
+    }
+    
+    private void createAppTwoContext() {
+        final Properties ejbClientContextProps = new Properties();
+        ejbClientContextProps.put("endpoint.name", "appMain->appTwoA_endpoint");
+        // Property to enable scoped EJB client context which will be tied to
+        // the JNDI context
+        ejbClientContextProps.put("org.jboss.ejb.client.scoped.context", true);
+        // Property which will handle the ejb: namespace during JNDI lookup
+        ejbClientContextProps.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+
+        final String connectionName = "appTwoConnection";
+        ejbClientContextProps.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED", "false");
+        // add the properties to connect the app-one host
+        ejbClientContextProps.put("remote.connections", connectionName);
+        ejbClientContextProps.put("remote.connection." + connectionName + ".host", "localhost");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".port", "8280");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".username", "quickuser1");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".password", "quick123+");
+        
+        try {
+            appTwoScopedEjbContextA = (Context) new InitialContext(ejbClientContextProps).lookup("ejb:");
+        } catch (NamingException e) {LOGGER.error("Could not create InitialContext('appTwoA')", e);}
+
+        // change the necessary properties to call the other server
+        ejbClientContextProps.put("endpoint.name", "appMain->appTwoB_endpoint");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".port", "8880");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".username", "quickuser2");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".password", "quick+123");
+
+        try {
+            appTwoScopedEjbContextB = (Context) new InitialContext(ejbClientContextProps).lookup("ejb:");
+        } catch (NamingException e) {LOGGER.error("Could not create InitialContext('appTwoB')", e);}
+    }
+    
+    @PostConstruct
+    private void createScopedContext() {
+        synchronized (activeInstances) {
+            if(activeInstances == 0) {
+                LOGGER.info("First instance of " + this.getClass().getSimpleName() + " initializing scoped-context");
+                createAppOneContext();
+                createAppTwoContext();
+            }
+            activeInstances++;
+        }
+    }
+    
+    @PreDestroy
+    private void destroyScopedContext() {
+        synchronized (activeInstances) {
+            activeInstances--;
+            if(activeInstances == 0) {
+                LOGGER.info("Last active instance of " + this.getClass().getSimpleName() + " closing scoped-context");
+                try {
+                    appOneScopedEjbContext.close();
+                } catch (NamingException e) {
+                    LOGGER.error("Could not close the scoped-context of AppOne", e);
+                }
+                appOneScopedEjbContext = null;
+                try {
+                    appTwoScopedEjbContextA.close();
+                } catch (NamingException e) {
+                    LOGGER.error("Could not close the scoped-context of AppTwo (A)", e);
+                }
+                appTwoScopedEjbContextA = null;
+                try {
+                    appTwoScopedEjbContextB.close();
+                } catch (NamingException e) {
+                    LOGGER.error("Could not close the scoped-context of AppTwo (B)", e);
+                }
+                appTwoScopedEjbContextB = null;
+            }
+        }
+    }
+    
+    @Override
+    public String getJBossNodeName() {
+        return System.getProperty("jboss.node.name");
+    }
+
+    @Override
+    public String invokeAll(String text) {
+        Principal caller = context.getCallerPrincipal();
+        LOGGER.info("[" + caller.getName() + "] " + text);
+        final StringBuilder result = new StringBuilder("MainAppSContext["+ caller.getName() + "]@" + getJBossNodeName());
+        // Call AppOne with the direct ejb: naming
+        try {
+            result.append("  >  [ " + invokeAppOne(text));
+        } catch (Exception e) {
+            LOGGER.error("Could not invoke AppOne", e);
+        }
+
+        result.append(" > " + invokeAppTwo(text));
+
+        result.append(" ]");
+
+        return result.toString();
+    }
+
+     /**
+     * Invoke the AppOne with the scoped client context. The initial connection
+     * will use the 'quickuser1', to differentiate the cluster connection it
+     * will be use the user 'quickuser2' to see if the clustered context is used
+     * or not.
+     * 
+     * @param text
+     *            Simple text which will be logged at server side.
+     * @return simple collection of the returned results
+     */
+    private String invokeAppOne(String text) {
+        try {
+        // this context will not use the server configured
+        // 'outbound-connection' and also did not use the
+        // jboss-ejb-client.xml.
+            final AppOne bean = (AppOne) appOneScopedEjbContext.lookup("jboss-ejb-multi-server-app-one/ejb//AppOneBean!" + AppOne.class.getName());
+
+            StringBuffer result = new StringBuffer("{");
+            for (int i = 0; i < 8; i++) {
+                // invoke on the bean
+                final String appOneResult = bean.invoke(text);
+                if (i > 0) {
+                    result.append(", ");
+                }
+                result.append(appOneResult);
+            }
+            result.append("}");
+
+            LOGGER.info("AppOne (loop) returns : " + result);
+            return result.toString();
+
+        } catch (NamingException e) {
+            LOGGER.error("Could not invoke appOne", e);
+            return null;
+        }
+    }
+
+    /**
+    * Close the given context and write a log message which endpoint is closed.
+    * 
+    * @param iCtx
+    *            context to close, <code>null</code> will be ignored.
+    */
+    private static void saveContextClose(Context iCtx) {
+        if (iCtx != null) {
+            try {
+                LOGGER.info("close Context "+ iCtx.getEnvironment().get("endpoint.name"));
+                iCtx.close();
+
+            } catch (NamingException e) {
+                LOGGER.error("InitialContext can not be closed", e);
+            }
+        }
+    }
+    
+    /**
+    * Invoke the App2 with different ejb-client context. The server AppTwoA
+    * will be called with the user quickuser1. The server AppTwoB will be
+    * called with the user quickuser2. Both invocations are separate, there
+    * will no mix between. Also the outbound-connection is not used.
+    * 
+    * @param text
+    *            Simple text which will be logged at server side.
+    * @return simple collection of the returned results
+    */
+    private String invokeAppTwo(String text) {
+        AppTwo beanA = null;
+        AppTwo beanB = null;
+
+        try {
+            beanA = (AppTwo) appTwoScopedEjbContextA.lookup("jboss-ejb-multi-server-app-two/ejb//AppTwoBean!" + AppTwo.class.getName());
+        } catch (NamingException e) {LOGGER.error("Could not create InitialContext('appTwoA')");}
+
+        try {
+            beanB = (AppTwo) appTwoScopedEjbContextB.lookup("jboss-ejb-multi-server-app-two/ejb//AppTwoBean!" + AppTwo.class.getName());
+        } catch (NamingException e) {
+            LOGGER.error("Could not create InitialContext('appTwoB')");
+        }
+
+        StringBuffer result = new StringBuffer(" appTwo loop(4 time A-B expected){");
+        for (int i = 0; i < 4; i++) {
+            // invoke on the bean
+            String appResult = beanA.invokeSecured(text);  
+            if (i > 0) {
+                result.append(", ");
+            }
+            result.append(appResult);
+            appResult = beanB.invokeSecured(text);
+            result.append(", ");
+            result.append(appResult);
+        }
+        result.append("}");
+
+        LOGGER.info("AppTwo (loop) returns : " + result);
+
+        return result.toString();
+    }
+    
+    /**
+    * Same method as {@link #invokeAppTwo(String)}, but the scoped context is created and destroyed
+    * inside the method. Because of this it is not possbile to use the transaction managed by the container
+    * as the connection must be open until the container send commit/rollback to the foreign server.
+    * Therefore it is necessary to add the annotation @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED) 
+    * to the {@link #invokeAll(String)} method.
+    * 
+    * For test you might rename this method.
+    * 
+    * @param text
+    *            Simple text which will be logged at server side.
+    * @return simple collection of the returned results
+    */
+    @SuppressWarnings("unused")
+    private String invokeAppTwoAlternative(String text) {
+        AppTwo beanA = null;
+        AppTwo beanB = null;
+
+        final Properties ejbClientContextProps = new Properties();
+        ejbClientContextProps.put("endpoint.name", "appMain->appTwoA_endpoint");
+        // Property to enable scoped EJB client context which will be tied to
+        // the JNDI context
+        ejbClientContextProps.put("org.jboss.ejb.client.scoped.context", true);
+        // Property which will handle the ejb: namespace during JNDI lookup
+        ejbClientContextProps.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+
+        final String connectionName = "appTwoConnection";
+        ejbClientContextProps.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED", "false");
+        // add the properties to connect the app-one host
+        ejbClientContextProps.put("remote.connections", connectionName);
+        ejbClientContextProps.put("remote.connection." + connectionName + ".host", "localhost");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".port", "8280");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".username", "quickuser1");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".password", "quick123+");
+        
+        Context iCtxA = null;
+        try {
+            iCtxA = (Context) new InitialContext(ejbClientContextProps).lookup("ejb:");
+            beanA = (AppTwo) iCtxA.lookup("jboss-ejb-multi-server-app-two/ejb//AppTwoBean!" + AppTwo.class.getName());
+        } catch (NamingException e) {LOGGER.error("Could not create InitialContext('appTwoA')");}
+
+        // change the necessary properties to call the other server
+        ejbClientContextProps.put("endpoint.name", "appMain->appTwoB_endpoint");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".port", "8880");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".username", "quickuser2");
+        ejbClientContextProps.put("remote.connection." + connectionName + ".password", "quick+123");
+        Context iCtxB = null;
+        try {
+            iCtxB = (Context) new InitialContext(ejbClientContextProps).lookup("ejb:");
+            beanB = (AppTwo) iCtxB.lookup("jboss-ejb-multi-server-app-two/ejb//AppTwoBean!" + AppTwo.class.getName());
+        } catch (NamingException e) {
+            LOGGER.error("Could not create InitialContext('appTwoB')");
+        }
+
+        StringBuffer result = new StringBuffer(" appTwo loop(4 time A-B expected){");
+        for (int i = 0; i < 4; i++) {
+            // invoke on the bean
+            String appResult = beanA.invokeSecured(text);  
+            if (i > 0) {
+                result.append(", ");
+            }
+            result.append(appResult);
+            appResult = beanB.invokeSecured(text);
+            result.append(", ");
+            result.append(appResult);
+        }
+        result.append("}");
+
+        LOGGER.info("AppTwo (loop) returns : " + result);
+
+        // should be closed and null the reference to close the connection
+        saveContextClose(iCtxA);
+        iCtxA = null;
+        saveContextClose(iCtxB);
+        iCtxB = null;
+
+        return result.toString();
+    }
+}

--- a/ejb-multi-server/app-main/ejb/src/main/resources/META-INF/ejb-jar.xml
+++ b/ejb-multi-server/app-main/ejb/src/main/resources/META-INF/ejb-jar.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<ejb-jar xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd" version="3.1">
+    <enterprise-beans>
+        <session>
+            <ejb-name>MainAppBean</ejb-name>
+      <!-- add a application local reference, the reference points to a server configuration specific -->
+            <ejb-ref>
+                <ejb-ref-name>AppTwoAlias</ejb-ref-name>
+                <lookup-name>java:global/AliasAppTwo</lookup-name>
+            </ejb-ref>
+        </session>
+    </enterprise-beans>
+</ejb-jar>

--- a/ejb-multi-server/app-main/pom.xml
+++ b/ejb-multi-server/app-main/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jboss-ejb-multi-server-app-main</artifactId>
+    <name>JBoss EAP Quickstart: ejb-multi-server - app-main</name>
+    <description>ejb-multi-server: Main application for the scenario
+     The project builds the EJB and WEB component of the main application
+     and pack it as a deployable EAR archive.
+  </description>
+    <packaging>pom</packaging>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modules>
+        <module>ejb</module>
+        <module>web</module>
+        <module>ear</module>
+    </modules>
+</project>

--- a/ejb-multi-server/app-main/web/pom.xml
+++ b/ejb-multi-server/app-main/web/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server-app-main</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <artifactId>jboss-ejb-multi-server-app-main-web</artifactId>
+
+    <name>JBoss EAP Quickstart: ejb-multi-server - app-main - web</name>
+    <url>http://maven.apache.org</url>
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ejb-client-bom</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-main-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.faces</groupId>
+            <artifactId>jboss-jsf-api_2.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${version.dependency.plugin}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+            <!-- Configure the plugin to copy the jar containing javax.annotation.* to a folder named "endorsed" within the 
+              project's build directory -->
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                                    <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}/endorsed</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.compiler.plugin}</version>
+                <configuration>
+                    <!-- Setup the compiler plugin to use the endorsed directory containing
+                         the jar for javax.annotation.* classes. Remember that we setup this folder
+                         via the maven-dependency-plugin configuration, above.
+                         See JsfController.java for more details.
+                     -->
+                    <compilerArgument>-Djava.endorsed.dirs=${project.build.directory}/endorsed</compilerArgument>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.war.plugin}</version>
+                <configuration>
+        <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/ejb-multi-server/app-main/web/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/EjbInvocation.java
+++ b/ejb-multi-server/app-main/web/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/EjbInvocation.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb.multi.server.app;
+
+/**
+ * A container for the result of an EJB invocation. It will be used by the JsfController.
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+public class EjbInvocation {
+
+    private String text;
+    private String result;
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    void setResult(String result) {
+        this.result = result;
+    }
+}

--- a/ejb-multi-server/app-main/web/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/JsfController.java
+++ b/ejb-multi-server/app-main/web/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/JsfController.java
@@ -1,0 +1,105 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb.multi.server.app;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.enterprise.inject.Model;
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+import org.jboss.logging.Logger;
+
+/**
+ * A simple JSF controller to show how the EJB invocation on different servers.
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@Model
+public class JsfController {
+    private static final Logger LOOGER = Logger.getLogger(JsfController.class);
+    private EjbInvocation invocation;
+
+  /**
+   * Inject the 'standard' bean.<br/>
+   * The simple @EJB injection is valid only if the MainApp is unique within the same application EAR archive.
+   * Since there is a MainAppSContextBean using same interface, we can use this @EJB approach and specify
+   * the name and interface as shown here to specify which exact reference should be injected.<br/>
+   * The beanInterface and the mappedName can be used in this case, but it is not necessary if the beanName is unique and implement only one interface.
+   */
+    @EJB(beanName = "MainAppBean", beanInterface = MainApp.class)
+    MainApp mainApp;
+
+  /**
+   * Inject a different bean implementation of the same interface.<br/>
+   * Or use the @Resource annotation with the lookup name only.
+   */
+    @Resource(mappedName = "ejb:jboss-ejb-multi-server-app-main/ejb/MainAppSContextBean!org.jboss.as.quickstarts.ejb.multi.server.app.MainApp")
+    MainApp mainAppScopedContext;
+
+  /**
+   * Injection with @EJB is not possible for foreign application in a different server. For this we can use @Resource.<br/>
+   * Lookup is introduced in Java EE6, so there are compiler or runtime problems if a Java version is used which not contain
+   * the <code>javax.annotation.Resource</code> <code>lookup</code>.
+   * Therefore a fix/workaround is necessary to be able to compile.
+   * See <a href="http://jaitechwriteups.blogspot.co.uk/2011/02/resource-and-new-lookup-attribute-how.html">Jaikiran's technical blog<a> 
+   */
+    @Resource(lookup = "ejb:jboss-ejb-multi-server-app-one/ejb//AppOneBean!org.jboss.as.quickstarts.ejb.multi.server.app.AppOne")
+    AppOne oneApp;
+
+  /**
+   * Injection with @EJB is not possible for a foreign application in a different server. For this we can use @Resource.
+   * Here, we use <code>mappedName</code>, which was available prior to Java EE 6, to avoid compilation errors.
+   */
+    @Resource(mappedName = "ejb:jboss-ejb-multi-server-app-two/ejb//AppTwoBean!org.jboss.as.quickstarts.ejb.multi.server.app.AppTwo")
+    AppTwo twoApp;
+
+  /**
+   * Initialize the controller.
+   */
+    @PostConstruct
+    public void initForm() {
+        this.invocation = new EjbInvocation();
+    }
+
+    @Produces
+    @Named
+    public EjbInvocation getInvocation() {
+        return this.invocation;
+    }
+
+    public void callEJBMainLocal() {
+        LOOGER.info("Try to invoke the local MainApp to log the given text and get the invocation results. Proxy=" + mainApp);
+        this.invocation.setResult(mainApp.invokeAll(this.invocation.getText()));
+    }
+
+    public void callEJBMainScopedContextLocal() {
+        LOOGER.info("Try to invoke the local MainAppSContext to log the given text and get the invocation results. Proxy=" + mainAppScopedContext);
+        this.invocation.setResult(mainAppScopedContext.invokeAll(this.invocation.getText()));
+    }
+
+    public void callEJBAppOneRemote() {
+        LOOGER.info("Try to invoke the remote AppOne to log the given text and get the invocation results. Proxy=" + oneApp);
+        this.invocation.setResult(oneApp.invoke(this.invocation.getText()));
+    }
+
+    public void callEJBAppTwoRemote() {
+        LOOGER.info("Try to invoke the remote AppTwo to log the given text and get the invocation results. Proxy=" + twoApp);
+        this.invocation.setResult(twoApp.invoke(this.invocation.getText()));
+    }
+}

--- a/ejb-multi-server/app-main/web/src/main/webapp/WEB-INF/beans.xml
+++ b/ejb-multi-server/app-main/web/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,23 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Marker file indicating CDI 1.0 should be enabled -->
+
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/ejb-multi-server/app-main/web/src/main/webapp/WEB-INF/faces-config.xml
+++ b/ejb-multi-server/app-main/web/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,23 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Marker file indicating JSF 2.0 should be enabled in the application -->
+
+<faces-config version="2.2" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee
+      http://java.sun.com/xml/ns/javaee/web-facesconfig_2_2.xsd">
+</faces-config>

--- a/ejb-multi-server/app-main/web/src/main/webapp/ejbinvoke.xhtml
+++ b/ejb-multi-server/app-main/web/src/main/webapp/ejbinvoke.xhtml
@@ -1,0 +1,58 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:h="http://java.sun.com/jsf/html"
+    xmlns:f="http://java.sun.com/jsf/core">
+
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+<title>Multi server quickstart - WAR in EAR EJB invocation</title>
+</head>
+
+<!--
+  Simple JSF page to demonstrate how a web application can use the EJB's provided by applications
+  deployed on different servers. 
+ -->
+<body>
+
+    <h1>EJB invoker for multiple server in a Domain</h1>
+    <div id="container">
+        <h:form id="response">
+            <h:panelGrid columns="2">
+                <h:outputLabel>Response:  </h:outputLabel>
+                <h:outputLabel value="#{invocation.result}" />
+            </h:panelGrid>
+        </h:form>
+        <br /> <br />
+        <h:form id="invokeForm">
+            <h:panelGrid columns="3">
+                <h:outputLabel>Text:</h:outputLabel>
+                <h:inputText value="#{invocation.text}" />
+                <h:commandButton id="clear" value="ClearForm" action="#{jsfController.initForm()}" />
+            </h:panelGrid>
+            <h:panelGrid columns="1">
+                <h:commandButton id="mainEjb" value="Invoke local MainApp" action="#{jsfController.callEJBMainLocal()}" />
+                <h:commandButton id="mainEjbSC" value="Invoke local MainApp with ScopedContext"
+                    action="#{jsfController.callEJBMainScopedContextLocal()}" />
+                <h:commandButton id="oneEjb" value="Invoke remote AppOne" action="#{jsfController.callEJBAppOneRemote()}" />
+                <h:commandButton id="twoEjb" value="Invoke remote AppTwo" action="#{jsfController.callEJBAppTwoRemote()}" />
+            </h:panelGrid>
+        </h:form>
+    </div>
+
+</body>
+</html>

--- a/ejb-multi-server/app-main/web/src/main/webapp/index.html
+++ b/ejb-multi-server/app-main/web/src/main/webapp/index.html
@@ -1,0 +1,23 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Plain HTML page that kicks us into the app -->
+
+<html>
+<head>
+<meta http-equiv="Refresh" content="0; URL=ejbinvoke.jsf">
+</head>
+</html>

--- a/ejb-multi-server/app-one/ear/pom.xml
+++ b/ejb-multi-server/app-one/ear/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server-app-one</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>jboss-ejb-multi-server-app-one-ear</artifactId>
+    <packaging>ear</packaging>
+    <name>JBoss EAP Quickstart: ejb-multi-server - app-one - ear</name>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
+            <type>ejb</type>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ejb-client-bom</artifactId>
+            <scope>provided</scope>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.parent.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>${version.ear.plugin}</version>
+                <configuration>
+                    <displayName>Application One</displayName>
+                    <description>A simple quickstart application to demonstrate the
+                        server-server communication</description>
+                    <version>6</version>
+          <!-- it work also without a application.xml but this is to demonstrate 
+            how to use it and activate the jarModule in it -->
+                    <generateApplicationXml>true</generateApplicationXml>
+                    <modules>
+                        <ejbModule>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
+                            <bundleFileName>ejb.jar</bundleFileName>
+                        </ejbModule>
+                    </modules>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/ejb-multi-server/app-one/ejb/pom.xml
+++ b/ejb-multi-server/app-one/ejb/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server-app-one</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+
+
+    <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
+
+    <name>JBoss EAP Quickstart: ejb-multi-server - app-one - ejb</name>
+    <url>http://maven.apache.org</url>
+    <packaging>ejb</packaging>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ejb-client-bom</artifactId>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>  <!--  must include ejb-plugin to change the EJB version from 2.1 to 3.1 -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ejb-plugin</artifactId>
+                <version>${version.ejb.plugin}</version>
+                <configuration>
+                    <ejbVersion>3.1</ejbVersion>
+                    <generateClient>true</generateClient>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources/META-INF</directory>
+        <!-- add the jboss configuration to mark the Beans as 'Clustered' without using the JBoss specific annotation -->
+                <includes>
+                    <include>jboss-ejb3.xml</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
+     </build>
+</project>

--- a/ejb-multi-server/app-one/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppOne.java
+++ b/ejb-multi-server/app-one/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppOne.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb.multi.server.app;
+
+import javax.ejb.Remote;
+
+/**
+ * Interface for the demo application One.
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@Remote
+public interface AppOne {
+
+  /**
+   * Unsecured invocation, will return the name of application, principal and JBoss node.
+   * 
+   * @param text Simple text written to to the logfile to identify the invocation
+   * @return app1[&lt;PrincipalName&gt;]@&lt;jboss.node.name&gt;
+   */
+    String invoke(String text);
+
+  /**
+   * @return The property of jboss.node.name, pattern &lt;host&gt;:&lt;server&gt;
+   */
+    String getJBossNodeName();
+
+  /**
+   * Secured invocation for Roles ( AppOne, Intern ). See {@link #invoke(String)}
+   * 
+   * @param text Simple text written to to the logfile to identify the invocation
+   * @return app1[&lt;PrincipalName&gt;]@&lt;jboss.node.name&gt;
+   */
+    String invokeSecured(String text);
+}

--- a/ejb-multi-server/app-one/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppOneBean.java
+++ b/ejb-multi-server/app-one/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppOneBean.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb.multi.server.app;
+
+import java.security.Principal;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+import org.jboss.logging.Logger;
+
+/**
+ * <p>
+ * Simple bean with methods to get the node name of the server and log messages. One method is annotated with a security role.
+ * The security-domain is declared within the deployment descriptor jboss-ejb3.xml instead of using the annotation.
+ * </p>
+ * <p>
+ * If the security-domain is removed the secured method can be invoked from every user. The shown principal user is 'anonymous'
+ * instead of the original logged in user.
+ * </p>
+ * 
+ * <p>
+ * The EJB is marked as clustered by using the xml deployment descriptor, see <code>jboss-ejb3.xml</code>
+ * </p>
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@Stateless
+public class AppOneBean implements AppOne {
+    private static final Logger LOGGER = Logger.getLogger(AppOneBean.class);
+
+    @Resource
+    SessionContext context;
+
+    @Override
+    public String getJBossNodeName() {
+        return System.getProperty("jboss.node.name");
+    }
+
+    @Override
+    public String invoke(String text) {
+        Principal caller = context.getCallerPrincipal();
+        LOGGER.info("[" + caller.getName() + "] " + text);
+        return "app1[" + caller.getName() + "]@" + getJBossNodeName();
+    }
+
+    @Override
+    @RolesAllowed({ "AppOne", "Intern" })
+    public String invokeSecured(String text) {
+        Principal caller = context.getCallerPrincipal();
+        LOGGER.info("Secured invocation [" + caller.getName() + "] " + text);
+        LOGGER.info("Is in Role AppOne=" + context.isCallerInRole("AppOne") + " Intern=" + context.isCallerInRole("Intern"));
+        return "app1[" + caller.getName() + "]@" + getJBossNodeName();
+    }
+}

--- a/ejb-multi-server/app-one/ejb/src/main/resources/META-INF/jboss-ejb3.xml
+++ b/ejb-multi-server/app-one/ejb/src/main/resources/META-INF/jboss-ejb3.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:s="urn:security" xmlns:c="urn:clustering:1.0"
+    xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
+                     http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+    version="3.1" impl-version="2.0">
+    <enterprise-beans>
+    </enterprise-beans>
+    <assembly-descriptor>
+      <!-- mark all EJB's of the application as clustered (without using the jboss specific @Clustered annotation for each class) -->
+        <c:clustering>
+            <ejb-name>*</ejb-name>
+            <c:clustered>true</c:clustered>
+        </c:clustering>
+    </assembly-descriptor>
+</jboss:ejb-jar>

--- a/ejb-multi-server/app-one/pom.xml
+++ b/ejb-multi-server/app-one/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jboss-ejb-multi-server-app-one</artifactId>
+    <name>JBoss EAP Quickstart: ejb-multi-server - app-one</name>
+    <description>ejb-multi-server: Application one for the scenario</description>
+    <packaging>pom</packaging>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modules>
+        <module>ejb</module>
+        <module>ear</module>
+    </modules>
+</project>

--- a/ejb-multi-server/app-two/ear/pom.xml
+++ b/ejb-multi-server/app-two/ear/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server-app-two</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>jboss-ejb-multi-server-app-two-ear</artifactId>
+    <packaging>ear</packaging>
+    <name>JBoss EAP Quickstart: ejb-multi-server - app-two - ear</name>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
+            <type>ejb</type>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ejb-client-bom</artifactId>
+            <scope>provided</scope>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.parent.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>${version.ear.plugin}</version>
+                <configuration>
+                    <displayName>Application Two</displayName>
+                    <description>A simple quickstart application to demonstrate the
+                        server-server communication</description>
+                    <version>6</version>
+          <!-- it work also without a application.xml but this is to demonstrate 
+            how to use it and activate the jarModule in it -->
+                    <generateApplicationXml>true</generateApplicationXml>
+                    <modules>
+                        <ejbModule>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
+                            <bundleFileName>ejb.jar</bundleFileName>
+                        </ejbModule>
+                    </modules>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/ejb-multi-server/app-two/ejb/pom.xml
+++ b/ejb-multi-server/app-two/ejb/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server-app-two</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+
+
+    <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
+
+    <name>JBoss EAP Quickstart: ejb-multi-server - app-two - ejb</name>
+    <url>http://maven.apache.org</url>
+    <packaging>ejb</packaging>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ejb-client-bom</artifactId>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ejb3</groupId>
+            <artifactId>jboss-ejb3-ext-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>  <!-- must include ejb-plugin to change the EJB version from 2.1 to 3.1 -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-ejb-plugin</artifactId>
+                <version>${version.ejb.plugin}</version>
+                <configuration>
+                    <ejbVersion>3.1</ejbVersion>
+                    <generateClient>true</generateClient>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/ejb-multi-server/app-two/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppTwo.java
+++ b/ejb-multi-server/app-two/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppTwo.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb.multi.server.app;
+
+import javax.ejb.Remote;
+
+/**
+ * Interface for the demo application One.
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@Remote
+public interface AppTwo {
+
+  /**
+   * Unsecured invocation, will return the name of application, principal and JBoss node.
+   * 
+   * @param text Simple text written to to the logfile to identify the invocation
+   * @return app1[&lt;PrincipalName&gt;]@&lt;jboss.node.name&gt;
+   */
+    String invoke(String text);
+
+  /**
+   * @return The property of jboss.node.name, pattern &lt;host&gt;:&lt;server&gt;
+   */
+    String getJBossNodeName();
+
+  /**
+   * Secured invocation for Roles ( AppTwo, Intern ). See {@link #invoke(String)}
+   * 
+   * @param text Simple text written to to the logfile to identify the invocation
+   * @return app1[&lt;PrincipalName&gt;]@&lt;jboss.node.name&gt;
+   */
+    String invokeSecured(String text);
+
+}

--- a/ejb-multi-server/app-two/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppTwoBean.java
+++ b/ejb-multi-server/app-two/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppTwoBean.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb.multi.server.app;
+
+import java.security.Principal;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import org.jboss.as.quickstarts.ejb.multi.server.app.AppTwo;
+import org.jboss.ejb3.annotation.SecurityDomain;
+import org.jboss.logging.Logger;
+
+/**
+ * Simple bean with methods to get the node name of the server and log messages. One method is annotated with a security role.
+ * The security-domain is declared by the JBoss specific annotation SecurityDomain.
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@SecurityDomain(value = "other")
+public @Stateless class AppTwoBean implements AppTwo {
+    private static final Logger LOGGER = Logger.getLogger(AppTwoBean.class);
+
+    @Resource
+    SessionContext context;
+
+    @Override
+    public String getJBossNodeName() {
+        return System.getProperty("jboss.node.name");
+    }
+
+    @Override
+    public String invoke(String text) {
+        Principal caller = context.getCallerPrincipal();
+        LOGGER.info("[" + caller.getName() + "] " + text);
+        return "app2[" + caller.getName() + "]@" + getJBossNodeName();
+    }
+
+    @Override
+    @RolesAllowed({ "AppTwo", "Intern" })
+    public String invokeSecured(String text) {
+        Principal caller = context.getCallerPrincipal();
+        LOGGER.info("Secured invocation [" + caller.getName() + "] " + text);
+        LOGGER.info("Is in Role AppTwo=" + context.isCallerInRole("AppTwo") + " Intern=" + context.isCallerInRole("Intern"));
+        return "app2[" + caller.getName() + "]@" + getJBossNodeName();
+    }
+
+}

--- a/ejb-multi-server/app-two/pom.xml
+++ b/ejb-multi-server/app-two/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jboss-ejb-multi-server-app-two</artifactId>
+    <name>JBoss EAP Quickstart: ejb-multi-server - app-two</name>
+    <description>ejb-multi-server: Application two for the scenario</description>
+    <packaging>pom</packaging>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modules>
+        <module>ejb</module>
+        <module>ear</module>
+    </modules>
+</project>

--- a/ejb-multi-server/app-web/pom.xml
+++ b/ejb-multi-server/app-web/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <artifactId>jboss-ejb-multi-server-app-web</artifactId>
+
+    <name>JBoss EAP Quickstart: ejb-multi-server - app-web</name>
+    <description>A simple web application, which contains a simple Servlet,
+    to demonstrate how a plain web application can use a EJB application
+    deployed on a different server.
+  </description>
+
+    <url>http://maven.apache.org</url>
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-ejb-client-bom</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+    <!-- add dependencies to all related EJB applications which are used.
+         The API jar files will be packed into the lib directory of the WAR archive. 
+     -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-main-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-one-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-two-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.war.plugin}</version>
+                <configuration>
+          <!-- Java EE 6 doesn't require web.xml, Maven needs to catch up! -->
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/ejb-multi-server/app-web/src/main/java/org/jboss/as/quickstarts/web/multi/server/app/Servlet.java
+++ b/ejb-multi-server/app-web/src/main/java/org/jboss/as/quickstarts/web/multi/server/app/Servlet.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.web.multi.server.app;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Hashtable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.as.quickstarts.ejb.multi.server.app.AppOne;
+import org.jboss.as.quickstarts.ejb.multi.server.app.AppTwo;
+
+/**
+ * A simple servlet that is used to invoke all other application EJB's.
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@WebServlet(urlPatterns = "/*")
+public class Servlet extends HttpServlet {
+    private static final Logger LOGGER = Logger.getLogger(Servlet.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+        boolean fail = false;
+
+        LOGGER.info("Servlet is called " + new Date());
+
+        response.setContentType("html");
+        write(response, "<h1>Example Servlet to show how EJB's can be invoked</h1>");
+        write(response, "The node.names are read from the destination server via EJB invocation.<br/>");
+        write(response, "It shows the name of the host instance (host-controller) and the unique server name on this host.<br/>");
+
+        try {
+            final InitialContext iCtx = getContext();
+
+            write(response, "<h2>Invoke AppOne on different server</h2>");
+            try {
+                AppOne proxy = (AppOne) lookup(response, iCtx,
+                    "ejb:jboss-ejb-multi-server-app-one/ejb//AppOneBean!org.jboss.as.quickstarts.ejb.multi.server.app.AppOne");
+                if (proxy != null) {
+                    write(response, "Invocation #1 return node.name => " + proxy.getJBossNodeName() + "<br/>");
+                    // second invocation shows whether the same or a different node is reached
+                    write(response, "Invocation #2 return node.name => " + proxy.getJBossNodeName() + "<br/>");
+                } else {
+                    fail = true;
+                }
+            } catch (Exception n) {
+                LOGGER.log(Level.SEVERE, "Failed to invoke AppOne", n);
+                write(response, "Failed to invoke AppOne<br/>");
+                write(response, n.getMessage());
+                fail = true;
+            }
+            write(response, "<h2>Invoke AppTwo on different server</h2>");
+            try {
+                AppTwo proxy = (AppTwo) lookup(response, iCtx,
+                    "ejb:jboss-ejb-multi-server-app-two/ejb//AppTwoBean!org.jboss.as.quickstarts.ejb.multi.server.app.AppTwo");
+                if (proxy != null) {
+                    write(response, "Invocation #1 return node.name => " + proxy.getJBossNodeName() + "<br/>");
+                    // second invocation shows whether the same or a different node is reached
+                    write(response, "Invocation #2 return node.name => " + proxy.getJBossNodeName() + "<br/>");
+                } else {
+                    fail = true;
+                }
+            } catch (Exception n) {
+                LOGGER.log(Level.SEVERE, "Failed to invoke AppTwo", n);
+                write(response, "Failed to invoke AppTwo<br/>");
+                write(response, n.getMessage());
+                fail = true;
+            }
+        } catch (NamingException e) {
+            write(response, "<h2>Failed to initialize InitialContext</h2>");
+            write(response, e.getMessage());
+        }
+
+        if (fail) {
+            write(response,
+                "<br/><br/><br/><p><b><i>Not all invocations are successful, see JBOSS_HOME/domain/servers/app-web/log/server.log</i></b></p>");
+        } else {
+            write(response, "<br/><br/><br/><p><i>All invocations are successful</i></p>");
+        }
+        write(response, "<p>Finish at " + new Date() + "</p>");
+    }
+
+    private static void write(HttpServletResponse writer, String message) {
+
+        try {
+            writer.getWriter().write(message + "\n");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static InitialContext getContext() throws NamingException {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        return new InitialContext(jndiProperties);
+    }
+
+    private Object lookup(HttpServletResponse response, InitialContext ic, String name) {
+        try {
+            Object proxy = ic.lookup(name);
+            if (proxy == null) {
+                write(response, "lookup(" + name + ") returns no proxy object");
+            }
+            return proxy;
+        } catch (NamingException e) {
+            write(response, "Failed to lookup(" + name + ")");
+            return null;
+        }
+    }
+}

--- a/ejb-multi-server/app-web/src/main/webapp/META-INF/jboss-ejb-client.xml
+++ b/ejb-multi-server/app-web/src/main/webapp/META-INF/jboss-ejb-client.xml
@@ -1,0 +1,37 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.2">
+    <client-context>
+        <ejb-receivers>
+            <!-- this is the connection to access the app-one -->
+            <remoting-ejb-receiver outbound-connection-ref="remote-connection-war-ejb-1" />
+            <!-- this is the connection to access the app-two -->
+            <remoting-ejb-receiver outbound-connection-ref="remote-connection-war-ejb-2" />
+        </ejb-receivers>
+
+        <!-- if there is a cluster behind the outbound connection the cluster element must be defined -->
+        <clusters>
+          <!-- cluster of remote-ejb-connection-1 -->
+            <cluster name="ejb" security-realm="ejb-security-realm-1" username="quickuser1">
+                <connection-creation-options>
+                    <property name="org.xnio.Options.SSL_ENABLED" value="false" />
+                    <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false" />
+                </connection-creation-options>
+            </cluster>
+        </clusters>
+    </client-context>
+</jboss-ejb-client>

--- a/ejb-multi-server/client/pom.xml
+++ b/ejb-multi-server/client/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jboss-ejb-multi-server-client</artifactId>
+
+    <name>JBoss EAP Quickstart: ejb-multi-server - client</name>
+    <packaging>jar</packaging>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <parent>
+        <groupId>org.jboss.as.quickstarts</groupId>
+        <artifactId>jboss-ejb-multi-server</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-ejb-multi-server-app-main-ejb</artifactId>
+            <version>${project.version}</version>
+            <type>ejb-client</type>
+        </dependency>
+
+    <!-- Import the transaction spec API, we use runtime scope because we aren't 
+      using any direct reference to the spec API in our client code -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+    <!-- client communications with the server use XNIO -->
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-nio</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+    <!-- The client needs JBoss remoting to access the server -->
+        <dependency>
+            <groupId>org.jboss.remoting</groupId>
+            <artifactId>jboss-remoting</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+    <!-- Remote EJB accesses can be secured -->
+        <dependency>
+            <groupId>org.jboss.sasl</groupId>
+            <artifactId>jboss-sasl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+
+    <!-- data serialization for invoking remote EJBs -->
+        <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-river</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+    <!-- Import the EJB 3.1 API, we use runtime scope because we aren't using 
+      any direct reference to EJB spec API in our client code -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-ejb-client</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+      <!-- Add the maven exec plugin to allow us to run a java program via maven -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${version.exec.plugin}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>org.jboss.as.quickstarts.ejb.multi.server.Client</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+     </build>
+</project>
+

--- a/ejb-multi-server/client/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/Client.java
+++ b/ejb-multi-server/client/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/Client.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb.multi.server;
+
+import java.util.Date;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+import org.jboss.as.quickstarts.ejb.multi.server.app.MainApp;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
+
+/**
+ * <p>
+ * A simple standalone application which uses the JBoss API to invoke the MainApp demonstration Bean.
+ * </p>
+ * <p>
+ * With the boolean property <i>UseScopedContext</i> the basic example or the example with the scoped-environment will be called.
+ * </p>
+ * 
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+public class Client {
+
+    /**
+     * @param args no args needed
+     * @throws Exception 
+     */
+    public static void main(String[] args) throws Exception {
+        // suppress output of client messages
+        Logger.getLogger("org.jboss").setLevel(Level.FINEST);
+        Logger.getLogger("org.xnio").setLevel(Level.FINEST);
+        
+        Properties p = new Properties();
+        p.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED", "false");
+        p.put("remote.connections", "one");
+        p.put("remote.connection.one.port", "8080");
+        p.put("remote.connection.one.host", "localhost");
+        p.put("remote.connection.one.username", "quickuser");
+        p.put("remote.connection.one.password", "quick-123");
+
+        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(p);
+        ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+        EJBClientContext.setSelector(selector);
+
+        Properties props = new Properties();
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        InitialContext context = new InitialContext(props);
+
+        final boolean useScopedExample = Boolean.getBoolean("UseScopedContext");
+        final String rcal = "ejb:jboss-ejb-multi-server-app-main/ejb//" + (useScopedExample ? "MainAppSContextBean" : "MainAppBean") + "!" + MainApp.class.getName();
+        final MainApp remote = (MainApp) context.lookup(rcal);
+        final String result = remote.invokeAll("Client call at "+new Date());
+
+        System.out.println("InvokeAll succeed: "+result);
+    }
+
+}

--- a/ejb-multi-server/deploy-domain.cli
+++ b/ejb-multi-server/deploy-domain.cli
@@ -1,0 +1,6 @@
+batch
+deploy app-one/ear/target/jboss-ejb-multi-server-app-one.ear --server-groups=quickstart-ejb-multi-appOne-server
+deploy app-two/ear/target/jboss-ejb-multi-server-app-two.ear --server-groups=quickstart-ejb-multi-appTwo-server
+deploy app-main/ear/target/jboss-ejb-multi-server-app-main.ear --server-groups=quickstart-ejb-multi-main-server
+deploy app-web/target/jboss-ejb-multi-server-app-web.war --server-groups=quickstart-ejb-multi-appWeb-server
+run-batch

--- a/ejb-multi-server/install-domain.cli
+++ b/ejb-multi-server/install-domain.cli
@@ -1,0 +1,240 @@
+# change the provided default configuration for the ejb-multi-server quickstart
+
+
+# stop the preconfigured server for the domain
+batch
+# first stop the default servers, block until the server is down
+/host=master/server-config=server-one:stop(blocking=true)
+/host=master/server-config=server-two:stop(blocking=true)
+
+# remove the default server configuration and server-groups
+/host=master/server-config=server-one:remove
+/host=master/server-config=server-two:remove
+/host=master/server-config=server-three:remove
+/server-group=main-server-group:remove
+/server-group=other-server-group:remove
+
+
+# ----  configure the domain for the quickstart ejb-multi-server
+
+# disable the local authentication for applications
+/host=master/core-service=management/security-realm=ApplicationRealm/authentication=local:remove
+
+/profile=default/subsystem=ejb3:write-attribute(name=default-missing-method-permissions-deny-access, value=false)
+/profile=ha/subsystem=ejb3:write-attribute(name=default-missing-method-permissions-deny-access, value=false)
+
+# Configure the connection from main server to "one" and "two"
+# this is to use the application "one" and "two" located at the remote server
+#
+# add the socket binding to the full-sockets, used by the app-main server
+/socket-binding-group=full-sockets/remote-destination-outbound-socket-binding=remote-ejb-1:add(host=localhost, port=8180)
+/socket-binding-group=full-sockets/remote-destination-outbound-socket-binding=remote-ejb-2:add(host=localhost, port=8280)
+
+# add the outbound connections to the remoting subsystem of the full-profile used by app-main server
+/profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection-1:add(outbound-socket-binding-ref=remote-ejb-1, protocol=http-remoting, security-realm=ejb-security-realm-1, username=quickuser1)
+/profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection-1/property=SASL_POLICY_NOANONYMOUS:add(value=false)
+/profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection-1/property=SSL_ENABLED:add(value=false)
+/profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection-2:add(outbound-socket-binding-ref=remote-ejb-2, protocol=http-remoting, security-realm=ejb-security-realm-2, username=quickuser2)
+/profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection-2/property=SASL_POLICY_NOANONYMOUS:add(value=false)
+/profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection-2/property=SSL_ENABLED:add(value=false)
+
+# add a pool for SLSB, otherwise the scoped-context EJB invocation will fail b/c can not commit a transaction after executing the SLSB as the bean (with context) is destroyed before !!
+/profile=full/subsystem=ejb3:write-attribute(name=default-slsb-instance-pool, value=slsb-strict-max-pool)
+
+# add the security realms with the secret (password base64) values for the server communication
+/host=master/core-service=management/security-realm=ejb-security-realm-1:add()
+/host=master/core-service=management/security-realm=ejb-security-realm-1/server-identity=secret:add(value=cXVpY2sxMjMr)
+/host=master/core-service=management/security-realm=ejb-security-realm-2:add()
+/host=master/core-service=management/security-realm=ejb-security-realm-2/server-identity=secret:add(value=cXVpY2srMTIz)
+
+# adjust the default JVM configuration to minimum
+/host=master/jvm=default:write-attribute(name=permgen-size, value=64m)
+/host=master/jvm=default:write-attribute(name=max-permgen-size, value=128m)
+
+#add the main-server group and the server which handle the standalone client requests
+/server-group=quickstart-ejb-multi-main-server:add(profile=full,socket-binding-group=full-sockets)
+/server-group=quickstart-ejb-multi-main-server/jvm=default:add()
+/host=master/server-config=app-main:add(auto-start=true, group=quickstart-ejb-multi-main-server)
+
+#add the app-server group and the servers for the destination application
+# app-one will be a clustered application, so use HA and add two servers
+/server-group=quickstart-ejb-multi-appOne-server:add(profile=ha,socket-binding-group=ha-sockets)
+/server-group=quickstart-ejb-multi-appOne-server/jvm=default:add()
+/host=master/server-config=app-oneA:add(auto-start=true, group=quickstart-ejb-multi-appOne-server, socket-binding-port-offset=100)
+/host=master/server-config=app-oneB:add(auto-start=true, group=quickstart-ejb-multi-appOne-server, socket-binding-port-offset=700)
+
+# app two is not a clustered application, so use default profile
+/server-group=quickstart-ejb-multi-appTwo-server:add(profile=default,socket-binding-group=standard-sockets)
+/server-group=quickstart-ejb-multi-appTwo-server/jvm=default:add()
+/host=master/server-config=app-twoA:add(auto-start=true, group=quickstart-ejb-multi-appTwo-server, socket-binding-port-offset=200)
+/host=master/server-config=app-twoB:add(auto-start=true, group=quickstart-ejb-multi-appTwo-server, socket-binding-port-offset=800)
+
+# add an alias for app2 bean to demonstrate how to avoid direct dependency to destination app name
+/profile=full/subsystem=naming/binding=java\:global\/AliasAppTwo:add(binding-type=lookup, lookup="ejb:jboss-ejb-multi-server-app-two/ejb//AppTwoBean!org.jboss.as.quickstarts.ejb.multi.server.app.AppTwo")
+
+
+# ---  add an additional server and group for web application only
+
+# create a new profile
+/profile=default-web:add()
+/profile=default-web/subsystem=logging:add()
+/profile=default-web/subsystem=logging/periodic-rotating-file-handler=FILE:add(autoflush=true,file={"relative-to"=>"jboss.server.log.dir", "path"=>"server.log"},append=true,suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n")
+/profile=default-web/subsystem=logging/logger=com.arjuna:add(level=WARN)
+/profile=default-web/subsystem=logging/logger=org.apache.tomcat.util.modeler:add(level=WARN)
+/profile=default-web/subsystem=logging/logger=org.jboss.as.config:add(level=DEBUG)
+/profile=default-web/subsystem=logging/logger=sun.rmi:add(level=WARN)
+/profile=default-web/subsystem=logging/logger=jacorb:add(level=WARN)
+/profile=default-web/subsystem=logging/logger=jacorb.config:add(level=ERROR)
+/profile=default-web/subsystem=logging/root-logger=ROOT:add(level=INFO,handlers=["FILE"])
+
+/profile=default-web/subsystem=batch:add()
+/profile=default-web/subsystem=batch/thread-pool=batch:add(keepalive-time={time=100,unit=milliseconds}, max-threads=10)
+
+/profile=default-web/subsystem=ee:add(spec-descriptor-property-replacement=false,jboss-descriptor-property-replacement=true,ejb-annotation-property-replacement=false)
+/profile=default-web/subsystem=ee/context-service=default:add(jndi-name="java:jboss/ee/concurrency/context/default", use-transaction-setup-provider=true)
+/profile=default-web/subsystem=ee/managed-thread-factory=default:add(context-service=default, jndi-name="java:jboss/ee/concurrency/factory/default")
+/profile=default-web/subsystem=ee/managed-executor-service=default:add(jndi-name="java:jboss/ee/concurrency/executor/default", context-service="default", hung-task-threshold="60000",  core-threads="5", max-threads=25, keepalive-time="5000")
+/profile=default-web/subsystem=ee/managed-scheduled-executor-service=default:add(jndi-name="java:jboss/ee/concurrency/scheduler/default", context-service="default", hung-task-threshold="60000", core-threads="2", keepalive-time="3000")
+/profile=default-web/subsystem=ee/service=default-bindings:add(context-service="java:jboss/ee/concurrency/context/default", datasource="java:jboss/datasources/ExampleDS", jms-connection-factory="java:jboss/DefaultJMSConnectionFactory", managed-executor-service="java:jboss/ee/concurrency/executor/default", managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default", managed-thread-factory="java:jboss/ee/concurrency/factory/default")
+
+/profile=default-web/subsystem=ejb3:add()
+/profile=default-web/subsystem=ejb3:write-attribute(name=default-slsb-instance-pool,value=slsb-strict-max-pool)
+/profile=default-web/subsystem=ejb3:write-attribute(name=default-sfsb-cache,value=simple)
+/profile=default-web/subsystem=ejb3:write-attribute(name=default-sfsb-passivation-disabled-cache, value="simple")
+/profile=default-web/subsystem=ejb3:write-attribute(name=default-stateful-bean-access-timeout, value=5000)
+/profile=default-web/subsystem=ejb3:write-attribute(name=default-singleton-bean-access-timeout, value=5000)
+/profile=default-web/subsystem=ejb3/strict-max-bean-instance-pool=slsb-strict-max-pool:add(max-pool-size=20,timeout=5,timeout-unit=MINUTES)
+/profile=default-web/subsystem=ejb3/strict-max-bean-instance-pool=mdb-strict-max-pool:add(max-pool-size=20,timeout=5,timeout-unit=MINUTES)
+/profile=default-web/subsystem=ejb3/cache=simple:add()
+/profile=default-web/subsystem=ejb3/cache=distributable:add(passivation-store=infinispan, aliases=["passivating clustered"])
+/profile=default-web/subsystem=ejb3/passivation-store=infinispan:add(cache-container=ejb, max-size=10000)
+/profile=default-web/subsystem=ejb3/service=async:add(thread-pool-name=default)
+# timer service can have a choice to storage data
+/profile=default-web/subsystem=ejb3/service=timer-service:add(thread-pool-name=default,default-data-store=default-file-store)
+/profile=default-web/subsystem=ejb3/service=timer-service/file-data-store=default-file-store:add(path=timer-service-data,relative-to=jboss.server.data.dir)
+
+/profile=default-web/subsystem=ejb3/service=remote:add(connector-ref=http-remoting-connector,thread-pool-name=default)
+/profile=default-web/subsystem=ejb3/thread-pool=default:add(max-threads=10,keepalive-time={"time"=>"100","unit"=>"MILLISECONDS"})
+
+/profile=default-web/subsystem=ejb3:write-attribute(name=default-security-domain, value="other")
+/profile=default-web/subsystem=ejb3:write-attribute(name=default-missing-method-permissions-deny-access, value="false")
+
+/profile=default-web/subsystem=io:add()
+/profile=default-web/subsystem=io/worker=default:add(io-threads=3)
+/profile=default-web/subsystem=io/buffer-pool=default:add(buffer-size=16384, buffers-per-slice=128)
+
+/profile=default-web/subsystem=infinispan:add()
+/profile=default-web/subsystem=infinispan/cache-container=web:add(default-cache=passivation, module=org.wildfly.clustering.web.infinispan)
+/profile=default-web/subsystem=infinispan/cache-container=web/local-cache=passivation:add(batching=true)
+/profile=default-web/subsystem=infinispan/cache-container=web/local-cache=passivation/file-store=FILE_STORE:add(passivation=true, purge=false)
+/profile=default-web/subsystem=infinispan/cache-container=web/local-cache=persistent:add(batching=true)
+/profile=default-web/subsystem=infinispan/cache-container=web/local-cache=persistent/file-store=FILE_STORE:add(passivation=false, purge=false)
+/profile=default-web/subsystem=infinispan/cache-container=ejb:add(default-cache=passivation, module="org.wildfly.clustering.ejb.infinispan", aliases=["sfsb"])
+/profile=default-web/subsystem=infinispan/cache-container=ejb/local-cache=passivation:add(batching=true)
+/profile=default-web/subsystem=infinispan/cache-container=ejb/local-cache=passivation/file-store=FILE_STORE:add(passivation=true, purge=false)
+/profile=default-web/subsystem=infinispan/cache-container=ejb/local-cache=persistent:add(batching=true)
+/profile=default-web/subsystem=infinispan/cache-container=ejb/local-cache=persistent/file-store=FILE_STORE:add(passivation=false, purge=false)
+
+/profile=default-web/subsystem=infinispan/cache-container=hibernate:add(default-cache=local-query, module="org.hibernate")
+/profile=default-web/subsystem=infinispan/cache-container=hibernate/local-cache=entity:add()
+/profile=default-web/subsystem=infinispan/cache-container=hibernate/local-cache=entity/transaction=TRANSACTION:add(mode=NON_XA)
+/profile=default-web/subsystem=infinispan/cache-container=hibernate/local-cache=entity/eviction=EVICTION:add(strategy=LRU, max-entries=10000)
+/profile=default-web/subsystem=infinispan/cache-container=hibernate/local-cache=entity/expiration=EXPIRATION:add(max-idle=100000)
+/profile=default-web/subsystem=infinispan/cache-container=hibernate/local-cache=local-query:add()
+/profile=default-web/subsystem=infinispan/cache-container=hibernate/local-cache=local-query/transaction=TRANSACTION:add(mode=NONE)
+/profile=default-web/subsystem=infinispan/cache-container=hibernate/local-cache=local-query/eviction=EVICTION:add(strategy=LRU, max-entries=10000)
+/profile=default-web/subsystem=infinispan/cache-container=hibernate/local-cache=local-query/expiration=EXPIRATION:add(max-idle=100000)
+/profile=default-web/subsystem=infinispan/cache-container=hibernate/local-cache=timestamps:add()
+/profile=default-web/subsystem=infinispan/cache-container=hibernate/local-cache=timestamps/transaction=TRANSACTION:add(mode=NONE)
+/profile=default-web/subsystem=infinispan/cache-container=hibernate/local-cache=timestamps/eviction=EVICTION:add(strategy=NONE)
+
+/profile=default-web/subsystem=jca:add()
+/profile=default-web/subsystem=jca/archive-validation=archive-validation:add(enabled=true, fail-on-error=true, fail-on-warn=false)
+/profile=default-web/subsystem=jca/bean-validation=bean-validation:add(enabled=true)
+/profile=default-web/subsystem=jca/cached-connection-manager=cached-connection-manager:add(install=true)
+/profile=default-web/subsystem=jca/workmanager=default:add(name=default)
+/profile=default-web/subsystem=jca/workmanager=default/short-running-threads=default:add(core-threads=50,queue-length=50,max-threads=50,keepalive-time={"time"=>"10", "unit"=>"SECONDS"})
+/profile=default-web/subsystem=jca/workmanager=default/long-running-threads=default:add(core-threads=50,queue-length=50,max-threads=50,keepalive-time={"time"=>"10", "unit"=>"SECONDS"})
+
+/profile=default-web/subsystem=jpa:add(default-datasource="", default-extended-persistence-inheritance="DEEP")
+
+/profile=default-web/subsystem=jsf:add
+
+/profile=default-web/subsystem=naming:add()
+/profile=default-web/subsystem=naming/service=remote-naming:add
+
+/profile=default-web/subsystem=pojo:add()
+
+/profile=default-web/subsystem=remoting:add()
+/profile=default-web/subsystem=remoting/http-connector=http-remoting-connector:add(connector-ref=default, security-realm=ApplicationRealm)
+# add the outbound connections to the remoting subsystem of the profile used by to connect the app servers
+# it might not necesarry to use a different name for 'outbound-socket-binding-ref', it is just to show the different configuration
+/profile=default-web/subsystem=remoting/remote-outbound-connection=remote-connection-war-ejb-1:add(outbound-socket-binding-ref=remote-war-1, protocol=http-remoting, security-realm=ejb-security-realm-1, username=quickuser1)
+/profile=default-web/subsystem=remoting/remote-outbound-connection=remote-connection-war-ejb-1/property=SASL_POLICY_NOANONYMOUS:add(value=false)
+/profile=default-web/subsystem=remoting/remote-outbound-connection=remote-connection-war-ejb-1/property=SSL_ENABLED:add(value=false)
+/profile=default-web/subsystem=remoting/remote-outbound-connection=remote-connection-war-ejb-2:add(outbound-socket-binding-ref=remote-war-2, protocol=http-remoting, security-realm=ejb-security-realm-2, username=quickuser2)
+/profile=default-web/subsystem=remoting/remote-outbound-connection=remote-connection-war-ejb-2/property=SASL_POLICY_NOANONYMOUS:add(value=false)
+/profile=default-web/subsystem=remoting/remote-outbound-connection=remote-connection-war-ejb-2/property=SSL_ENABLED:add(value=false)
+
+/profile=default-web/subsystem=security:add
+/profile=default-web/subsystem=security/security-domain=other:add(cache-type=default)
+/profile=default-web/subsystem=security/security-domain=other/authentication=classic:add(login-modules=[{"code"=>"Remoting","flag"=>"optional","module-options"=>[("password-stacking"=>"useFirstPass")]},{"code"=>"RealmDirect","flag"=>"required","module-options"=>[("password-stacking"=>"useFirstPass")]}])
+/profile=default-web/subsystem=security/security-domain=jboss-web-policy:add(cache-type=default)
+/profile=default-web/subsystem=security/security-domain=jboss-web-policy/authorization=classic:add(policy-modules=[{"code"=>"Delegating","flag"=>"required"}])
+/profile=default-web/subsystem=security/security-domain=jboss-ejb-policy:add(cache-type=default)
+/profile=default-web/subsystem=security/security-domain=jboss-ejb-policy/authorization=classic:add(policy-modules=[{"code"=>"Delegating","flag"=>"required"}])
+
+/profile=default-web/subsystem=threads:add
+
+/profile=default-web/subsystem=transactions:add(socket-binding=txn-recovery-environment, status-socket-binding=txn-status-manager, default-timeout=300, process-id-uuid=true)
+
+/profile=default-web/subsystem=undertow:add
+/profile=default-web/subsystem==undertow/buffer-cache=default:add(buffer-size=1024, buffers-per-region=1024, max-regions=10)
+/profile=default-web/subsystem=undertow/server=default-server:add()
+/profile=default-web/subsystem=undertow/server=default-server/http-listener=default:add(socket-binding=http)
+/profile=default-web/subsystem=undertow/server=default-server/host=default-host:add(alias=["localhost"])
+/profile=default-web/subsystem=undertow/server=default-server/host=default-host/location="/":add(handler="welcome-content")
+/profile=default-web/subsystem=undertow/servlet-container=default:add(default-buffer-cache=default, stack-trace-on-error=local-only)
+/profile=default-web/subsystem=undertow/servlet-container=default/setting=jsp:add
+/profile=default-web/subsystem=undertow/servlet-container=default/setting=persistent-sessions:add(path=persistent-web-sessions, relative-to=jboss.server.data.dir)
+/profile=default-web/subsystem=undertow/configuration=handler:add()
+/profile=default-web/subsystem=undertow/configuration=handler/file=welcome-content:add(path="${jboss.home.dir}/welcome-content", directory-listing="true")
+
+/profile=default-web/subsystem=webservices:add(modify-wsdl-address=true, wsdl-host="${jboss.bind.address:127.0.0.1}")
+/profile=default-web/subsystem=webservices/endpoint-config=Standard-Endpoint-Config:add
+/profile=default-web/subsystem=webservices/endpoint-config=Recording-Endpoint-Config:add
+/profile=default-web/subsystem=webservices/endpoint-config=Recording-Endpoint-Config/pre-handler-chain=recording-handlers:add(protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM"
+/profile=default-web/subsystem=webservices/endpoint-config=Recording-Endpoint-Config/pre-handler-chain=recording-handlers/handler=RecordingHandler:add(class="org.jboss.ws.common.invocation.RecordingServerHandler")
+/profile=default-web/subsystem=webservices/client-config=Standard-Client-Config:add
+
+/profile=default-web/subsystem=weld:add
+
+
+/socket-binding-group=standard-sockets-web:add(default-interface=public)
+/socket-binding-group=standard-sockets-web/socket-binding=http:add(port=8080)
+/socket-binding-group=standard-sockets-web/socket-binding=https:add(port=8443)
+/socket-binding-group=standard-sockets-web/socket-binding=txn-recovery-environment:add(port=4712)
+/socket-binding-group=standard-sockets-web/socket-binding=txn-status-manager:add(port=4713)
+
+# add the socket binding for connection to app-one, app-two
+/socket-binding-group=standard-sockets-web/remote-destination-outbound-socket-binding=remote-war-1:add(host=localhost, port=8180)
+/socket-binding-group=standard-sockets-web/remote-destination-outbound-socket-binding=remote-war-2:add(host=localhost, port=8280)
+
+
+
+/server-group=quickstart-ejb-multi-appWeb-server:add(profile=default-web,socket-binding-group=standard-sockets-web)
+/server-group=quickstart-ejb-multi-appWeb-server/jvm=default:add()
+/host=master/server-config=app-web:add(auto-start=true, group=quickstart-ejb-multi-appWeb-server, socket-binding-port-offset=300)
+
+run-batch
+
+# without restart, outside the batch, there are different problems
+:restart-servers
+
+# finally start the configured servers
+/host=master/server-config=app-oneA:start
+/host=master/server-config=app-oneB:start
+/host=master/server-config=app-twoA:start
+/host=master/server-config=app-twoB:start
+/host=master/server-config=app-main:start
+/host=master/server-config=app-web:start

--- a/ejb-multi-server/pom.xml
+++ b/ejb-multi-server/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.as.quickstarts</groupId>
+    <artifactId>jboss-ejb-multi-server</artifactId>
+    <version>8.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>JBoss EAP Quickstart: ejb-multi-server</name>
+    <description>ejb-multi-server: An example that demonstrates multiple applications deployed on different servers.
+     This POM defines common properties to specify the used versions and plugins.
+     The subprojects are built in the appropriate sequence.
+  </description>
+
+    <url>http://wildfly.org</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+    <modules>
+        <module>app-one</module>
+        <module>app-two</module>
+        <module>app-main</module>
+        <module>app-web</module>
+        <module>client</module>
+    </modules>
+    <properties>
+        <!-- Explicitly declaring the source encoding eliminates the following
+            message: -->
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered
+            resources, i.e. build is platform dependent! -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <version.wildfly.maven.plugin>1.0.0.Final</version.wildfly.maven.plugin>
+
+        <version.wildfly>8.0.0.Final</version.wildfly>
+        <!-- Alternatively, comment out the above line, and un-comment the
+            line below to use version 7.2.0.Final-redhat-1 which is a release certified
+            to work with JBoss EAP 6. It requires you have access to the JBoss EAP 6
+            maven repository. -->
+        <!-- <version.server>7.2.0.Final-redhat-1</version.server> -->
+
+        <version.jboss.spec.javaee.7.0>1.0.0.Final</version.jboss.spec.javaee.7.0>
+
+        <!-- other plugin versions -->
+        <version.compiler.plugin>3.1</version.compiler.plugin>
+        <version.dependency.plugin>2.1</version.dependency.plugin>
+        <version.ejb.plugin>2.3</version.ejb.plugin>
+        <version.ear.plugin>2.6</version.ear.plugin>
+        <version.war.plugin>2.2</version.war.plugin>
+        <version.exec.plugin>1.2.1</version.exec.plugin>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Define the version of JBoss' Java EE 7 APIs we want to use -->
+            <!-- JBoss distributes a complete set of Java EE 7 APIs including
+                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                a collection) of artifacts. We use this here so that we always get the correct
+                versions of artifacts. Here we use the jboss-javaee-7.0 stack (you can
+                read this as the JBoss stack of the Java EE 7 APIs). You can actually
+                use this stack with any version of WildFly that implements Java EE 7, not
+                just WildFly 8! -->
+            <dependency>
+                <groupId>org.jboss.spec</groupId>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>${version.jboss.spec.javaee.7.0}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-ejb-client-bom</artifactId>
+                <version>${version.wildfly}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <!-- WildFly plugin to deploy apps -->
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.maven.plugin}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${version.exec.plugin}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/ejb-multi-server/remove-configuration.cli
+++ b/ejb-multi-server/remove-configuration.cli
@@ -1,0 +1,87 @@
+# Batch script to remove the quickstart-domain security domain from the JBoss server
+
+# Start batching commands
+batch
+
+# Stop the installed servers so that they can be removed.
+/host=master/server-config=app-web:stop(blocking=true)
+/host=master/server-config=app-main:stop(blocking=true)
+/host=master/server-config=app-oneA:stop(blocking=true)
+/host=master/server-config=app-oneB:stop(blocking=true)
+/host=master/server-config=app-twoA:stop(blocking=true)
+/host=master/server-config=app-twoB:stop(blocking=true)
+
+# Remove the socket binding from the full-sockets, used by the app-main server
+/socket-binding-group=full-sockets/remote-destination-outbound-socket-binding=remote-ejb-1:remove
+/socket-binding-group=full-sockets/remote-destination-outbound-socket-binding=remote-ejb-2:remove
+
+# Remove socket bindings from the standard sockets
+/socket-binding-group=standard-sockets-web:remove()
+
+# Remove the outbound connections from the remoting subsystem of the full-profile used by app-main server
+/profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection-1:remove
+/profile=full/subsystem=remoting/remote-outbound-connection=remote-ejb-connection-2:remove
+
+# Remove the security realms with the secret (password base64) values for the server communication
+/host=master/core-service=management/security-realm=ejb-security-realm-1:remove()
+/host=master/core-service=management/security-realm=ejb-security-realm-2:remove()
+
+# Remove the alias for app2 bean
+/profile=full/subsystem=naming/binding=java\:global\/AliasAppTwo:remove()
+
+# Remove server and server-groups
+/server-group=quickstart-ejb-multi-appWeb-server:remove()
+/host=master/server-config=app-web:remove()
+/profile=default-web/subsystem=remoting:remove()
+/server-group=quickstart-ejb-multi-main-server:remove()
+/host=master/server-config=app-main:remove()
+/server-group=quickstart-ejb-multi-appOne-server:remove()
+/host=master/server-config=app-oneA:remove()
+/host=master/server-config=app-oneB:remove()
+/server-group=quickstart-ejb-multi-appTwo-server:remove()
+/host=master/server-config=app-twoA:remove()
+/host=master/server-config=app-twoB:remove()
+
+
+# Remove all default subsystem profiles
+/profile=default-web/subsystem=logging:remove()
+/profile=default-web/subsystem=configadmin:remove()
+/profile=default-web/subsystem=ee:remove()
+/profile=default-web/subsystem=ejb3:remove()
+/profile=default-web/subsystem=jca:remove()
+/profile=default-web/subsystem=naming:remove()
+/profile=default-web/subsystem=security:remove()
+/profile=default-web/subsystem=threads:remove()
+/profile=default-web/subsystem=transactions:remove()
+/profile=default-web/subsystem=web:remove()
+/profile=default-web:remove()
+
+
+# Add default server groups back to the profile
+/server-group=main-server-group:add(profile=full,socket-binding-group=full-sockets)
+/server-group=main-server-group/jvm=default:add()
+
+
+/server-group=other-server-group:add(profile=full-ha,socket-binding-group=full-ha-sockets)
+
+/server-group=other-server-group/jvm=default:add()
+
+/server-group=main-server-group/jvm=default:write-attribute(name=heap-size, value=1303m)  
+/server-group=main-server-group/jvm=default:write-attribute(name=max-heap-size, value=1303m)
+/server-group=other-server-group/jvm=default:write-attribute(name=heap-size, value=1303m)  
+/server-group=other-server-group/jvm=default:write-attribute(name=max-heap-size, value=1303m)
+/server-group=main-server-group/jvm=default:write-attribute(name=heap-size, value=1303m)  
+/server-group=main-server-group/jvm=default:write-attribute(name=max-permgen-size, value=256m)
+/server-group=other-server-group/jvm=default:write-attribute(name=max-permgen-size, value=256m)
+
+# Add the default server-configs back to the profile
+/host=master/server-config=server-one:add(group=main-server-group)
+/host=master/server-config=server-two:add(group=main-server-group,socket-binding-port-offset=150)
+/host=master/server-config=server-three:add(group=other-server-group,auto-start=false,socket-binding-port-offset=250)
+
+# Run the batch commands
+run-batch
+
+
+
+

--- a/ejb-multi-server/undeploy-domain.cli
+++ b/ejb-multi-server/undeploy-domain.cli
@@ -1,0 +1,5 @@
+# remove all deployments from the domain
+undeploy --server-groups=quickstart-ejb-multi-appWeb-server jboss-ejb-multi-server-app-web.war
+undeploy --server-groups=quickstart-ejb-multi-main-server jboss-ejb-multi-server-app-main.ear
+undeploy --server-groups=quickstart-ejb-multi-appOne-server jboss-ejb-multi-server-app-one.ear
+undeploy --server-groups=quickstart-ejb-multi-appTwo-server jboss-ejb-multi-server-app-two.ear

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
                 <module>ejb-in-war</module>
                 <module>ejb-remote</module>
                 <module>ejb-security</module>
+                <module>ejb-multi-server</module>
                 <module>greeter</module>
                 <module>helloworld</module>
                 <module>helloworld-html5</module>


### PR DESCRIPTION
- use http-remoting instead of native remoting
- adding missing properties and new subsystems
- use maven property project.groupId instead of having hardcoded in dependencies
- synchronize changed with jboss-eap-quickstarts
