### PR TITLE
Add a remote EJB client to the security example.

### DIFF
--- a/ejb-security/README.md
+++ b/ejb-security/README.md
@@ -10,7 +10,7 @@ Source: <https://github.com/wildfly/quickstart/>
 What is it?
 -----------
 
-This example demonstrates the use of Java EE declarative security to control access to Servlets and EJBs in *JBoss WildFly*.
+This example demonstrates the use of Java EE declarative security to control access to Servlets and EJBs in *WildFly*.
 
 This quickstart takes the following steps to implement EJB security:
 
@@ -53,6 +53,8 @@ Add the Application Users
 ---------------
 
 This quickstart uses a secured management interface and requires that you create an application user to access the running application. Instructions to set up an Application user can be found here:  [Add an Application User](../README.md#addapplicationuser)
+
+For this quickstart it is recommended you create a user called `quickstartUser` with a password of `quickstartPwd1!` and ensure they are granted the role `guest`.
 
 After you add the default `quickstartUser`, use the same steps to add a second application user who is not in the `guest` role and therefore is not authorized to access the application. 
 
@@ -118,7 +120,18 @@ When you access the application, you are presented with a browser login challeng
         exception
         javax.ejb.EJBAccessException: JBAS014502: Invocation on method: public java.lang.String org.jboss.as.quickstarts.ejb_security.SecuredEJB.getSecurityInfo() of bean: SecuredEJB is not allowed
 
+Remote Client
+-------------
 
+In addition to access through the web application it is also possible to access the secured EJB from a remote stand alone client.
+
+1.  Type this command to execute the client:
+
+		mvn exec:exec
+
+This will execute the remote client which connects to the server and invokes the `getSecurityInfo()` method of the EJB to obtain the name of the current authenticated user.
+
+One important file to note is under `src/main/resources` and is called `jboss-ejb-client.properties` this file contains the settings to connect to the server and also supplies the username and password of the user to connect as.
 
 Undeploy the Archive
 --------------------

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -47,12 +47,12 @@
 
         <version.wildfly>8.1.0.Final</version.wildfly>
 
-
         <version.jboss.spec.javaee.7.0>1.0.0.Final</version.jboss.spec.javaee.7.0>
-
 
         <!-- other plugin versions -->
         <version.compiler.plugin>3.1</version.compiler.plugin>
+
+        <version.exec.plugin>1.2.1</version.exec.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.7</maven.compiler.target>
@@ -118,6 +118,56 @@
             <artifactId>jboss-ejb3-ext-api</artifactId>
         </dependency>
 
+       <!-- JBoss EJB client API jar. We use runtime scope because the EJB client API
+        isn't directly used in this example. We just need it in our runtime classpath -->
+       <dependency>
+           <groupId>org.jboss</groupId>
+           <artifactId>jboss-ejb-client</artifactId>
+           <scope>runtime</scope>
+       </dependency>
+
+       <!-- client communications with the server use XNIO -->
+       <dependency>
+           <groupId>org.jboss.xnio</groupId>
+           <artifactId>xnio-api</artifactId>
+           <scope>runtime</scope>
+       </dependency>
+
+       <dependency>
+           <groupId>org.jboss.xnio</groupId>
+           <artifactId>xnio-nio</artifactId>
+           <scope>runtime</scope>
+       </dependency>
+
+      <!-- The client needs JBoss remoting to access the server -->
+       <dependency>
+            <groupId>org.jboss.remoting</groupId>
+            <artifactId>jboss-remoting</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Remote EJB accesses can be secured -->
+        <dependency>
+            <groupId>org.jboss.sasl</groupId>
+            <artifactId>jboss-sasl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- data serialization for invoking remote EJBs -->
+        <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-river</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+       <!-- Import the transaction spec API, we use runtime scope because we aren't using any direct
+        reference to the spec API in our client code -->
+      <dependency>
+         <groupId>org.jboss.spec.javax.transaction</groupId>
+         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+         <scope>runtime</scope>
+      </dependency>
+
     </dependencies>
 
     <build>
@@ -125,6 +175,31 @@
             is deployed -->
         <finalName>${project.artifactId}</finalName>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${version.exec.plugin}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>java</executable>
+                    <workingDirectory>${project.build.directory}/exec-working-directory</workingDirectory>
+                    <arguments>
+                        <!-- automatically creates the classpath using all project dependencies, 
+                             also adding the project build directory -->
+                        <argument>-classpath</argument>
+                        <classpath>
+                        </classpath>
+                        <argument>org.jboss.as.quickstarts.ejb_security.RemoteClient</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+
             <!-- WildFly plugin to deploy war -->
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>

--- a/ejb-security/src/main/java/org/jboss/as/quickstarts/ejb_security/RemoteClient.java
+++ b/ejb-security/src/main/java/org/jboss/as/quickstarts/ejb_security/RemoteClient.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.quickstarts.ejb_security;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+/**
+ * The remote client responsible for calling the secured EJB.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class RemoteClient {
+
+    /**
+     * @param args
+     */
+    public static void main(String[] args) throws Exception {
+        System.out.println("\n\n\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n\n");
+
+        SecuredRemote remote = lookupEJB();
+
+        String principal = remote.getSecurityInfo();
+
+        System.out.println(String.format("Called EJB, authenticated Principal is '%s'", principal));
+
+        System.out.println("\n\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n\n\n");
+    }
+
+    static SecuredRemote lookupEJB() throws Exception {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context context = new InitialContext(jndiProperties);
+
+        return (SecuredRemote) context.lookup("ejb:/wildfly-ejb-security/SecuredEJB!" + SecuredRemote.class.getName());
+    }
+
+}

--- a/ejb-security/src/main/java/org/jboss/as/quickstarts/ejb_security/SecuredEJB.java
+++ b/ejb-security/src/main/java/org/jboss/as/quickstarts/ejb_security/SecuredEJB.java
@@ -14,32 +14,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.jboss.as.quickstarts.ejb_security;
 
 import java.security.Principal;
 
 import javax.annotation.Resource;
 import javax.annotation.security.RolesAllowed;
+import javax.ejb.Remote;
 import javax.ejb.SessionContext;
 import javax.ejb.Stateless;
 
 import org.jboss.ejb3.annotation.SecurityDomain;
 
 /**
- * Simple secured EJB using EJB security annotations
- * 
- * @author Sherif Makary
- * 
- */
-/**
- * 
+ * Simple secured EJB using EJB security annotations.
+ *
  * Annotate this EJB for authorization. Allow only those in the "guest" role. For EJB authorization, you must also specify the
  * security domain. This example uses the "other" security domain which is provided by default in the standalone.xml file.
- * 
+ *
+ * @author Sherif Makary
  */
 @Stateless
 @RolesAllowed({ "guest" })
 @SecurityDomain("other")
+@Remote(SecuredRemote.class)
 public class SecuredEJB {
 
     // Inject the Session Context
@@ -53,6 +52,6 @@ public class SecuredEJB {
         // Session context injected using the resource annotation
         Principal principal = ctx.getCallerPrincipal();
 
-        return principal.toString();
+        return principal.getName();
     }
 }

--- a/ejb-security/src/main/java/org/jboss/as/quickstarts/ejb_security/SecuredEJBServlet.java
+++ b/ejb-security/src/main/java/org/jboss/as/quickstarts/ejb_security/SecuredEJBServlet.java
@@ -18,6 +18,7 @@ package org.jboss.as.quickstarts.ejb_security;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+
 import javax.ejb.EJB;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.HttpConstraint;
@@ -27,14 +28,13 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.jboss.as.quickstarts.ejb_security.SecuredEJB;
 
 /**
  * A simple secured Servlet which calls a secured EJB. Upon successful authentication and authorization the EJB will return the
  * principal's name. Servlet security is implemented using annotations.
- * 
+ *
  * @author Sherif Makary
- * 
+ *
  */
 @SuppressWarnings("serial")
 @WebServlet("/SecuredEJBServlet")
@@ -46,8 +46,9 @@ public class SecuredEJBServlet extends HttpServlet {
     private static String PAGE_FOOTER = "</body></html>";
 
     // Inject the Secured EJB
+    //@EJB(lookup="java:global/wildfly-ejb-security/SecuredEJB")
     @EJB
-    private SecuredEJB securedEJB;
+    private SecuredRemote securedEJB;
 
     /**
      * Servlet entry point method which calls securedEJB.getSecurityInfo()

--- a/ejb-security/src/main/java/org/jboss/as/quickstarts/ejb_security/SecuredRemote.java
+++ b/ejb-security/src/main/java/org/jboss/as/quickstarts/ejb_security/SecuredRemote.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.quickstarts.ejb_security;
+
+/**
+ * The remote interface for the secured EJB.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface SecuredRemote {
+
+    /**
+     * Get the name of the {@link Principal} associated with the request.
+     *
+     * @return The name of the {@link Principal} associated with the request.
+     */
+    public String getSecurityInfo();
+
+}

--- a/ejb-security/src/main/resources/jboss-ejb-client.properties
+++ b/ejb-security/src/main/resources/jboss-ejb-client.properties
@@ -1,0 +1,29 @@
+#
+# JBoss, Home of Professional Open Source
+# Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+# contributors by the @authors tag. See the copyright.txt in the
+# distribution for a full listing of individual contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=default
+
+remote.connection.default.host=localhost
+remote.connection.default.port = 8080
+remote.connection.default.username = quickstartUser
+remote.connection.default.password = quickstartPwd1!
+remote.connection.default.connect.options.org.xnio.Options.SASL_DISALLOWED_MECHANISMS=JBOSS-LOCAL-USER
+
+ 
+


### PR DESCRIPTION
At the moment we have a remote client where security is not in use and we have remote clients for the more complex examples but we don't have a remote client for the most basic security example.
