### PR TITLE
Fix the MarkDown syntax of the intro

### DIFF
--- a/guide/GettingStarted.asciidoc
+++ b/guide/GettingStarted.asciidoc
@@ -1,5 +1,5 @@
 Getting started with WildFly
-========================================================================
+============================
 :Author: Pete Muir
 
 [[GettingStarted-]]
@@ -216,7 +216,7 @@ It will take a short time to import the projects, as Maven needs to download the
 
 
 Managing JBoss WildFly
---------------------------------------------------------------
+----------------------
 
 Here we will quickly outline how you can access both the command line interface and the web management interface for managing JBoss WildFly. Detailed information for both can be found in the link:http://docs.redhat.com/docs/en-US/JBoss_Enterprise_Application_Platform/6/html/Administration_and_Configuration_Guide/index.html[Administration and Configuration Guide for JBoss Enterprise Application Platform 6] or the link:https://docs.jboss.org/author/display/AS71/Admin+Guide[Admin Guide for JBoss WildFly].
 


### PR DESCRIPTION
The underlines of the headings were too long; they were causing whole sections to be parsed as quote blocks, hiding images and making it difficult to read.