### PR TITLE
Fixing the XSD location for web-facesconfig_2_2.xsd

### DIFF
--- a/ejb-multi-server/app-main/web/src/main/webapp/WEB-INF/faces-config.xml
+++ b/ejb-multi-server/app-main/web/src/main/webapp/WEB-INF/faces-config.xml
@@ -16,8 +16,8 @@
 -->
 <!-- Marker file indicating JSF 2.0 should be enabled in the application -->
 
-<faces-config version="2.2" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/web-facesconfig_2_2.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
 </faces-config>


### PR DESCRIPTION
Sadly, http://java.sun.com/xml/ns/javaee/web-facesconfig_2_2.xsd redirects to
http://www.oracle.com/technetwork/java/index.html, which is not a valid xsd :/
