### PR TITLE
add JAX-RS activation class to make rest/* work

### DIFF
--- a/helloworld-rs/src/main/java/org/jboss/as/quickstarts/rshelloworld/JAXActivator.java
+++ b/helloworld-rs/src/main/java/org/jboss/as/quickstarts/rshelloworld/JAXActivator.java
@@ -1,0 +1,30 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.rshelloworld;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * JAXActivator is an arbitrary name, what is important is that javax.ws.rs.core.Application is extended
+ * and the @ApplicationPath annotation is used with a "rest" path.  Without this the rest routes linked to
+ * from index.html would not be found.
+ */
+@ApplicationPath("rest")
+public class JAXActivator extends Application {
+    // Left empty intentionally
+}


### PR DESCRIPTION
The links to http://localhost:8080/wildfly-helloworld-rs/rest/json and http://localhost:8080/wildfly-helloworld-rs/rest/xml at the index page (http://localhost:8080/wildfly-helloworld-rs/) did not work as the JAX-RS was not active.  This adds an activation class that makes them work.