### PR TITLE
fixed the websocket url to use wildfly

### DIFF
--- a/websocket-hello/src/main/webapp/index.html
+++ b/websocket-hello/src/main/webapp/index.html
@@ -23,7 +23,7 @@
             var websocket = null;
 
             function connect() {
-                var wsURI = 'ws://' + window.location.host + '/jboss-websocket-hello/websocket/helloName';
+                var wsURI = 'ws://' + window.location.host + '/wildfly-websocket-hello/websocket/helloName';
                 websocket = new WebSocket(wsURI);
 
                 websocket.onopen = function() {


### PR DESCRIPTION
The URL in the example is using still the jboss-websocket URL. Switched it to wildfly-websocket.
I intentionally didn't change the README as this is done in https://github.com/wildfly/quickstart/pull/115