### PR TITLE
Fix link to helloworld-rs on resteasy-jaxrs

### DIFF
--- a/resteasy-jaxrs-client/README.md
+++ b/resteasy-jaxrs-client/README.md
@@ -11,7 +11,7 @@ Source: <https://github.com/wildfly/quickstart/>
 What is it?
 -----------
 
-The `resteasy-jaxrs-client` quickstart demonstrates an external JAX-RS RestEasy client which interacts with a JAX-RS Web service that uses *CDI* and *JAX-RS* 
+The `resteasy-jaxrs-client` quickstart demonstrates an external JAX-RS RestEasy client which interacts with a JAX-RS Web service that uses *CDI* and *JAX-RS*
 in Red Hat JBoss Enterprise Application Platform.
 
 This client "calls" the HelloWorld JAX-RS Web Service that was created in the [helloworld-rs](../helloworld-rs/README.md) quickstart. See the **Prerequisite** section below for details on how to build and deploy the [helloworld-rs](../helloworld-rs/README.md) quickstart.
@@ -20,7 +20,7 @@ This client "calls" the HelloWorld JAX-RS Web Service that was created in the [h
 System requirements
 -------------------
 
-The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 7 or later. 
+The application this project produces is designed to be run on Red Hat JBoss Enterprise Application Platform 7 or later.
 
 All you need to build this project is Java 8.0 (Java SDK 1.8) or later and Maven 3.1.1 or later. See [Configure Maven for WildFly 10](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONFIGURE_MAVEN_JBOSS_EAP7.md#configure-maven-to-build-and-deploy-the-quickstarts) to make sure you are configured correctly for testing the quickstarts.
 
@@ -32,41 +32,41 @@ IMPORTANT: This quickstart depends on the deployment of the 'helloworld-rs' quic
 
 You can verify the deployment of the [helloworld-rs](../helloworld-rs/README.md) quickstart by accessing the following content:
 
-* The *XML* content can be viewed by accessing the following URL: <http://localhost:8080/jboss-helloworld-rs/rest/xml> 
-* The *JSON* content can be viewed by accessing this URL: <http://localhost:8080/jboss-helloworld-rs/rest/json>
+* The *XML* content can be viewed by accessing the following URL: <http://localhost:8080/wildfly-helloworld-rs/rest/xml>
+* The *JSON* content can be viewed by accessing this URL: <http://localhost:8080/wildfly-helloworld-rs/rest/json>
 
 
 
-Run the Arquillian Tests 
+Run the Arquillian Tests
 -------------------------
 
-This quickstart provides Arquillian tests. 
+This quickstart provides Arquillian tests.
 
 1. Make sure you have started the WildFly server as described above.
 2. Make sure the `helloworld-rs` quickstart has been deployed on the server as noted in the **Prerequisites** section above.
 3. Open a command prompt and navigate to the root directory of this quickstart.
 4. Type the following command to run the test goal with the following profile activated:
 
-        mvn clean test 
+        mvn clean test
 
 
 Investigate the Console Output
 ----------------------------
 
-This command will compile the example and execute a test to make two separate requests to the Web Service.  Towards the end of the Maven build output, you 
+This command will compile the example and execute a test to make two separate requests to the Web Service.  Towards the end of the Maven build output, you
 should see the following if the execution is successful:
 
         ===============================================
-        URL: http://localhost:8080/jboss-helloworld-rs/rest/xml
+        URL: http://localhost:8080/wildfly-helloworld-rs/rest/xml
         MediaType: application/xml
 
         *** Response from Server ***
 
         <xml><result>Hello World!</result></xml>
-    
+
         ===============================================
         ===============================================
-        URL: http://localhost:8080/jboss-helloworld-rs/rest/json
+        URL: http://localhost:8080/wildfly-helloworld-rs/rest/json
         MediaType: application/json
 
         *** Response from Server ***
@@ -76,4 +76,3 @@ should see the following if the execution is successful:
 
 
 <!-- Build and Deploy the Quickstart to OpenShift - Coming soon! -->
-

--- a/resteasy-jaxrs-client/pom.xml
+++ b/resteasy-jaxrs-client/pom.xml
@@ -142,11 +142,11 @@
                             <systemProperties>
                                 <property>
                                     <name>xmlUrl</name>
-                                    <value>http://localhost:8080/jboss-helloworld-rs/rest/xml</value>
+                                    <value>http://localhost:8080/wildfly-helloworld-rs/rest/xml</value>
                                 </property>
                                 <property>
                                     <name>jsonUrl</name>
-                                    <value>http://localhost:8080/jboss-helloworld-rs/rest/json</value>
+                                    <value>http://localhost:8080/wildfly-helloworld-rs/rest/json</value>
                                 </property>
                             </systemProperties>
                         </configuration>


### PR DESCRIPTION
Outdated link was still pointing to "jboss-helloworld-rs"