### PR TITLE
Fix path and added web.xml descriptor

### DIFF
--- a/greeter/README.md
+++ b/greeter/README.md
@@ -67,7 +67,7 @@ Build and Deploy the Quickstart
 Access the application 
 ---------------------
 
-The application will be running at the following URL: <http://localhost:8080/jboss-greeter>. 
+The application will be running at the following URL: <http://localhost:8080/wildfly-greeter/>. 
 
 
 Undeploy the Archive

--- a/greeter/src/main/webapp/WEB-INF/web.xml
+++ b/greeter/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.1"
+         xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+    <servlet>
+        <servlet-name>Faces Servlet</servlet-name>
+        <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>Faces Servlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>
+            30
+        </session-timeout>
+    </session-config>
+    <welcome-file-list>
+        <welcome-file>greet.xhtml</welcome-file>
+    </welcome-file-list>
+</web-app>


### PR DESCRIPTION
Hello, 

I followed the instructions to build and deploy the greeter app, but when I requested in my browser the URL of the app I got a 404 Not Found error. Replacing the URL with the correct one resulted in a second error - 403 Forbidden. Adding a web.xml descriptor file solved the second issue.