### PR TITLE
Cleanup typos and maven inconsistencies

### DIFF
--- a/batch-processing/README.md
+++ b/batch-processing/README.md
@@ -60,7 +60,7 @@ Build and Deploy the Quickstart
 Access the application
 ---------------------
 
-Access the running application in a browser at the following URL:  <http://localhost:8080/jboss-batch-processing/>
+Access the running application in a browser at the following URL:  <http://localhost:8080/wildfly-batch-processing/>
 
 You're presented with a simple form that allows you to generate sample files to be imported. 
 

--- a/bmt/README.md
+++ b/bmt/README.md
@@ -66,7 +66,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-bmt/>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-bmt/>.
 
 You will be presented with a simple form for adding key/value pairs and a checkbox to indicate whether the updates should be executed using an unmanaged component. Effectively this will run the transaction and JPA updates in the servlet, not session beans. If the box is checked then the updates will be executed within a session bean method.
 

--- a/cdi-alternative/README.md
+++ b/cdi-alternative/README.md
@@ -61,7 +61,7 @@ Build and Deploy the Quickstart
 Access the application
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-cdi-alternative>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-cdi-alternative>.
 
 You can specify alternative versions of the bean in the WEB-INF/beans.xml file by doing one of the following:
 

--- a/cdi-decorator/README.md
+++ b/cdi-decorator/README.md
@@ -57,7 +57,7 @@ Build and Deploy the Quickstart
 Access the application
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-cdi-decorator>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-cdi-decorator>.
 
 You can specify decorator of the bean in the WEB-INF/beans.xml file by doing one of the following:
 

--- a/cdi-injection/README.md
+++ b/cdi-injection/README.md
@@ -52,7 +52,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL <http://localhost:8080/jboss-cdi-injection/>.
+The application will be running at the following URL <http://localhost:8080/wildfly-cdi-injection/>.
 
 
 Undeploy the Archive

--- a/cdi-interceptors/README.md
+++ b/cdi-interceptors/README.md
@@ -60,7 +60,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-cdi-interceptors>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-cdi-interceptors>.
 
 You can now comment out classes in the WEB-INF/beans.xml file to disable one or both of the interceptors and view the results.
 

--- a/cdi-stereotype/README.md
+++ b/cdi-stereotype/README.md
@@ -66,7 +66,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL <http://localhost:8080/jboss-cdi-stereotype>
+The application will be running at the following URL <http://localhost:8080/wildfly-cdi-stereotype>
 
 You can now comment out classes in the WEB-INF/beans.xml file to disable one or both of the interceptors or alternative stereotype and view the results.
 

--- a/cmt/README.md
+++ b/cmt/README.md
@@ -82,7 +82,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-cmt/>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-cmt/>.
 
 You will be presented with a simple form for adding customers to a database.
 

--- a/contacts-jquerymobile/README.md
+++ b/contacts-jquerymobile/README.md
@@ -93,7 +93,7 @@ Build and Deploy the Quickstart
 Access the application
 ----------------------
 
-Access the running client application in a browser at the following URL: <http://localhost:8080/jboss-contacts-jquerymobile/>.
+Access the running client application in a browser at the following URL: <http://localhost:8080/wildfly-contacts-jquerymobile/>.
 
 The app is made up of the following pages:
 

--- a/contacts-jquerymobile/functional-tests/pom.xml
+++ b/contacts-jquerymobile/functional-tests/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.as.quickstarts.eap</groupId>
+    <groupId>org.jboss.as.quickstarts</groupId>
     <artifactId>jboss-contacts-jquerymobile-test-webdriver</artifactId>
     <version>7.0.0-SNAPSHOT</version>
     <name>WildFly Quickstarts: Contacts test via WebDriver with Arquillian</name>

--- a/ejb-in-ear/README.md
+++ b/ejb-in-ear/README.md
@@ -70,7 +70,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL <http://localhost:8080/jboss-ejb-in-ear>.
+The application will be running at the following URL <http://localhost:8080/wildfly-ejb-in-ear>.
 
 Enter a name in the input field and click the _Greet_ button to see the response.
 

--- a/ejb-in-war/README.md
+++ b/ejb-in-war/README.md
@@ -59,7 +59,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL <http://localhost:8080/jboss-ejb-in-war>.
+The application will be running at the following URL <http://localhost:8080/wildfly-ejb-in-war>.
 
 
 Undeploy the Archive

--- a/ejb-multi-server/README.md
+++ b/ejb-multi-server/README.md
@@ -273,7 +273,7 @@ Access the JSF application inside the main-application
 The JSF example shows different annotations to inject the EJB. Also how to handle the annotation if different beans implement the same interface and therefore the container is not able to decide which bean needs to be injected without additional informations.
 
 1. Make sure that the deployments are successful as described above.
-2. Use a browser to access the JSF application at the following URL: <http://localhost:8080/jboss-ejb-multi-server-app-main-web/>
+2. Use a browser to access the JSF application at the following URL: <http://localhost:8080/wildfly-ejb-multi-server-app-main-web/>
 3. Insert a message in the Text input and invoke the different methods. The result is shown in the browser.
 4. See server logfiles and find your given message logged as INFO.
 

--- a/ejb-security/README.md
+++ b/ejb-security/README.md
@@ -100,7 +100,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL <http://localhost:8080/jboss-ejb-security/>.
+The application will be running at the following URL <http://localhost:8080/wildfly-ejb-security/>.
 
 When you access the application, you are presented with a browser login challenge. 
 

--- a/ejb-throws-exception/README.md
+++ b/ejb-throws-exception/README.md
@@ -72,7 +72,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL <http://localhost:8080/jboss-ejb-throws-exception-web/>.
+The application will be running at the following URL <http://localhost:8080/wildfly-ejb-throws-exception-web/>.
 
 Enter a name in the input field `Name` and click the `Say Hello` button to see the response.
 

--- a/greeter/README.md
+++ b/greeter/README.md
@@ -67,7 +67,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-greeter>. 
+The application will be running at the following URL: <http://localhost:8080/wildfly-greeter>. 
 
 
 Undeploy the Archive

--- a/h2-console/README.md
+++ b/h2-console/README.md
@@ -31,7 +31,7 @@ Prerequisites
 
 This quickstart depends on the deployment of the `greeter` quickstart. Before running this quickstart, see the [greeter README](../greeter/README.md) file for details on how to deploy it.
 
-You can verify the deployment of the `greeter` quickstart by accessing the following URL: <http://localhost:8080/jboss-greeter> 
+You can verify the deployment of the `greeter` quickstart by accessing the following URL: <http://localhost:8080/wildfly-greeter> 
 
 When you have completed testing this quickstart, see the [greeter README](../greeter/README.md) file for instructions to undeploy the archive.
 

--- a/helloworld-html5/README.md
+++ b/helloworld-html5/README.md
@@ -59,12 +59,12 @@ _NOTE: The following build command assumes you have configured your Maven user s
 Access the application 
 ---------------------
 
-The application will be running at the following URL <http://localhost:8080/jboss-helloworld-html5/>.
+The application will be running at the following URL <http://localhost:8080/wildfly-helloworld-html5/>.
 
 You can also test the REST endpoint as follows. Feel free to replace `YOUR_NAME` with a name of your choosing.
 
-* The *XML* content can be tested by accessing the following URL: <http://localhost:8080/jboss-helloworld-html5/hello/xml/YOUR_NAME> 
-* The *JSON* content can be tested by accessing this URL: <http://localhost:8080/jboss-helloworld-html5/hello/json/YOUR_NAME>
+* The *XML* content can be tested by accessing the following URL: <http://localhost:8080/wildfly-helloworld-html5/hello/xml/YOUR_NAME> 
+* The *JSON* content can be tested by accessing this URL: <http://localhost:8080/wildfly-helloworld-html5/hello/json/YOUR_NAME>
 
 
 Undeploy the Archive

--- a/helloworld-html5/functional-tests/pom.xml
+++ b/helloworld-html5/functional-tests/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.quickstarts.eap</groupId>
+    <groupId>org.wildfly.quickstarts</groupId>
     <artifactId>jboss-helloworld-html5-test-webdriver</artifactId>
     <version>7.0.0-SNAPSHOT</version>
     <name>WildFly Quickstart: Hello World test via WebDriver with Arquillian</name>

--- a/helloworld-mbean/README.md
+++ b/helloworld-mbean/README.md
@@ -61,7 +61,7 @@ Build and Deploy the Quickstart
 Access and Test the MBeans
 --------------------------
 
-This quickstart differs from the other quickstarts in that it uses 'JConsole' to access and test the quickstart rather than access an URL in the browser. If you do access <http://localhost:8080/jboss-helloworld-mbean-helloworld-mbean-webapp/>, you will see a screen shot image of the JConsole application,
+This quickstart differs from the other quickstarts in that it uses 'JConsole' to access and test the quickstart rather than access an URL in the browser. If you do access <http://localhost:8080/wildfly-helloworld-mbean-helloworld-mbean-webapp/>, you will see a screen shot image of the JConsole application,
 
 The following sections describe how to use 'JConsole' to inspect and test the MBeans. 
 

--- a/helloworld-mbean/helloworld-mbean-service/pom.xml
+++ b/helloworld-mbean/helloworld-mbean-service/pom.xml
@@ -19,11 +19,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss.quickstarts.eap</groupId>
-        <artifactId>jboss-helloworld-mbean</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <groupId>org.wildfly.quickstarts</groupId>
+        <artifactId>wildfly-helloworld-mbean</artifactId>
+        <version>10.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>jboss-helloworld-mbean-helloworld-mbean-service</artifactId>
+    <artifactId>wildfly-helloworld-mbean-helloworld-mbean-service</artifactId>
     <packaging>jboss-sar</packaging>
     <name>WildFly Quickstart: helloworld-mbean - helloworld-mbean-service</name>
     <url>http://www.wildfly.org</url>

--- a/helloworld-mbean/helloworld-mbean-webapp/pom.xml
+++ b/helloworld-mbean/helloworld-mbean-webapp/pom.xml
@@ -19,11 +19,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss.quickstarts.eap</groupId>
-        <artifactId>jboss-helloworld-mbean</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <groupId>org.wildfly.quickstarts</groupId>
+        <artifactId>wildfly-helloworld-mbean</artifactId>
+        <version>10.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>jboss-helloworld-mbean-helloworld-mbean-webapp</artifactId>
+    <artifactId>wildfly-helloworld-mbean-helloworld-mbean-webapp</artifactId>
     <packaging>war</packaging>
     <name>WildFly Quickstart: helloworld-mbean - helloworld-mbean-webapp</name>
     <url>http://www.wildfly.org</url>

--- a/helloworld-mdb-propertysubstitution/README.md
+++ b/helloworld-mdb-propertysubstitution/README.md
@@ -120,9 +120,9 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-helloworld-mdb-propertysubstitution/> and will send some messages to the queue.
+The application will be running at the following URL: <http://localhost:8080/wildfly-helloworld-mdb-propertysubstitution/> and will send some messages to the queue.
 
-To send messages to the topic, use the following URL: <http://localhost:8080/jboss-helloworld-mdb-propertysubstitution/HelloWorldMDBServletClient?topic>
+To send messages to the topic, use the following URL: <http://localhost:8080/wildfly-helloworld-mdb-propertysubstitution/HelloWorldMDBServletClient?topic>
 
 Investigate the Server Console Output
 -------------------------

--- a/helloworld-rs/README.md
+++ b/helloworld-rs/README.md
@@ -52,11 +52,11 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application is deployed to <http://localhost:8080/jboss-helloworld-rs>.
+The application is deployed to <http://localhost:8080/wildfly-helloworld-rs>.
 
-The *XML* content can be viewed by accessing the following URL: <http://localhost:8080/jboss-helloworld-rs/rest/xml> 
+The *XML* content can be viewed by accessing the following URL: <http://localhost:8080/wildfly-helloworld-rs/rest/xml> 
 
-The *JSON* content can be viewed by accessing this URL: <http://localhost:8080/jboss-helloworld-rs/rest/json>
+The *JSON* content can be viewed by accessing this URL: <http://localhost:8080/wildfly-helloworld-rs/rest/json>
 
 
 Undeploy the Archive

--- a/helloworld-singleton/README.md
+++ b/helloworld-singleton/README.md
@@ -51,7 +51,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-helloworld-singleton>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-helloworld-singleton>.
 
 This example demonstrates a singleton session bean that maintains state information for 2 variables: "Increment A" and "Increment B". 
 

--- a/helloworld-ws/README.md
+++ b/helloworld-ws/README.md
@@ -49,7 +49,7 @@ Build and Deploy the Quickstart
 5. Review the server log to see useful information about the deployed web service endpoint.
 
         JBWS024061: Adding service endpoint metadata: id=org.jboss.as.quickstarts.wshelloworld.HelloWorldServiceImpl
-         address=http://localhost:8080/jboss-helloworld-ws/HelloWorldService
+         address=http://localhost:8080/wildfly-helloworld-ws/HelloWorldService
          implementor=org.jboss.as.quickstarts.wshelloworld.HelloWorldServiceImpl
          serviceName={http://www.jboss.org/eap/quickstarts/wshelloworld/HelloWorld}HelloWorldService
          portName={http://www.jboss.org/eap/quickstarts/wshelloworld/HelloWorld}HelloWorld
@@ -61,7 +61,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-You can verify that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jboss-helloworld-ws/HelloWorldService?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
+You can verify that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/wildfly-helloworld-ws/HelloWorldService?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
 
 
 Undeploy the Archive

--- a/helloworld/README.md
+++ b/helloworld/README.md
@@ -52,7 +52,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-helloworld>. 
+The application will be running at the following URL: <http://localhost:8080/wildfly-helloworld>. 
 
 
 Undeploy the Archive

--- a/hibernate5/README.md
+++ b/hibernate5/README.md
@@ -82,7 +82,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-hibernate5/>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-hibernate5/>.
 
 
 Server Log: Expected warnings and errors

--- a/hornetq-clustering/README.md
+++ b/hornetq-clustering/README.md
@@ -168,11 +168,11 @@ To send messages to the topic, use the following URL: <http://localhost:9080/jbo
 
 ### Access the Application Running in Standalone Mode
 
-The application will be running at the following URL: <http://localhost:8080/jboss-helloworld-mdb/HelloWorldMDBServletClient>. 
+The application will be running at the following URL: <http://localhost:8080/wildfly-helloworld-mdb/HelloWorldMDBServletClient>. 
 
 It will send some messages to the queue. 
 
-To send messages to the topic, use the following URL: <http://localhost:8080/jboss-helloworld-mdb/HelloWorldMDBServletClient?topic>
+To send messages to the topic, use the following URL: <http://localhost:8080/wildfly-helloworld-mdb/HelloWorldMDBServletClient?topic>
 
 
 Investigate the Server Console Output

--- a/inter-app/README.md
+++ b/inter-app/README.md
@@ -61,8 +61,8 @@ Access the application
 
 Access the running application in a browser at the following URLs:
 
-* <http://localhost:8080/jboss-inter-app-appA>
-* <http://localhost:8080/jboss-inter-app-appB>
+* <http://localhost:8080/wildfly-inter-app-appA>
+* <http://localhost:8080/wildfly-inter-app-appB>
 
 You are presented with a form that allows you to set the value on the bean in the other application, as well as display of the value on this application's bean. Enter a new value and press "Update and Send!" to update the value on the other application. Do the same on the other application, and hit the button again on the first application. You should see the values shared between the applications.
 

--- a/jaxws-addressing/README.md
+++ b/jaxws-addressing/README.md
@@ -46,7 +46,7 @@ _NOTE: The following build command assumes you have configured your Maven user s
 Access the application 
 ---------------------
 
-You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jboss-jaxws-addressing/AddressingService?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
+You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/wildfly-jaxws-addressing/AddressingService?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
 
 Run the Client
 --------------

--- a/jaxws-addressing/client/pom.xml
+++ b/jaxws-addressing/client/pom.xml
@@ -19,11 +19,11 @@
    <modelVersion>4.0.0</modelVersion>
 
     <parent>
-      <groupId>org.jboss.quickstarts.eap</groupId>
-      <artifactId>jboss-jaxws-addressing</artifactId>
-      <version>7.0.0-SNAPSHOT</version>
+      <groupId>org.wildfly.quickstarts</groupId>
+    <artifactId>wildfly-jaxws-addressing</artifactId>
+    <version>10.0.0-SNAPSHOT</version>
    </parent>
-    <artifactId>jboss-jaxws-addressing-client</artifactId>
+    <artifactId>wildfly-jaxws-addressing-client</artifactId>
     <packaging>jar</packaging>
     <name>WildFly Quickstart: jaxws-addressing - client</name>
     <url>http://www.wildfly.org</url>
@@ -43,8 +43,8 @@
     <dependencies>
 
       <dependency>
-         <groupId>org.jboss.quickstarts.eap</groupId>
-         <artifactId>jboss-jaxws-addressing-service</artifactId>
+         <groupId>org.wildfly.quickstarts</groupId>
+         <artifactId>wildfly-jaxws-addressing-service</artifactId>
          <version>${project.version}</version>
          <classifier>classes</classifier>
       </dependency>

--- a/jaxws-addressing/service/pom.xml
+++ b/jaxws-addressing/service/pom.xml
@@ -19,11 +19,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-      <groupId>org.jboss.quickstarts.eap</groupId>
-      <artifactId>jboss-jaxws-addressing</artifactId>
-      <version>7.0.0-SNAPSHOT</version>
+      <groupId>org.wildfly.quickstarts</groupId>
+    <artifactId>wildfly-jaxws-addressing</artifactId>
+    <version>10.0.0-SNAPSHOT</version>
    </parent>
-    <artifactId>jboss-jaxws-addressing-service</artifactId>
+    <artifactId>wildfly-jaxws-addressing-service</artifactId>
     <packaging>war</packaging>
     <name>WildFly Quickstart: jaxws-addressing - service</name>
     <url>http://www.wildfly.org</url>

--- a/jaxws-ejb/README.md
+++ b/jaxws-ejb/README.md
@@ -46,7 +46,7 @@ _NOTE: The following build command assumes you have configured your Maven user s
 Access the application 
 ---------------------
 
-You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jboss-jaxws-ejb-endpoint/EJB3Bean01?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
+You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/wildfly-jaxws-ejb-endpoint/EJB3Bean01?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
 
 Run the Client
 --------------

--- a/jaxws-ejb/client/pom.xml
+++ b/jaxws-ejb/client/pom.xml
@@ -19,11 +19,11 @@
    <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss.quickstarts.eap</groupId>
-        <artifactId>jboss-jaxws-ejb</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+       <groupId>org.wildfly.quickstarts</groupId>
+    <artifactId>wildfly-jaxws-ejb</artifactId>
+    <version>10.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>jboss-jaxws-ejb-client</artifactId>
+    <artifactId>wildfly-jaxws-ejb-client</artifactId>
     <packaging>jar</packaging>
     <name>WildFly Quickstart: jaxws-ejb - client</name>
     <url>http://www.wildfly.org</url>
@@ -52,8 +52,8 @@
     <dependencies>
 
       <dependency>
-          <groupId>org.jboss.quickstarts.eap</groupId>
-          <artifactId>jboss-jaxws-ejb-service</artifactId>
+          <groupId>org.wildfly.quickstarts</groupId>
+          <artifactId>wildfly-jaxws-ejb-service</artifactId>
           <version>${project.version}</version>
          <classifier>classes</classifier>
       </dependency>

--- a/jaxws-ejb/service/pom.xml
+++ b/jaxws-ejb/service/pom.xml
@@ -19,11 +19,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss.quickstarts.eap</groupId>
-        <artifactId>jboss-jaxws-ejb</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <groupId>org.wildfly.quickstarts</groupId>
+    <artifactId>wildfly-jaxws-ejb</artifactId>
+    <version>10.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>jboss-jaxws-ejb-service</artifactId>
+    <artifactId>wildfly-jaxws-ejb-service</artifactId>
     <packaging>war</packaging>
     <name>WildFly Quickstart: jaxws-ejb - service</name>
     <url>http://www.wildfly.org</url>
@@ -37,16 +37,6 @@
     </licenses>
 
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.ejb3</groupId>
-            <artifactId>jboss-ejb3-ext-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.istack</groupId>
-            <artifactId>istack-commons-runtime</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
             <artifactId>jboss-ejb-api_3.2_spec</artifactId>

--- a/jaxws-pojo/README.md
+++ b/jaxws-pojo/README.md
@@ -46,7 +46,7 @@ _NOTE: The following build command assumes you have configured your Maven user s
 Access the application 
 ---------------------
 
-You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jboss-jaxws-pojo-endpoint/JSEBean01?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
+You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/wildfly-jaxws-pojo-endpoint/JSEBean01?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
 
 Run the Client
 --------------

--- a/jaxws-pojo/client/pom.xml
+++ b/jaxws-pojo/client/pom.xml
@@ -19,11 +19,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss.quickstarts.eap</groupId>
-        <artifactId>jboss-jaxws-pojo</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <groupId>org.wildfly.quickstarts</groupId>
+    <artifactId>wildfly-jaxws-pojo</artifactId>
+    <version>10.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>jboss-jaxws-pojo-client</artifactId>
+    <artifactId>wildfly-jaxws-pojo-client</artifactId>
     <packaging>jar</packaging>
     <name>WildFly Quickstart: jaxws-pojo - client</name>
     <url>http://www.wildfly.org</url>
@@ -38,8 +38,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.quickstarts.eap</groupId>
-            <artifactId>jboss-jaxws-pojo-service</artifactId>
+            <groupId>org.wildfly.quickstarts</groupId>
+            <artifactId>wildfly-jaxws-pojo-service</artifactId>
             <version>${project.version}</version>
             <classifier>classes</classifier>
         </dependency>

--- a/jaxws-pojo/service/pom.xml
+++ b/jaxws-pojo/service/pom.xml
@@ -19,11 +19,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.jboss.quickstarts.eap</groupId>
-        <artifactId>jboss-jaxws-pojo</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <groupId>org.wildfly.quickstarts</groupId>
+    <artifactId>wildfly-jaxws-pojo</artifactId>
+    <version>10.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>jboss-jaxws-pojo-service</artifactId>
+    <artifactId>wildfly-jaxws-pojo-service</artifactId>
     <packaging>war</packaging>
     <name>WildFly Quickstart: jaxws-pojo - service</name>
     <url>http://www.wildfly.org</url>

--- a/jaxws-retail/README.md
+++ b/jaxws-retail/README.md
@@ -49,7 +49,7 @@ _NOTE: The following build command assumes you have configured your Maven user s
 Access the application 
 ---------------------
 
-You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jboss-jaxws-retail/ProfileMgmtService/ProfileMgmt?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
+You can check that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/wildfly-jaxws-retail/ProfileMgmtService/ProfileMgmt?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
 
 Run the Client
 --------------

--- a/jaxws-retail/client/pom.xml
+++ b/jaxws-retail/client/pom.xml
@@ -19,11 +19,11 @@
    <modelVersion>4.0.0</modelVersion>
 
     <parent>
-      <groupId>org.jboss.quickstarts.eap</groupId>
-      <artifactId>jboss-jaxws-retail</artifactId>
-      <version>7.0.0-SNAPSHOT</version>
+      <groupId>org.wildfly.quickstarts</groupId>
+      <artifactId>wildfly-jaxws-retail</artifactId>
+      <version>10.0.0-SNAPSHOT</version>
    </parent>
-    <artifactId>jboss-jaxws-retail-client</artifactId>
+    <artifactId>wildfly-jaxws-retail-client</artifactId>
     <packaging>jar</packaging>
     <name>WildFly Quickstart: jaxws-retail - client</name>
     <url>http://www.wildfly.org</url>
@@ -42,8 +42,8 @@
 
     <dependencies>
       <dependency>
-         <groupId>org.jboss.quickstarts.eap</groupId>
-         <artifactId>jboss-jaxws-retail-service</artifactId>
+         <groupId>org.wildfly.quickstarts</groupId>
+         <artifactId>wildfly-jaxws-retail-service</artifactId>
          <version>${project.version}</version>
          <classifier>classes</classifier>
       </dependency>

--- a/jaxws-retail/service/pom.xml
+++ b/jaxws-retail/service/pom.xml
@@ -19,14 +19,14 @@
    <modelVersion>4.0.0</modelVersion>
 
     <parent>
-      <groupId>org.jboss.quickstarts.eap</groupId>
-      <artifactId>jboss-jaxws-retail</artifactId>
-      <version>7.0.0-SNAPSHOT</version>
+      <groupId>org.wildfly.quickstarts</groupId>
+      <artifactId>wildfly-jaxws-retail</artifactId>
+      <version>10.0.0-SNAPSHOT</version>
      <!-- -->
       <relativePath>../pom.xml</relativePath>
 
    </parent>
-    <artifactId>jboss-jaxws-retail-service</artifactId>
+    <artifactId>wildfly-jaxws-retail-service</artifactId>
     <packaging>war</packaging>
     <name>WildFly Quickstart: jaxws-retail - service</name>
     <url>http://www.wildfly.org</url>

--- a/jsonp/README.md
+++ b/jsonp/README.md
@@ -48,7 +48,7 @@ Build and Deploy the Quickstart
 Access the application
 ---------------------
 
-Access the running application in a browser at the following URL:  <http://localhost:8080/jboss-jsonp/>
+Access the running application in a browser at the following URL:  <http://localhost:8080/wildfly-jsonp/>
 
 You're presented with a simple form that is pre-filled with personal data. You can change those values if you prefer. 
 

--- a/jta-crash-rec/README.md
+++ b/jta-crash-rec/README.md
@@ -85,7 +85,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-jta-crash-rec/XA>. 
+The application will be running at the following URL: <http://localhost:8080/wildfly-jta-crash-rec/XA>. 
 
 
 Test the application
@@ -113,7 +113,7 @@ Test the application
              JAVA_OPTS=%JAVA_OPTS% -javaagent:C:BYTEMAN_HOME\lib\byteman.jar=script:C:\QUICKSTART_HOME\jta-crash-rec\src\main\scripts\xa.btm %JAVA_OPTS%
     * [Start the WildFly server](#start-the-jboss-eap-server) as instructed above.
     
-5. Once you complete step 4, you are ready to create a _recovery record_. Go to the application URL <http://localhost:8080/jboss-jta-crash-rec/XA> and insert another row into the database. At this point, Byteman halts the application server. 
+5. Once you complete step 4, you are ready to create a _recovery record_. Go to the application URL <http://localhost:8080/wildfly-jta-crash-rec/XA> and insert another row into the database. At this point, Byteman halts the application server. 
 
 6. If you want to verify the database insert was committed but that message delivery is still pending, you can use an SQL client such as the H2 database console tool. Issue a query to show that the value is present but does not contain the message added by the consumer (*" updated via JMS"*). Here is how you can do it using H2:
     * Start the H2 console by typing:

--- a/jts-distributed-crash-rec/README.md
+++ b/jts-distributed-crash-rec/README.md
@@ -55,7 +55,7 @@ Developers should be familiar with the concepts introduced in the following quic
 
 IMPORTANT: This quickstart depends on the deployment of the `jts` quickstart for its test. Before running this quickstart, see the [jts README](../jts/README.md) file for details on how to deploy it.
 
-You can verify the deployment of the `jts` quickstart by accessing the following URL:  <http://localhost:8080/jboss-jts-application-component-1/>.
+You can verify the deployment of the `jts` quickstart by accessing the following URL:  <http://localhost:8080/wildfly-jts-application-component-1/>.
 
 
 Use of WILDFLY_HOME
@@ -103,7 +103,7 @@ _Note:_ This quickstart README file use the following replaceable values. When y
         Server 1: WILDFLY_HOME_1\bin\standalone.bat -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID_1
         Server 2: WILDFLY_HOME_2\bin\standalone.bat -c standalone-full.xml -Djboss.tx.node.id=UNIQUE_NODE_ID_2 -Djboss.socket.binding.port-offset=100 
 
-4. Access the application at the following URL: <http://localhost:8080/jboss-jts-application-component-1/>
+4. Access the application at the following URL: <http://localhost:8080/wildfly-jts-application-component-1/>
     * When you enter a name and click to "add" that customer, you will see the following in the application server 1 console:
 
             09:58:40,443 INFO  [org.jboss.ejb.client] (RequestProcessor-10) JBoss EJB Client version 1.0.26.Final-redhat-1
@@ -276,6 +276,6 @@ _Note:_ This quickstart README file use the following replaceable values. When y
                                 `-- ArjunaTransactionImple
                                     `-- ServerTransaction
 
-7. After recovery is complete, access the application URL <http://localhost:8080/jboss-jts-application-component-1/customers.jsf>. The user you created should now appear in the list.
+7. After recovery is complete, access the application URL <http://localhost:8080/wildfly-jts-application-component-1/customers.jsf>. The user you created should now appear in the list.
 
 8. Do NOT forget to [Disable the Byteman script](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONFIGURE_BYTEMAN.md#disable-the-byteman-script) by restoring the backup server configuration file. The Byteman rule must be removed to ensure that your application server will be able to commit 2PC transactions!

--- a/jts/README.md
+++ b/jts/README.md
@@ -189,7 +189,7 @@ Since this quickstart builds two separate components, you can not use the standa
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-jts-application-component-1/>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-jts-application-component-1/>.
 
 When you enter a name and click to "Add" that customer, you will see the following in the application server 1 console:
     

--- a/kitchensink-ear/README.md
+++ b/kitchensink-ear/README.md
@@ -58,7 +58,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-kitchensink-ear-web>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-kitchensink-ear-web>.
 
 1. Enter a name, email address, and Phone nubmer in the input field and click the _Register_ button.
 2. If the data entered is valid, the new member will be registered and added to the _Members_ display list.

--- a/kitchensink-ear/ear/pom.xml
+++ b/kitchensink-ear/ear/pom.xml
@@ -71,7 +71,7 @@
                         register our War as a web module and set the contextRoot property -->
                     <!--
                     <webModule>
-                        <groupId>org.jboss.quickstarts.eap</groupId>
+                        <groupId>org.wildfly.quickstarts</groupId>
                         <artifactId>jboss-kitchensink-ear-web</artifactId>
                         <contextRoot>/jboss-kitchensink-ear</contextRoot>
                     </webModule>

--- a/kitchensink-html5-mobile/README.md
+++ b/kitchensink-html5-mobile/README.md
@@ -62,7 +62,7 @@ Build and Deploy the Quickstart
 Access the application
 ----------------------
 
-Access the running client application in a browser at the following URL: <http://localhost:8080/jboss-kitchensink-html5-mobile/>.
+Access the running client application in a browser at the following URL: <http://localhost:8080/wildfly-kitchensink-html5-mobile/>.
 
 
 Undeploy the Archive

--- a/kitchensink-jsp/README.md
+++ b/kitchensink-jsp/README.md
@@ -57,7 +57,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-kitchensink-jsp/>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-kitchensink-jsp/>.
 
 
 Server Log: Expected warnings and errors

--- a/kitchensink-ml-ear/README.md
+++ b/kitchensink-ml-ear/README.md
@@ -134,7 +134,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-kitchensink-ml-ear-web>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-kitchensink-ml-ear-web>.
 
 1. Enter a name, email address, and Phone nubmer in the input field and click the _Register_ button.
 2. If the data entered is valid, the new member will be registered and added to the _Members_ display list.

--- a/kitchensink-ml-ear/ear/pom.xml
+++ b/kitchensink-ml-ear/ear/pom.xml
@@ -71,7 +71,7 @@
                         register our War as a web module and set the contextRoot property -->
                         <!--
                         <webModule>
-                            <groupId>org.jboss.quickstarts.eap</groupId>
+                            <groupId>org.wildfly.quickstarts</groupId>
                             <artifactId>jboss-kitchensink-ml-ear-web</artifactId>
                             <contextRoot>/jboss-kitchensink-ml-ear</contextRoot>
                         </webModule>

--- a/kitchensink-ml/README.md
+++ b/kitchensink-ml/README.md
@@ -135,7 +135,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-kitchensink-ml/>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-kitchensink-ml/>.
 
 Change your browser preferred language to French or Spanish and refresh the page to see it displayed in the new language. 
 

--- a/kitchensink/README.md
+++ b/kitchensink/README.md
@@ -57,7 +57,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-kitchensink/>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-kitchensink/>.
 
 
 Server Log: Expected warnings and errors

--- a/logging-tools/README.md
+++ b/logging-tools/README.md
@@ -74,18 +74,18 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-logging-tools/>
+The application will be running at the following URL: <http://localhost:8080/wildfly-logging-tools/>
 
 This landing page provides details and links to test the quickstart features. You can also directly access the following URLs.
 
-1.  `http://localhost:8080/jboss-logging-tools/rest/greetings/'name'` 
-    * Example:  <http://localhost:8080/jboss-logging-tools/rest/greetings/Harold>
+1.  `http://localhost:8080/wildfly-logging-tools/rest/greetings/'name'` 
+    * Example:  <http://localhost:8080/wildfly-logging-tools/rest/greetings/Harold>
     * Demonstrates simple use of localized messages (with parameter) and logging.
     * It returns the localized "hello `name`" string where `name` is the last component of the URL.
     * It also logs the localized "Hello message sent" in the server log.
 
-2. `http://localhost:8080/jboss-logging-tools/rest/greetings/'locale'/'name'`
-    * Example: <http://localhost:8080/jboss-logging-tools/rest/greetings/fr-FR/Harold>
+2. `http://localhost:8080/wildfly-logging-tools/rest/greetings/'locale'/'name'`
+    * Example: <http://localhost:8080/wildfly-logging-tools/rest/greetings/fr-FR/Harold>
     * Demonstrates how to obtain a message bundle for a specified locale and how to throw a localized exceptions. Note that the localized exception is a wrapper around `WebApplicationException`.
     * Returns a localized "hello `name`" string where `name` is the last component of the URL and the locale used is the one supplied in the `locale` URL.
     * Logs a localized "Hello message sent in `locale`" message using the JVM locale for the translation.
@@ -93,16 +93,16 @@ This landing page provides details and links to test the quickstart features. Yo
    
       Note that `WebApplicationException` cannot be directly localized by JBoss Logging Tools using the `@Message` annotation due to the message parameter being ignored by the `WebApplicationException` constructors. Cases like this can be worked around by creating a subclass with a constructor that does deal with the message parameter.
    
-3. <http://localhost:8080/jboss-logging-tools/rest/greetings/crashme>
+3. <http://localhost:8080/wildfly-logging-tools/rest/greetings/crashme>
     * Demonstrates how to throw a localized exception with another exception specified as the cause.  This is a completely contrived example.
     * Attempts to divide by zero, catches the exception, and throws the localized one.
    
-4. `http://localhost:8080/jboss-logging-tools/rest/dates/daysuntil/'targetdate'`
-    * Example: <http://localhost:8080/jboss-logging-tools/rest/dates/daysuntil/2020-12-25>
+4. `http://localhost:8080/wildfly-logging-tools/rest/dates/daysuntil/'targetdate'`
+    * Example: <http://localhost:8080/wildfly-logging-tools/rest/dates/daysuntil/2020-12-25>
     * Demonstrates how to pass parameters through to the constructor of a localized exception, and how to specify an exception as a cause of a log message. 
     * Attempts to turn the `targetdate` URL component into a date object using the format `dd-MM-yyyy`
     * Returns number of days (as an integer) until that date
-    * If the `targetdate` is invalid, for example, <http://localhost:8080/jboss-logging-tools/rest/dates/daysuntil/2015-02-31>:
+    * If the `targetdate` is invalid, for example, <http://localhost:8080/wildfly-logging-tools/rest/dates/daysuntil/2015-02-31>:
         * Catches the `ParseException`
         * Creates a localized `ParseException` passing values from the caught exception as parameters to its constructor
         * Logs a localized message with the localized exception as the cause

--- a/logging/README.md
+++ b/logging/README.md
@@ -57,7 +57,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application is running at the following URL: <http://localhost:8080/jboss-logging/>.
+The application is running at the following URL: <http://localhost:8080/wildfly-logging/>.
 
 You will see the following message in the server console:
 

--- a/mail/README.md
+++ b/mail/README.md
@@ -118,7 +118,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-mail>. 
+The application will be running at the following URL: <http://localhost:8080/wildfly-mail>. 
 
 
 Undeploy the Archive

--- a/numberguess/README.md
+++ b/numberguess/README.md
@@ -52,7 +52,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-numberguess>. 
+The application will be running at the following URL: <http://localhost:8080/wildfly-numberguess>. 
 
 
 Undeploy the Archive

--- a/payment-cdi-event/README.md
+++ b/payment-cdi-event/README.md
@@ -77,7 +77,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-payment-cdi-event/>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-payment-cdi-event/>.
 
 
 Undeploy the Archive

--- a/resteasy-jaxrs-client/README.md
+++ b/resteasy-jaxrs-client/README.md
@@ -32,8 +32,8 @@ IMPORTANT: This quickstart depends on the deployment of the 'helloworld-rs' quic
 
 You can verify the deployment of the [helloworld-rs](../helloworld-rs/README.md) quickstart by accessing the following content:
 
-* The *XML* content can be viewed by accessing the following URL: <http://localhost:8080/jboss-helloworld-rs/rest/xml> 
-* The *JSON* content can be viewed by accessing this URL: <http://localhost:8080/jboss-helloworld-rs/rest/json>
+* The *XML* content can be viewed by accessing the following URL: <http://localhost:8080/wildfly-helloworld-rs/rest/xml> 
+* The *JSON* content can be viewed by accessing this URL: <http://localhost:8080/wildfly-helloworld-rs/rest/json>
 
 
 
@@ -57,7 +57,7 @@ This command will compile the example and execute a test to make two separate re
 should see the following if the execution is successful:
 
         ===============================================
-        URL: http://localhost:8080/jboss-helloworld-rs/rest/xml
+        URL: http://localhost:8080/wildfly-helloworld-rs/rest/xml
         MediaType: application/xml
 
         *** Response from Server ***
@@ -66,7 +66,7 @@ should see the following if the execution is successful:
     
         ===============================================
         ===============================================
-        URL: http://localhost:8080/jboss-helloworld-rs/rest/json
+        URL: http://localhost:8080/wildfly-helloworld-rs/rest/json
         MediaType: application/json
 
         *** Response from Server ***

--- a/servlet-async/README.md
+++ b/servlet-async/README.md
@@ -61,7 +61,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL <http://localhost:8080/jboss-servlet-async/>.
+The application will be running at the following URL <http://localhost:8080/wildfly-servlet-async/>.
 
 
 Undeploy the Archive

--- a/servlet-filterlistener/README.md
+++ b/servlet-filterlistener/README.md
@@ -58,7 +58,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL <http://localhost:8080/jboss-servlet-filterlistener/>.
+The application will be running at the following URL <http://localhost:8080/wildfly-servlet-filterlistener/>.
 
 You are presented with a form containing an input field and a *Send* button. To test the quickstart:
 

--- a/servlet-security/README.md
+++ b/servlet-security/README.md
@@ -124,7 +124,7 @@ Build and Deploy the Quickstart
 Access the Application 
 ---------------------
 
-The application will be running at the following URL <http://localhost:8080/jboss-servlet-security/>.
+The application will be running at the following URL <http://localhost:8080/wildfly-servlet-security/>.
 
 When you access the application, you should get a browser login challenge. 
 

--- a/temperature-converter/README.md
+++ b/temperature-converter/README.md
@@ -60,7 +60,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-temperature-converter/>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-temperature-converter/>.
 
 You will be presented with a simple form for temperature conversion.
 

--- a/template/README.md
+++ b/template/README.md
@@ -98,7 +98,7 @@ Access the application
 
 <!-- Contributor: Add this section only if the quickstart has a UI component and provide the URL to access the running application. Be sure to make the URL a hyperlink as below, substituting the your quickstart name for the `QUICKSTART_NAME`. -->
 
-        Access the running application in a browser at the following URL:  <http://localhost:8080/jboss-QUICKSTART_NAME>
+        Access the running application in a browser at the following URL:  <http://localhost:8080/wildfly-QUICKSTART_NAME>
 
 
 <!--Contributor: Briefly describe what you will see when you access the application. For example: -->

--- a/websocket-endpoint/README.md
+++ b/websocket-endpoint/README.md
@@ -58,7 +58,7 @@ Build and Deploy the Quickstart
 Access the application
 ---------------------
 
-Access the running application in a browser at the following URL:  <http://localhost:8080/jboss-websocket-endpoint/>
+Access the running application in a browser at the following URL:  <http://localhost:8080/wildfly-websocket-endpoint/>
 
 You're presented with a simple form that shows a bidding with the status `NOT_STARTED`. 
 

--- a/websocket-hello/README.md
+++ b/websocket-hello/README.md
@@ -60,7 +60,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-websocket-hello>. 
+The application will be running at the following URL: <http://localhost:8080/wildfly-websocket-hello>. 
 
 1. Click on the `Open Connection` button to create the WebSocket connection and display current status of `Open`.
 2. Type a name and click `Say Hello` to create and send the 'Say hello to `<NAME>`' message. The message appears in the server log and a response is sent to the client.

--- a/xml-dom4j/README.md
+++ b/xml-dom4j/README.md
@@ -53,7 +53,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-xml-dom4j/>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-xml-dom4j/>.
 
 
 Undeploy the Archive

--- a/xml-jaxp/README.md
+++ b/xml-jaxp/README.md
@@ -56,7 +56,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-xml-jaxp/>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-xml-jaxp/>.
 
 To test the quickstart, follow these steps.
 
@@ -69,7 +69,7 @@ To test the quickstart, follow these steps.
 To enable the alternative SAXXMLParser parser:
 
 1. Remove the comments that surround the alternate parser element in the `WEB-INF/beans.xml` file.
-2. Redeploy the application using the instructions above and access the application in a browser at the following URL:  <http://localhost:8080/jboss-xml-jaxp/>.
+2. Redeploy the application using the instructions above and access the application in a browser at the following URL:  <http://localhost:8080/wildfly-xml-jaxp/>.
 3. Click the `Browse` button and navigate to the `QUICKSTART_HOME/src/main/resources/catalog.xml` file.
 4. Click the `Upload` button. The XML file content is parsed and displayed on the page. 
 5. You should now see following output in the server console:


### PR DESCRIPTION
Hi,

this PR fixes typos in **README.MD** where to old urls referring to jboss instead of wildfly. I also renamed all submodules (e.g. cdi-decorator) and dependencies which still referring to jboss instead of wildfly.

Kind regards
Alex