### PR TITLE
Jbeap 2670: Cherry-pick fixes from JBoss EAP helloworld-mdb-propertysubstitution quickstart

### DIFF
--- a/helloworld-mdb-propertysubstitution/README.md
+++ b/helloworld-mdb-propertysubstitution/README.md
@@ -12,13 +12,12 @@ What is it?
 
 The `helloworld-mdb-propertysubstitution` quickstart demonstrates the use of *JMS* and *EJB Message-Driven Bean* in Red Hat JBoss Enterprise Application Platform. 
 
-It is based on the [helloworld-mdb](../helloworld-mdb/README.md) quickstart, but has been enhanced to enable property substitution using 
-the `@Resource` and `@ActivationConfigProperty` annotations.
+It is based on the [helloworld-mdb](../helloworld-mdb/README.md) quickstart, but has been enhanced to enable property substitution using the `@Resource` and `@ActivationConfigProperty` annotations.
 
 This project creates two JMS resources:
 
-* A queue named `MDBPropertySubQueue` bound in JNDI as `java:/queue/MDBPROPERTYSUBQueue`
-* A topic named `MDBPropertySubTopic` bound in JNDI as `java:/topic/MDBPROPERTYSUBTopic`
+* A queue named `HELLOWORLDMDBQueue` bound in JNDI as `java:/${property.helloworldmdb.queue}`
+* A topic named `HELLOWORLDMDBTopic` bound in JNDI as `java:/${property.helloworldmdb.topic}`
 
 
 System requirements

--- a/helloworld-mdb-propertysubstitution/README.md
+++ b/helloworld-mdb-propertysubstitution/README.md
@@ -70,7 +70,7 @@ After stopping the server, open the `WILDFLY_HOME/standalone/configuration/stand
 
 The `<annotation-property-replacement>` attribute is set to true in the `ee` subsystem :
 
-        <subsystem xmlns="urn:jboss:domain:ee:3.0">
+        <subsystem xmlns="urn:jboss:domain:ee:4.0">
             ...
             <annotation-property-replacement>true</annotation-property-replacement>
             ...

--- a/helloworld-mdb-propertysubstitution/README.md
+++ b/helloworld-mdb-propertysubstitution/README.md
@@ -119,9 +119,9 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-helloworld-mdb-propertysubstitution/> and will send some messages to the queue.
+The application will be running at the following URL: <http://localhost:8080/wildfly-helloworld-mdb-propertysubstitution/> and will send some messages to the queue.
 
-To send messages to the topic, use the following URL: <http://localhost:8080/jboss-helloworld-mdb-propertysubstitution/HelloWorldMDBServletClient?topic>
+To send messages to the topic, use the following URL: <http://localhost:8080/wildfly-helloworld-mdb-propertysubstitution/HelloWorldMDBServletClient?topic>
 
 Investigate the Server Console Output
 -------------------------

--- a/helloworld-mdb-propertysubstitution/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldQueueMDB.java
+++ b/helloworld-mdb-propertysubstitution/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldQueueMDB.java
@@ -33,7 +33,7 @@ import javax.jms.TextMessage;
  *
  */
 @MessageDriven(name = "HelloWorldQueueMDB", activationConfig = {
-    @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "queue/HELLOWORLDMDBQueue"),
+    @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "${property.helloworldmdb.queue}"),
     @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
     @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge") })
 public class HelloWorldQueueMDB implements MessageListener {

--- a/helloworld-mdb-propertysubstitution/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldTopicMDB.java
+++ b/helloworld-mdb-propertysubstitution/src/main/java/org/jboss/as/quickstarts/mdb/HelloWorldTopicMDB.java
@@ -33,7 +33,7 @@ import javax.jms.TextMessage;
  *
  */
 @MessageDriven(name = "HelloWorldQTopicMDB", activationConfig = {
-    @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "topic/HELLOWORLDMDBTopic"),
+    @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "${property.helloworldmdb.topic}"),
     @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
     @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge") })
 public class HelloWorldTopicMDB implements MessageListener {

--- a/helloworld-mdb-propertysubstitution/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
+++ b/helloworld-mdb-propertysubstitution/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
@@ -40,12 +40,12 @@ import javax.servlet.http.HttpServletResponse;
 @JMSDestinationDefinitions(
     value = {
         @JMSDestinationDefinition(
-            name = "java:/queue/HELLOWORLDMDBQueue",
+            name = "java:/${property.helloworldmdb.queue}",
             interfaceName = "javax.jms.Queue",
             destinationName = "HelloWorldMDBQueue"
         ),
         @JMSDestinationDefinition(
-            name = "java:/topic/HELLOWORLDMDBTopic",
+            name = "java:/${property.helloworldmdb.topic}",
             interfaceName = "javax.jms.Topic",
             destinationName = "HelloWorldMDBTopic"
         )

--- a/helloworld-mdb-propertysubstitution/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
+++ b/helloworld-mdb-propertysubstitution/src/main/java/org/jboss/as/quickstarts/servlet/HelloWorldMDBServletClient.java
@@ -73,10 +73,10 @@ public class HelloWorldMDBServletClient extends HttpServlet {
     @Inject
     private JMSContext context;
 
-    @Resource(lookup = "java:/queue/HELLOWORLDMDBQueue")
+    @Resource(lookup = "${property.helloworldmdb.queue}")
     private Queue queue;
 
-    @Resource(lookup = "java:/topic/HELLOWORLDMDBTopic")
+    @Resource(lookup = "${property.helloworldmdb.topic}")
     private Topic topic;
 
     @Override

--- a/helloworld-mdb-propertysubstitution/src/main/webapp/WEB-INF/activemq-jms.xml
+++ b/helloworld-mdb-propertysubstitution/src/main/webapp/WEB-INF/activemq-jms.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<messaging-deployment xmlns="urn:jboss:messaging-activemq-deployment:1.0">
+    <server>
+         <jms-destinations>
+            <jms-queue name="HELLOWORLDMDBQueue">
+                <entry name="${property.helloworldmdb.queue}"/>
+            </jms-queue>
+            <jms-topic name="HELLOWORLDMDBTopic">
+                <entry name="${property.helloworldmdb.topic}"/>
+            </jms-topic>
+        </jms-destinations>
+    </server>
+</messaging-deployment>


### PR DESCRIPTION
It seems the property substitution code disappeared from the helloworld-mdb-propertysubstitution. It was restored in the JBoss EAP 7 version of the quickstart. This pull is a cherry-pick of those fixes. 

There is an additional fix to the application context in the URL for the running application in the README file. A number of other quickstart README files also have invalid application contexts: 

        `http://localhost:8080/jboss-*` instead of `http://localhost:8080/wildfly-*`

I didn't squash the commits since they were cherry-picked from the other repository, but can do that if you prefer.
