### PR TITLE
wildfly-wicket quickstarts upgrade and bug fix

### DIFF
--- a/wicket-ear/README.md
+++ b/wicket-ear/README.md
@@ -3,14 +3,14 @@ wicket-ear: Wicket Framework used in a WAR inside an EAR.
 Author: Ondrej Zizka <ozizka@redhat.com>  
 Level: Intermediate  
 Technologies: Apache Wicket, JPA  
-Summary: Demonstrates how to use the Wicket Framework 1.5 with the JBoss server using the Wicket-Stuff Java EE integration, packaged as an EAR  
+Summary: Demonstrates how to use the Wicket Framework 7.x with the JBoss server using the Wicket Java EE integration, packaged as an EAR  
 Target Product: WildFly  
 Source: <https://github.com/wildfly/quickstart/>  
 
 What is it?
 -----------
 
-This is an example of how to use Wicket Framework 1.5 with WildFly, leveraging features of Java EE 7, using the Wicket-Stuff Java EE integration.
+This is an example of how to use Wicket Framework 7.x with WildFly, leveraging features of Java EE 7, using the Wicket Java EE integration.
 
 Features used:
 

--- a/wicket-ear/ejb/src/main/java/org/jboss/as/quickstarts/wicketEar/ejbjar/dao/ContactDao.java
+++ b/wicket-ear/ejb/src/main/java/org/jboss/as/quickstarts/wicketEar/ejbjar/dao/ContactDao.java
@@ -55,8 +55,8 @@ public interface ContactDao {
     /**
      * Removes a specific item from the DB
      *
-     * @param modelObject The specific Contact object, which we wants to remove
+     * @param id of the specific Contact object, which we wants to remove
      */
-    public void remove(Contact modelObject);
+    public void remove(Long id);
 
 }

--- a/wicket-ear/ejb/src/main/java/org/jboss/as/quickstarts/wicketEar/ejbjar/dao/ContactDaoBean.java
+++ b/wicket-ear/ejb/src/main/java/org/jboss/as/quickstarts/wicketEar/ejbjar/dao/ContactDaoBean.java
@@ -59,8 +59,8 @@ public class ContactDaoBean implements ContactDao {
      * Remove a Contact.
      */
     @Override
-    public void remove(Contact modelObject) {
-        Contact managed = em.merge(modelObject);
+    public void remove(Long id) {
+        Contact managed = em.find(Contact.class, id);
         em.remove(managed);
         em.flush();
     }

--- a/wicket-ear/pom.xml
+++ b/wicket-ear/pom.xml
@@ -49,8 +49,7 @@
 
 
         <!-- Other dependency versions -->
-        <version.org.apache.wicket>1.5.5</version.org.apache.wicket>
-        <version.net.ftlines.wicket-cdi>1.2</version.net.ftlines.wicket-cdi>
+        <version.org.apache.wicket>7.3.0</version.org.apache.wicket>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>3.1</version.compiler.plugin>
@@ -102,9 +101,9 @@
 
             <!-- Wicket Java EE integration. -->
             <dependency>
-                <groupId>net.ftlines.wicket-cdi</groupId>
-                <artifactId>wicket-cdi</artifactId>
-                <version>${version.net.ftlines.wicket-cdi}</version>
+                <groupId>org.apache.wicket</groupId>
+                <artifactId>wicket-cdi-1.1</artifactId>
+                <version>${version.org.apache.wicket}</version>
             </dependency>
 
             <!-- EJB JAR module. -->

--- a/wicket-ear/war/pom.xml
+++ b/wicket-ear/war/pom.xml
@@ -53,8 +53,8 @@
 
         <!-- Wicket Java EE integration. -->
         <dependency>
-            <groupId>net.ftlines.wicket-cdi</groupId>
-            <artifactId>wicket-cdi</artifactId>
+            <groupId>org.apache.wicket</groupId>
+            <artifactId>wicket-cdi-1.1</artifactId>
         </dependency>
 
         <!-- EJB JAR. -->
@@ -93,6 +93,19 @@
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+            <!-- This is workaround for avoiding ClassNotFoundException during deserialization 
+             of Wicket component with @Inject. For more info please see https://issues.jboss.org/browse/WFLY-988 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                           <Dependencies>org.jboss.msc</Dependencies>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/wicket-ear/war/src/main/java/org/jboss/as/quickstarts/wicketEar/war/WicketJavaEEApplication.java
+++ b/wicket-ear/war/src/main/java/org/jboss/as/quickstarts/wicketEar/war/WicketJavaEEApplication.java
@@ -16,15 +16,8 @@
  */
 package org.jboss.as.quickstarts.wicketEar.war;
 
-import static net.ftlines.wicket.cdi.ConversationPropagation.NONE;
-
-import javax.enterprise.inject.spi.BeanManager;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-
-import net.ftlines.wicket.cdi.CdiConfiguration;
-
 import org.apache.wicket.Page;
+import org.apache.wicket.cdi.CdiConfiguration;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.jboss.as.quickstarts.wicketEar.war.pages.InsertContact;
 import org.jboss.as.quickstarts.wicketEar.war.pages.ListContacts;
@@ -44,16 +37,8 @@ public class WicketJavaEEApplication extends WebApplication {
     protected void init() {
         super.init();
 
-        // Enable CDI
-        BeanManager bm;
-        try {
-            bm = (BeanManager) new InitialContext().lookup("java:comp/BeanManager");
-        } catch (NamingException e) {
-            throw new IllegalStateException("Unable to obtain CDI BeanManager", e);
-        }
-
         // Configure CDI, disabling Conversations as we aren't using them
-        new CdiConfiguration(bm).setPropagation(NONE).configure(this);
+        new CdiConfiguration().configure(this);
 
         // Mount the InsertContact page at /insert
         mountPage("/insert", InsertContact.class);

--- a/wicket-ear/war/src/main/java/org/jboss/as/quickstarts/wicketEar/war/pages/ListContacts.java
+++ b/wicket-ear/war/src/main/java/org/jboss/as/quickstarts/wicketEar/war/pages/ListContacts.java
@@ -16,14 +16,21 @@
  */
 package org.jboss.as.quickstarts.wicketEar.war.pages;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
 import javax.annotation.Resource;
 import javax.inject.Inject;
 
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.Link;
-import org.apache.wicket.markup.html.list.ListItem;
-import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.repeater.Item;
+import org.apache.wicket.markup.repeater.RefreshingView;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 import org.jboss.as.quickstarts.wicketEar.ejbjar.dao.ContactDao;
 import org.jboss.as.quickstarts.wicketEar.ejbjar.model.Contact;
 
@@ -49,19 +56,28 @@ public class ListContacts extends WebPage {
         add(new Label("welcomeMessage", welcome));
 
         // Populate the table of contacts
-        add(new ListView<Contact>("contacts", contactDao.getContacts()) {
-
+        add(new RefreshingView<ContactDto>("contacts") {
+            
             @Override
-            protected void populateItem(final ListItem<Contact> item) {
-                Contact contact = item.getModelObject();
+            protected Iterator<IModel<ContactDto>> getItemModels() {
+                List<IModel<ContactDto>> models = new ArrayList<>();
+                for (Contact contact : contactDao.getContacts()) {
+                    models.add(Model.of(new ContactDto(contact)));
+                }
+                return models.iterator();
+            }
+            
+            @Override
+            protected void populateItem(final Item<ContactDto> item) {
+                ContactDto contact = item.getModelObject();
                 item.add(new Label("name", contact.getName()));
                 item.add(new Label("email", contact.getEmail()));
-                item.add(new Link<Contact>("delete", item.getModel()) {
+                item.add(new Link<ContactDto>("delete", item.getModel()) {
 
                     // Add a click handler
                     @Override
                     public void onClick() {
-                        contactDao.remove(item.getModelObject());
+                        contactDao.remove(item.getModelObject().getId());
                         setResponsePage(ListContacts.class);
                     }
                 });
@@ -69,4 +85,33 @@ public class ListContacts extends WebPage {
         });
     }
 
+    /**
+     * This class is detached version of {@link Contact} and it's purpose is to
+     * avoid detachable model in order not to complicate this example.
+     * 
+     * For more information please see
+     * https://ci.apache.org/projects/wicket/guide/7.x/guide/modelsforms.html#modelsforms_6
+     */
+    private static class ContactDto implements Serializable {
+        private final Long id;
+        private final String name;
+        private final String email;
+        
+        public ContactDto(Contact contact) {
+            this.id = contact.getId();
+            this.name = contact.getName();
+            this.email = contact.getEmail();
+        }
+        
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+        public String getEmail() {
+            return email;
+        }
+    }
 }

--- a/wicket-war/README.md
+++ b/wicket-war/README.md
@@ -3,14 +3,14 @@ wicket-war: Wicket Framework used in a WAR.
 Author: Ondrej Zizka <ozizka@redhat.com>  
 Level: Intermediate  
 Technologies: Apache Wicket, JPA  
-Summary: Demonstrates how to use the Wicket Framework 1.5 with the JBoss server using the Wicket-Stuff Java EE integration packaged as a WAR  
+Summary: Demonstrates how to use the Wicket Framework 7.x with the JBoss server using the Wicket Java EE integration packaged as a WAR  
 Target Product: WildFly  
 Source: <https://github.com/wildfly/quickstart/>  
 
 What is it?
 -----------
 
-This is an example of how to use Wicket Framework 1.5 with WildFly, leveraging features of Java EE 7, using the Wicket-Stuff Java EE integration.
+This is an example of how to use Wicket Framework 7.x with WildFly, leveraging features of Java EE 7, using the Wicket-Stuff Java EE integration.
 
 Features used:
 

--- a/wicket-war/pom.xml
+++ b/wicket-war/pom.xml
@@ -50,8 +50,7 @@
 
 
         <!-- Other dependency versions -->
-        <version.org.apache.wicket>1.5.5</version.org.apache.wicket>
-        <version.net.ftlines.wicket-cdi>1.2</version.net.ftlines.wicket-cdi>
+        <version.org.apache.wicket>7.3.0</version.org.apache.wicket>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>3.1</version.compiler.plugin>
@@ -96,9 +95,9 @@
 
             <!-- Wicket Java EE integration. -->
             <dependency>
-                <groupId>net.ftlines.wicket-cdi</groupId>
-                <artifactId>wicket-cdi</artifactId>
-                <version>${version.net.ftlines.wicket-cdi}</version>
+                <groupId>org.apache.wicket</groupId>
+                <artifactId>wicket-cdi-1.1</artifactId>
+                <version>${version.org.apache.wicket}</version>
             </dependency>
 
         </dependencies>
@@ -145,8 +144,8 @@
 
         <!-- Wicket CDI integration. -->
         <dependency>
-            <groupId>net.ftlines.wicket-cdi</groupId>
-            <artifactId>wicket-cdi</artifactId>
+            <groupId>org.apache.wicket</groupId>
+            <artifactId>wicket-cdi-1.1</artifactId>
         </dependency>
 
     </dependencies>

--- a/wicket-war/src/main/java/org/jboss/as/quickstarts/wicketWar/WicketJavaEEApplication.java
+++ b/wicket-war/src/main/java/org/jboss/as/quickstarts/wicketWar/WicketJavaEEApplication.java
@@ -16,15 +16,8 @@
  */
 package org.jboss.as.quickstarts.wicketWar;
 
-import static net.ftlines.wicket.cdi.ConversationPropagation.NONE;
-
-import javax.enterprise.inject.spi.BeanManager;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-
-import net.ftlines.wicket.cdi.CdiConfiguration;
-
 import org.apache.wicket.Page;
+import org.apache.wicket.cdi.CdiConfiguration;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.jboss.as.quickstarts.wicketWar.pages.InsertContact;
 import org.jboss.as.quickstarts.wicketWar.pages.ListContacts;
@@ -44,16 +37,8 @@ public class WicketJavaEEApplication extends WebApplication {
     protected void init() {
         super.init();
 
-        // Enable CDI
-        BeanManager bm;
-        try {
-            bm = (BeanManager) new InitialContext().lookup("java:comp/BeanManager");
-        } catch (NamingException e) {
-            throw new IllegalStateException("Unable to obtain CDI BeanManager", e);
-        }
-
         // Configure CDI, disabling Conversations as we aren't using them
-        new CdiConfiguration(bm).setPropagation(NONE).configure(this);
+        new CdiConfiguration().configure(this);
 
         // Mount the InsertContact page at /insert
         mountPage("/insert", InsertContact.class);

--- a/wicket-war/src/main/java/org/jboss/as/quickstarts/wicketWar/dao/ContactDao.java
+++ b/wicket-war/src/main/java/org/jboss/as/quickstarts/wicketWar/dao/ContactDao.java
@@ -55,7 +55,7 @@ public interface ContactDao {
     /**
      * Removes a specific item from the DB.
      *
-     * @param modelObject The specific Contact object, which we wants to remove
+     * @param id of the specific Contact object, which we wants to remove
      */
-    public void remove(Contact modelObject);
+    public void remove(Long id);
 }

--- a/wicket-war/src/main/java/org/jboss/as/quickstarts/wicketWar/dao/ContactDaoBean.java
+++ b/wicket-war/src/main/java/org/jboss/as/quickstarts/wicketWar/dao/ContactDaoBean.java
@@ -59,8 +59,8 @@ public class ContactDaoBean implements ContactDao {
      * Remove a Contact.
      */
     @Override
-    public void remove(Contact modelObject) {
-        Contact managed = em.merge(modelObject);
+    public void remove(Long id) {
+        Contact managed = em.find(Contact.class, id);
         em.remove(managed);
         em.flush();
     }


### PR DESCRIPTION
Both WildFly Wicket quickstarts (wicket-ear, wicket-war) use Wicket version 1.5 which is not supported anymore.
Also when you run wicket-ear and try:
1. click on "Insert a new Contact" and add a new contact 
2. click on "Insert a new Contact" and then click on the browser back button, you get: ERROR [org.apache.wicket.DefaultExceptionMapper] (default task-46) Unexpected error occurred: java.lang.RuntimeException: Could not deserialize object from byte[]

This PR upgrades Wicket version to 7.3 and also fixes mentioned bug.
