### PR TITLE
[JDF-857] ejb-security-interceptors deny login delegation with a hidd ArrayIndexOutOfBounds

### DIFF
--- a/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/DelegationLoginModule.java
+++ b/ejb-security-interceptors/src/main/java/org/jboss/as/quickstarts/ejb_security_interceptors/DelegationLoginModule.java
@@ -140,7 +140,7 @@ public class DelegationLoginModule extends AbstractServerLoginModule {
         }
 
         String[] allowedMappings = loadPropertyValue(connectionUser.getName(), connectionUser.getRealm());
-        if (allowedMappings.length == 1 && "*".equals(allowedMappings[1])) {
+        if (allowedMappings.length == 1 && "*".equals(allowedMappings[0])) {
             // A wild card mapping was found.
             return true;
         }


### PR DESCRIPTION
Fix the array access for 
https://issues.jboss.org/browse/JDF-857
