### PR TITLE
helloworld-ws quickstart: updated URLs, instructions to run the Arqui…

### DIFF
--- a/helloworld-ws/README.md
+++ b/helloworld-ws/README.md
@@ -1,4 +1,4 @@
-helloworld-ws: Hello World JAX-WS Web Service
+helloworld-ws: Hello World JAX-WS Web Service_
 ==================================================
 Author: Lee Newson  
 Level: Beginner  
@@ -49,19 +49,20 @@ Build and Deploy the Quickstart
 5. Review the server log to see useful information about the deployed web service endpoint.
 
         JBWS024061: Adding service endpoint metadata: id=org.jboss.as.quickstarts.wshelloworld.HelloWorldServiceImpl
-         address=http://localhost:8080/jboss-helloworld-ws/HelloWorldService
+         address=http://localhost:8080/wildfly-helloworld-ws/HelloWorldService
          implementor=org.jboss.as.quickstarts.wshelloworld.HelloWorldServiceImpl
-         serviceName={http://www.jboss.org/eap/quickstarts/wshelloworld/HelloWorld}HelloWorldService
-         portName={http://www.jboss.org/eap/quickstarts/wshelloworld/HelloWorld}HelloWorld
+         serviceName={http://www.wildfly.org/quickstarts/wshelloworld/HelloWorld}HelloWorldService
+         portName={http://www.wildfly.org/quickstarts/wshelloworld/HelloWorld}HelloWorld
          annotationWsdlLocation=null
          wsdlLocationOverride=null
          mtomEnabled=false
 
 
+
 Access the application 
 ---------------------
 
-You can verify that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/jboss-helloworld-ws/HelloWorldService?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
+You can verify that the Web Service is running and deployed correctly by accessing the following URL: <http://localhost:8080/wildfly-helloworld-ws/HelloWorldService?wsdl>. This URL will display the deployed WSDL endpoint for the Web Service.
 
 
 Undeploy the Archive
@@ -79,11 +80,12 @@ Run the Client Tests using Arquillian
 
 This quickstart provides Arquillian tests. By default, these tests are configured to be skipped as Arquillian tests require the use of a container. 
 
-1. Make sure you have started the WildFly server as described above.
+1. Make sure you have a WildFly server installed on your machine. 
+2. Edit the arquillian.xml file and enter the path of your local WildFly installation. 
 2. Open a command prompt and navigate to the root directory of this quickstart.
 3. Type the following command to run the test goal with the following profile activated:
 
-		mvn clean test -Parq-wildfly-remote
+		mvn clean test -Parq-wildfly-managed
 
 
 Investigate the Console Output

--- a/helloworld-ws/pom.xml
+++ b/helloworld-ws/pom.xml
@@ -178,6 +178,7 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <version>1.1.0.Final</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -265,7 +266,6 @@
                         <version>${version.war.plugin}</version>
                         <configuration>
                             <outputDirectory>deployments</outputDirectory>
-                            <warName>${project.artifactId}</warName>
                             <failOnMissingWebXml>false</failOnMissingWebXml>
                         </configuration>
                     </plugin>

--- a/helloworld-ws/src/main/java/org/jboss/as/quickstarts/wshelloworld/HelloWorldService.java
+++ b/helloworld-ws/src/main/java/org/jboss/as/quickstarts/wshelloworld/HelloWorldService.java
@@ -27,7 +27,7 @@ import javax.jws.WebService;
  * @author lnewson@redhat.com
  */
 
-@WebService(targetNamespace = "http://www.jboss.org/eap/quickstarts/wshelloworld/HelloWorld")
+@WebService(targetNamespace = "http://www.wildfly.org/quickstarts/wshelloworld/HelloWorld")
 public interface HelloWorldService {
 
     /**

--- a/helloworld-ws/src/main/webapp/index.html
+++ b/helloworld-ws/src/main/webapp/index.html
@@ -21,8 +21,8 @@
 
     	<h1>helloworld-ws Quickstart</h1>
     	<p>
-    	  The <i>helloworld-ws</i> quickstart demonstrates the use of <b>JAX-WS</b> in
-          Red Hat JBoss Enterprise Application Platform as a simple Hello World application.
+    	  The <i>helloworld-ws</i> quickstart demonstrates the use of a <b>JAX-WS</b> component
+            embedded in a simple HelloWorld application.
     	</p>
     	<p>
     	 There is no user interface for this quickstart. Instead, you can verify the

--- a/helloworld-ws/src/test/java/org/jboss/as/quickstarts/wshelloworld/Client.java
+++ b/helloworld-ws/src/test/java/org/jboss/as/quickstarts/wshelloworld/Client.java
@@ -38,7 +38,7 @@ public class Client implements HelloWorldService {
      * @param url The URL to the Hello World WSDL endpoint.
      */
     public Client(final URL wsdlUrl) {
-        QName serviceName = new QName("http://www.jboss.org/eap/quickstarts/wshelloworld/HelloWorld", "HelloWorldService");
+        QName serviceName = new QName("http://www.wildfly.org/quickstarts/wshelloworld/HelloWorld", "HelloWorldService");
 
         Service service = Service.create(wsdlUrl, serviceName);
         helloWorldService = service.getPort(HelloWorldService.class);

--- a/helloworld-ws/src/test/resources/arquillian.xml
+++ b/helloworld-ws/src/test/resources/arquillian.xml
@@ -21,11 +21,14 @@
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <!-- Example configuration for a managed JBoss WildFly instance -->
-    <container qualifier="jbossas-managed" default="true">
-        <!-- By default, arquillian will use the JBOSS_HOME environment variable.  Alternatively, the configuration below can be uncommented. -->
-        <!--<configuration> -->
-        <!--<property name="jbossHome">/path/to/wildfly</property> -->
-        <!--</configuration> -->
-    </container>
+    <!-- By default, Arquillian will try to use the JBOSS_HOME environment variable. -->
+    <!-- If this doesn't work, uncomment the configuration below and enter the path to your Wildfly installation. -->
 
+    <!--
+    <container qualifier="jbossas-managed" default="true">
+        <configuration>
+            <property name="jbossHome">/path/to/wildfly</property>
+        </configuration>
+    </container>
+    -->
 </arquillian>


### PR DESCRIPTION
1.
Updated the URLs for deployment on a WildFly server. 

2.
Arquillian appears to have problems retrieving the WildFly path from the JBOSS_HOME environment variable. The path is 'null' and the managed container is not started. Providing the path in the arquillian.xml configuration solves this problem. 