### PR TITLE
JBEAP-11751 - Set "jpa" as default for functional tests

### DIFF
--- a/spring-petclinic/functional-tests/src/test/java/org/jboss/as/quickstarts/spring/petclinic/test/webdriver/Deployments.java
+++ b/spring-petclinic/functional-tests/src/test/java/org/jboss/as/quickstarts/spring/petclinic/test/webdriver/Deployments.java
@@ -16,7 +16,7 @@ public class Deployments {
     public static WebArchive archive() {
         WebArchive archive = ShrinkWrap.createFromZipFile(WebArchive.class, new File(PETCLINIC));
 
-        String discriminator = System.getProperty("discriminator");
+        String discriminator = System.getProperty("discriminator", "jpa");
         if (discriminator.equals("jdbc")) {
             archive.addAsWebInfResource(new File("src/test/resources/jdbc_web.xml"), "web.xml");
         } else if (discriminator.equals("spring-data-jpa")) {


### PR DESCRIPTION
**Motivation**

https://issues.jboss.org/browse/JBEAP-11751

See web.xml in Spring Petclinic. You can see "jpa" is set as default profile there. This PR set "jpa" as default for functional tests too.