### PR TITLE
[WFLY-8592] adding xts dependency to wsat-simple maven war plugin

### DIFF
--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -92,5 +92,19 @@
     <build>
         <!-- Set the name of the WAR, used as the context root when the app is deployed. -->
         <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest/>
+                        <manifestEntries>
+                            <Dependencies>org.jboss.xts</Dependencies>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>


### PR DESCRIPTION
Maven war plugin should define dependency on xts module for packaged war file could be deployed for configuration `standalone-xts.xml` without errors.

https://issues.jboss.org/browse/WFLY-8592
https://github.com/jbossas/eap-quickstarts/pull/34