### PR TITLE
Revert "Don't cast"

### DIFF
--- a/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldQueueMDB.java
+++ b/helloworld-mdb/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldQueueMDB.java
@@ -47,7 +47,7 @@ public class HelloWorldQueueMDB implements MessageListener {
         TextMessage msg = null;
         try {
             if (rcvMessage instanceof TextMessage) {
-                msg = rcvMessage.getBody(TextMessage.class);
+                msg = (TextMessage) rcvMessage;
                 LOGGER.info("Received Message from queue: " + msg.getText());
             } else {
                 LOGGER.warning("Message of wrong type: " + rcvMessage.getClass().getName());


### PR DESCRIPTION
This reverts commit ce22cde218638c4e8beb9d0d153b53bc383c0918.

The commit was throwing an exception:

```
java.lang.RuntimeException: javax.jms.MessageFormatException: Body not assignable to interface javax.jms.TextMessage
    at org.jboss.as.quickstarts.mdb.HelloWorldQueueMDB.onMessage(HelloWorldQueueMDB.java:56)
```
