### PR TITLE
Adding a no-maven way to run HelloWorldJMSClient

### DIFF
--- a/helloworld-jms/README.md
+++ b/helloworld-jms/README.md
@@ -25,7 +25,7 @@ It contains the following:
 System requirements
 -------------------
 
-All you need to build this project is Java 7.0 (Java SDK 1.7) or better, optionall Maven 3.0 or better.
+All you need to build this project is Java 7.0 (Java SDK 1.7) or better, optional Maven 3.0 or better.
 
 The application this project produces is designed to be run on WildFly 8.
 


### PR DESCRIPTION
Modified the readme.md showing how to run the HelloWorldJMSClient without the need to use Maven.
