### PR TITLE
WFLY-5247 - unify wf ejb-multi-server quickstart with eap7 quickstart

### DIFF
--- a/ejb-multi-server/app-one/ejb/src/main/resources/META-INF/jboss-ejb3.xml
+++ b/ejb-multi-server/app-one/ejb/src/main/resources/META-INF/jboss-ejb3.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:s="urn:security" xmlns:c="urn:clustering:1.0"
+    xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
+                     http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+    version="3.1" impl-version="2.0">
+    <enterprise-beans>
+    </enterprise-beans>
+    <assembly-descriptor>
+      <!-- mark all EJB's of the application as clustered (without using the jboss specific @Clustered annotation for each class) -->
+        <c:clustering>
+            <ejb-name>*</ejb-name>
+            <c:clustered>true</c:clustered>
+        </c:clustering>
+    </assembly-descriptor>
+</jboss:ejb-jar>


### PR DESCRIPTION
This patch unifies the ejb-multi-server quickstart's descriptor with that of the eap7.  

I am not entirely sure this patch is needed, or whether it is better to have no jboss-ejb3.xml file, or whether the one in EAP is a good choice. But I trust that the EAP quickstarts have done a good job and this file seems to be a better addition to help guide the users. 