### PR TITLE
FIX: replace link jboss-cdi-alternative with wildfly-cdi-alternative

### DIFF
--- a/cdi-alternative/README.md
+++ b/cdi-alternative/README.md
@@ -61,7 +61,7 @@ Build and Deploy the Quickstart
 Access the application
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-cdi-alternative>.
+The application will be running at the following URL: <http://localhost:8080/wildfly-cdi-alternative>.
 
 You can specify alternative versions of the bean in the WEB-INF/beans.xml file by doing one of the following:
 


### PR DESCRIPTION
wildfly-cdi-alternative deploys under wildfly-cdi-alternative instead of jboss-cdi-alternative. It could be accessed by http://localhost:8080/wildfly-cdi-alternative/