### PR TITLE
Fixed incorrect URL in HelloWorld quickstart

### DIFF
--- a/helloworld/README.md
+++ b/helloworld/README.md
@@ -52,7 +52,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-helloworld>. 
+The application will be running at the following URL: <http://localhost:8080/wildfly-helloworld/HelloWorld>. 
 
 
 Undeploy the Archive


### PR DESCRIPTION
Hello. The _http://localhost:8080/jboss-helloworld_ URL provided in the README of HelloWorld quickstart generates a 404 error. 
