### PR TITLE
adding a new Security Vault Askpass quickstart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
                 <module>mail</module>
                 <module>numberguess</module>
                 <module>payment-cdi-event</module>
+                <module>security-vault-askpass</module>
                 <module>servlet-async</module>
                 <module>servlet-filterlistener</module>
                 <module>servlet-security</module>

--- a/security-vault-askpass/README.md
+++ b/security-vault-askpass/README.md
@@ -1,0 +1,218 @@
+security-vault-askpass: Using Security Vault based on external askpass command to secure Datasource password
+====================
+Author: Ivo Studensky
+Level: Intermediate
+Technologies: Servlet, Security Vault, Java KeyStore
+Summary: Demonstrates how to use Security Vault to secure Datasource password
+Target Project: WildFly
+Source: <https://github.com/wildfly/quickstart/>
+
+What is it?
+-----------
+
+This example demonstrates the use of Security Vault to secure Datasource password in JBoss WildFly.
+
+Security Vault is a facility of PicketBox which allows to mask sensitive attributes such as passwords.
+With the use of Security Vault any password can be masked by a cipher algorithm whose key is taken from a Java KeyStore.
+The Java KeyStore itself is guarded by another password which can either be masked again or taken from an external utility.
+This example demonstrates the use of Security Vault provided with the keystore key by an askpass-like external command,
+eg. ksshaskpass for KWallet, gnome-ssh-askpass for GNOME Keyring, etc.
+
+This quickstart uses a mock askpass script instead of a real one, see `bin/askpass.sh`.
+An example of the external command configuration for ksshaskpass could be as follows:
+
+        {CMD}/usr/bin/ksshaskpass,Enter passphrase for askpass quickstart
+
+This quickstart takes the following steps to set up Security Vault:
+
+1. Create Java KeyStore for Security Vault
+2. Initialize Security Vault
+3. Define Security Vault in the `standalone.xml` configuration file
+4. Add a password in the Vault format to the Datasource definition
+
+
+System requirements
+-------------------
+
+All you need to build this project is Java 7.0 (Java SDK 1.7) or better, Maven 3.1 or better,
+UNIX/Linux operating system or a Bash support on a different operating system.
+
+The application this project produces is designed to be run on JBoss WildFly.
+
+
+Configure Maven
+---------------
+
+If you have not yet done so, you must [Configure Maven](../README.md#mavenconfiguration) before testing the quickstarts.
+
+
+Create Java Keystore for Security Vault
+----------------
+
+You can leverage standard JDK tool to create a KeyStore as follows:
+
+        $ keytool -genkey -alias vault -keyalg RSA -keysize 1024  -keystore vault.keystore
+        Enter keystore password: vault22
+        Re-enter new password:vault22
+        What is your first and last name?
+          [Unknown]:  Picketbox vault
+        What is the name of your organizational unit?
+          [Unknown]:  picketbox
+        What is the name of your organization?
+          [Unknown]:  JBoss
+        What is the name of your City or Locality?
+          [Unknown]:  chicago
+        What is the name of your State or Province?
+          [Unknown]:  il
+        What is the two-letter country code for this unit?
+          [Unknown]:  us
+        Is CN=Picketbox vault, OU=picketbox, O=JBoss, L=chicago, ST=il, C=us correct?
+          [no]:  yes
+
+        Enter key password for <vault>
+                (RETURN if same as keystore password):
+
+It is important to keep track of the keystore password and the alias. In this example, the keystore password is `vault22` and the alias is `vault`.
+If one prefers just one command here is equivalent:
+
+        keytool -genkey -alias vault -keystore vault.keystore -keyalg RSA -keysize 1024 -storepass vault22 -keypass vault22 -dname "CN=Picketbox vault,OU=picketbox,O=JBoss,L=chicago,ST=il,C=us"
+
+
+Use the Vault Tool script to store the password into the Vault
+---------------
+
+This quickstart needs to store the Datasource password (`sa`) to the Vault. This can be done with the following command:
+
+        $ $JBOSS_HOME/bin/vault.sh -k "$PWD/vault.keystore" -p "{CMD}sh,$PWD/bin/askpass.sh,Enter passphrase for askpass quickstart" -e "$PWD" -i 50 -s 12345678 -v vault -b ds_SecurityVaultDS -a password -x sa
+
+        =========================================================================
+
+          JBoss Vault
+
+          JBOSS_HOME: .../wildfly-8.0.0.Final
+
+          JAVA: .../bin/java
+
+        =========================================================================
+
+        Feb 21, 2014 9:15:15 AM org.picketbox.plugins.vault.PicketBoxSecurityVault init
+        INFO: PBOX000361: Default Security Vault Implementation Initialized and Ready
+        Secured attribute value has been stored in Vault.
+        Please make note of the following:
+        ********************************************
+        Vault Block:ds_SecurityVaultDS
+        Attribute Name:password
+        Configuration should be done as follows:
+        VAULT::ds_SecurityVaultDS::password::1
+        ********************************************
+        Vault Configuration in WildFly configuration file:
+        ********************************************
+        ...
+        </extensions>
+        <vault>
+          <vault-option name="KEYSTORE_URL" value=".../quickstart/security-vault-askpass/vault.keystore"/>
+          <vault-option name="KEYSTORE_PASSWORD" value="{CMD}sh,.../quickstart/security-vault-askpass/bin/askpass.sh,Enter passphrase for askpass quickstart"/>
+          <vault-option name="KEYSTORE_ALIAS" value="vault"/>
+          <vault-option name="SALT" value="12345678"/>
+          <vault-option name="ITERATION_COUNT" value="50"/>
+          <vault-option name="ENC_FILE_DIR" value=".../quickstart/security-vault-askpass/"/>
+        </vault><management> ...
+        ********************************************
+        $
+
+Please note the Vault value of the Datasource password `VAULT::ds_SecurityVaultDS::password::1`, this value must match
+the one defined in the `/src/main/webapp/WEB-INF/security-vault-quickstart-ds.xml` file.
+
+There is also an option of interactive session in the Vault Tool script. The interactive session, however, cannot
+take an external command to get the KeyStore password. The password has to be manually typed in instead.
+
+For more information use `vault.sh --help`.
+
+### Configure the Security Vault by Manually Editing the Server Configuration File
+
+1.  If it is running, stop the JBoss WildFly Server.
+2.  Backup the file: `JBOSS_HOME/standalone/configuration/standalone.xml`
+3.  Open the `JBOSS_HOME/standalone/configuration/standalone.xml` file in an editor and locate the terminating element `</extensions>` there.
+4.  Add the XML snippet generated before to the configuration file:
+
+        <vault>
+          <vault-option name="KEYSTORE_URL" value=".../quickstart/security-vault-askpass/vault.keystore"/>
+          <vault-option name="KEYSTORE_PASSWORD" value="{CMD}sh,.../quickstart/security-vault-askpass/bin/askpass.sh,Enter passphrase for askpass quickstart"/>
+          <vault-option name="KEYSTORE_ALIAS" value="vault"/>
+          <vault-option name="SALT" value="12345678"/>
+          <vault-option name="ITERATION_COUNT" value="50"/>
+          <vault-option name="ENC_FILE_DIR" value=".../quickstart/security-vault-askpass/"/>
+        </vault>
+
+
+Start JBoss WildFly with the Web Profile
+-------------------------
+
+1. Open a command line and navigate to the root of the JBoss server directory.
+2. The following shows the command line to start the server with the web profile:
+
+        For Linux:   JBOSS_HOME/bin/standalone.sh
+        For Windows: JBOSS_HOME\bin\standalone.bat
+
+
+<a id="buildanddeploy"></a>
+Build and Deploy the Quickstart
+-------------------------
+
+_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See [Build and Deploy the Quickstarts](../README.md#buildanddeploy) for complete instructions and additional options._
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. Type this command to build and deploy the archive:
+
+        mvn clean package wildfly:deploy
+
+4. This will deploy `target/wildfly-servlet-security.war` to the running instance of the server.
+
+
+<a id="accesstheapp"></a>
+Access the Application 
+---------------------
+
+The application will be running at the following URL <http://localhost:8080/wildfly-security-vault-askpass/AskpassServlet>.
+
+When you access the application the browser should display the following info:
+
+        Security Vault Askpass Servlet
+        The connection to the datasource is valid? true
+
+_NOTE:  The H2 database used in this quickstart is known to not be precisely reliable which applies to its login/authentication facilities as well. If you want to run this quickstart  in a more reliable way you need to switch the database it is running against to a different one. See [Install and Configure the PostgreSQL Database](../README.md#postgresql) for instructions._
+
+Undeploy the Archive
+--------------------
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. When you are finished testing, type this command to undeploy the archive:
+
+        mvn wildfly:undeploy
+
+
+Remove the Security Vault Configuration
+----------------------------
+
+You can remove the Security Vault configuration by manually restoring the back-up copy of the configuration file.
+
+### Remove the Security Domain Configuration Manually
+1. If it is running, stop the JBoss WildFly Server.
+2. Replace the `JBOSS_HOME/standalone/configuration/standalone.xml` file with the back-up copy of the file
+   or remove the Vault related lines added there before.
+
+
+Run the Quickstart in JBoss Developer Studio or Eclipse
+-------------------------------------
+You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see [Use JBoss Developer Studio or Eclipse to Run the Quickstarts](../README.md#useeclipse) 
+
+
+Debug the Application
+------------------------------------
+
+If you want to debug the source code or look at the Javadocs of any library in the project, run either of the following commands to pull them into your local repository. The IDE should then detect them.
+
+      mvn dependency:sources
+      mvn dependency:resolve -Dclassifier=javadoc

--- a/security-vault-askpass/pom.xml
+++ b/security-vault-askpass/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wildfly.quickstarts</groupId>
+    <artifactId>wildfly-security-vault-askpass</artifactId>
+    <version>8.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <name>WildFly Quickstarts: Security Vault Askpass</name>
+    <description>WildFly Quickstarts: Security Vault Askpass</description>
+
+    <url>http://wildfly.org</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <!-- Explicitly declaring the source encoding eliminates the following message: -->
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+            resources, i.e. build is platform dependent! -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+
+        <version.wildfly.maven.plugin>1.0.0.Final</version.wildfly.maven.plugin>
+
+        <version.jboss.spec.javaee.7.0>1.0.0.Final</version.jboss.spec.javaee.7.0>
+
+
+        <!-- other plugin versions -->
+        <version.compiler.plugin>3.1</version.compiler.plugin>
+        <version.war.plugin>2.1.1</version.war.plugin>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Define the version of JBoss' Java EE 7 APIs we want to use -->
+            <!-- JBoss distributes a complete set of Java EE 7 APIs including
+                a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
+                a collection) of artifacts. We use this here so that we always get the correct
+                versions of artifacts. Here we use the jboss-javaee-7.0 stack (you can
+                read this as the JBoss stack of the Java EE 7 APIs). You can actually
+                use this stack with any version of WildFly that implements Java EE 7, not
+                just WildFly 8! -->
+            <dependency>
+                <groupId>org.jboss.spec</groupId>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>${version.jboss.spec.javaee.7.0}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- Import the CDI API, we use provided scope as the API is included in JBoss WildFly -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Import the Common Annotations API (JSR-250), we use provided scope 
+            as the API is included in JBoss WildFly -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Import the Servlet API, we use provided scope as the API is included in JBoss WildFly. -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <!-- Set the name of the war, used as the context root when the app is deployed. -->
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.war.plugin}</version>
+                <configuration>
+                    <!-- Java EE 7 doesn't require web.xml, Maven needs to catch up! -->
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+            <!-- WildFly plugin to deploy war -->
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.maven.plugin}</version>
+            </plugin>
+            <!-- Compiler plugin enforces Java 1.6 compatibility and activates annotation processors. -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.compiler.plugin}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/security-vault-askpass/src/main/java/org/jboss/as/quickstarts/securityvault/AskpassServlet.java
+++ b/security-vault-askpass/src/main/java/org/jboss/as/quickstarts/securityvault/AskpassServlet.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.securityvault;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+
+import javax.annotation.Resource;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+
+/**
+ * A simple Servlet which tries to access the Datasource secured by Vault.
+ *
+ * @author Ivo Studensky
+ * 
+ */
+@SuppressWarnings("serial")
+@WebServlet("/AskpassServlet")
+public class AskpassServlet extends HttpServlet {
+
+    private static String PAGE_HEADER = "<html><head><title>security-vault-askpass-servlet</title></head><body>";
+
+    private static String PAGE_FOOTER = "</body></html>";
+
+    @Resource(mappedName = "java:jboss/datasources/SecurityVaultDS")
+    private DataSource ds;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        PrintWriter writer = resp.getWriter();
+
+        writer.println(PAGE_HEADER);
+        writer.println("<h1>" + "Security Vault Askpass Servlet " + "</h1>");
+        try {
+            boolean canConnect = ds.getConnection().isValid(5);
+            writer.println("The connection to the datasource is valid? " + canConnect);
+        } catch (SQLException e) {
+            writer.println("ERROR: Could not connect to the datasource due to " + e);
+            writer.println("<pre>");
+            e.printStackTrace(writer);
+            writer.println("</pre>");
+        }
+        writer.println(PAGE_FOOTER);
+        writer.close();
+    }
+
+}

--- a/security-vault-askpass/src/main/resources/META-INF/persistence.xml
+++ b/security-vault-askpass/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<persistence version="2.0"
+    xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://java.sun.com/xml/ns/persistence
+        http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+    <persistence-unit name="primary">
+        <!-- If you are running in a production environment, add a managed 
+            data source, this example data source is just for development and testing! -->
+        <!-- The datasource is deployed as WEB-INF/security-vault-quickstart-ds.xml,
+            you can find it in the source at src/main/webapp/WEB-INF/security-vault-quickstart-ds.xml -->
+        <jta-data-source>java:jboss/datasources/SecurityVaultDS</jta-data-source>
+        <properties>
+            <!-- Properties for Hibernate -->
+            <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+            <property name="hibernate.show_sql" value="false" />
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/security-vault-askpass/src/main/webapp/WEB-INF/security-vault-quickstart-ds.xml
+++ b/security-vault-askpass/src/main/webapp/WEB-INF/security-vault-quickstart-ds.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- This is an unmanaged datasource. It should be used for proofs of concept 
+    or testing only. It uses H2, an in memory database that ships with JBoss 
+    AS. -->
+<datasources xmlns="http://www.jboss.org/ironjacamar/schema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.jboss.org/ironjacamar/schema http://docs.jboss.org/ironjacamar/schema/datasources_1_0.xsd">
+    <!-- The datasource is bound into JNDI at this location. We reference 
+        this in META-INF/persistence.xml -->
+    <datasource jndi-name="java:jboss/datasources/SecurityVaultDS"
+        pool-name="security-vault" enabled="true" use-java-context="true">
+        <connection-url>jdbc:h2:mem:security-vault;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+        <driver>h2</driver>
+        <security>
+            <user-name>sa</user-name>
+            <password>VAULT::ds_SecurityVaultDS::password::1</password>
+        </security>
+    </datasource>
+</datasources>


### PR DESCRIPTION
Security Vault Askpass quickstart which demonstrates how to set up the Vault with the keystore password taken from an external askpass-like command. The password secured by the Vault is then used/demonstrated in a Datasource configuration.
