### PR TITLE
Replacing the 'jar' package type with 'ejb'

### DIFF
--- a/jts/application-component-2/pom.xml
+++ b/jts/application-component-2/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>wildfly-jts-application-component-2</artifactId>
     <name>WildFly Quickstarts: Java Transaction Service Application Component 2</name>
     <description>Using CMT with JTS</description>
-    <packaging>jar</packaging>
+    <packaging>ejb</packaging>
 
 
     <parent>


### PR DESCRIPTION
This helps JBoss Tools and JBoss Developer Studio installing the appropriate Facets and Maven configurators when
importing this project.
