### PR TITLE
REVIEW CAREFULLY - JBEAP-3041: Updgrade quickstarts to use the resteasy-jackson2-provider

### DIFF
--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -129,7 +129,7 @@
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson-provider</artifactId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/managedexecutorservice/pom.xml
+++ b/managedexecutorservice/pom.xml
@@ -227,7 +227,7 @@
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson-provider</artifactId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
@rafabene  or WildFly quickstart administrator: 

THIS NEEDS TESTING! DO NOT MERGE THIS UNTIL YOU TEST AND CONFIRM IT WORKS!!!

I upgraded and tested the JBoss EAP 7 quickstarts to use the new `resteasy-jackson2-provider`. This fix works there. I then cherry-picked the commit to backport the fix to the wildfly-quickstarts . 

I tried to test the fixes, however I am not set up with a WildFly server, so I tested against JBoss EAP 7. When I run the Maven tests, I get the following errors.

    jaxrs-client:
            Failed tests: 
              ContactsRestClientTest.requestResponseFiltersTest:189 All contacts should be dropped expected:<200> but was:<405>
              ContactsRestClientTest.delayedInvocationTest:154 All contacts should be dropped expected:<200> but was:<405>
              ContactsRestClientTest.asyncCrudTest:89 All contacts should be dropped expected:<200> but was:<405>
              ContactsRestClientTest.invocationCallBackTest:122 All contacts should be dropped expected:<200> but was:<405>
              ContactsRestClientTest.cruedTest:50 All contacts should be dropped expected:<200> but was:<405>

    managedexecutorservice:
            Failed tests: 
              ProductsRestClientTest.testRestResources:44 expected:<200> but was:<404>



