### PR TITLE
Update pom.xml

### DIFF
--- a/app-client/ear/pom.xml
+++ b/app-client/ear/pom.xml
@@ -49,6 +49,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
+            <version>${version.wildfly}</version>
             <scope>provided</scope>
             <type>pom</type>
         </dependency>


### PR DESCRIPTION
Maven could not validate this pom file because the version of wildfly-ejb-client-bom was missing
