### PR TITLE
JBEAP-12917: Add undeploy to JBDS instructions where needed

### DIFF
--- a/ejb-asynchronous/README.md
+++ b/ejb-asynchronous/README.md
@@ -106,6 +106,7 @@ This quickstart consists of multiple projects, so it deploys and runs differentl
     * Right-click on the `${project.artifactId}-client` project and choose `Run As` --> `Java Application`.
     * In the `Select Java Application` window, choose `AsynchronousClient - org.jboss.as.quickstarts.ejb.asynchronous.client` and click `OK`.
     * The client output displays in the `Console` window.
+3. To undeploy the project, right-click on the `${project.artifactId}-ejb` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 
 
 ## Debug the Application

--- a/ejb-in-ear/README.md
+++ b/ejb-in-ear/README.md
@@ -83,9 +83,10 @@ You can also start the server and deploy the quickstarts or run the Arquillian t
 
 For this quickstart, follow the special instructions to build [Quickstarts Containing an EAR](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/USE_JBDS.md#quickstarts-containing-an-ear).
 
-1. Right-click on the `${project.artifactId}` subproject, and choose `Run As` --> `Run on Server`.
+1. Right-click on the `${project.artifactId}-ear` subproject, and choose `Run As` --> `Run on Server`.
 2. Choose the server and click `Finish`.
 3. This starts the server, deploys the application, and opens a browser window that accesses the running application at <http://localhost:8080/ejb-in-ear>.
+4. 3. To undeploy the project, right-click on the `${project.artifactId}-ear` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 
 
 ## Debug the Application

--- a/ejb-remote/README.md
+++ b/ejb-remote/README.md
@@ -164,6 +164,7 @@ This quickstart consists of multiple projects, so it deploys and runs differentl
     * In the `Select Java Application` window, choose `RemoteEJBClient - org.jboss.as.quickstarts.ejb.remote.client` and click `OK`.
     * The client output displays in the `Console` window.
 
+3. To undeploy the project, right-click on the `${project.artifactId}-server-side` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 
 ## Debug the Application
 

--- a/ejb-security-context-propagation/README.md
+++ b/ejb-security-context-propagation/README.md
@@ -337,11 +337,12 @@ This quickstart requires additional configuration and deploys and runs different
 
 1. Be sure to [Add the Application Users](#add-the-application-users) as described above.
 2. Follow the steps above to [Configure the Server](#configure-the-server). Stop the server at the end of that step.
-3. To deploy the application to the ${product.name} server, right-click on the `ejb-security-context-propagation` project and choose `Run As` --> `Run on Server`.
-4. To access the application, right-click on the `ejb-security-context-propagation` project and choose `Run As` --> `Java Application`.
+3. To deploy the application to the ${product.name} server, right-click on the `${project.artifactId}` project and choose `Run As` --> `Run on Server`.
+4. To access the application, right-click on the `${project.artifactId}` project and choose `Run As` --> `Java Application`.
 5. Choose `RemoteClient - org.jboss.as.quickstarts.ejb_security_context_propagation` and click `OK`.
 6. Review the output in the console window.
-7. Be sure to [Restore the Server Configuration](#restore-the-server-configuration) when you have completed testing this quickstart.
+7. To undeploy the project, right-click on the `${project.artifactId}` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
+8. Be sure to [Restore the Server Configuration](#restore-the-server-configuration) when you have completed testing this quickstart.
 
 ## Debug the Application
 

--- a/ejb-security-interceptors/README.md
+++ b/ejb-security-interceptors/README.md
@@ -5,16 +5,20 @@ Level: Advanced
 Technologies: EJB, Security  
 Summary: The `ejb-security-interceptors` quickstart demonstrates how to use client and server side interceptors to switch the identity for an EJB call.  
 Target Product: ${product.name}  
-Source: <${github.repo.url}>  
+Source: <${github.repo.url}>
+Deprecated: This quickstart is deprecated in favour of ejb-security-context-propagation and ejb-security-programatic-auth
 
 ## What is it?
 
-The `ejb-security-interceptors` quickstart demonstrates how to use client and server side interceptors to switch the identity for an EJB call in ${product.name.full}. It also demonstrates how Elytron supports identity switching based on permissions.
+The `ejb-security-interceptors` quickstart demonstrates how to use client and server side interceptors to switch the identity for an EJB call in ${product.name.full}.
 
-By default, when you make a remote call to an EJB deployed to the application server, the connection to the server is authenticated and any request received over this connection is executed as the identity that authenticated the connection. This is true for both client-to-server and server-to-server calls. Although it is possible to switch identities without requiring a new connection to be established, in this quickstart a single identity is used to establish the connection to and the interceptors are then used to switch the connection identity to a different identity for the EJB call. This is achieved with the addition of the following two components:
+By default, when you make a remote call to an EJB deployed to the application server, the connection to the server is authenticated and any request received over this connection is executed as the identity that authenticated the connection. This is true for both client-to-server and server-to-server calls. If you need to use different identities from the same client, you normally need to open multiple connections to the server so that each one is authenticated as a different identity.
+
+Rather than open multiple client connections, this quickstart offers an alternative solution. The identity used to authenticate the connection is given permission to execute a request as a different user. This is achieved with the addition of the following three components:
 
 1. A client side interceptor to pass the requested identity to the remote server.
 2. A server side interceptor to receive the identity and request that the call switches to that identity.
+3. A JAAS LoginModule to decide if the user of the connection is allowed to execute requests as the specified identity.
 
 The quickstart then makes use of two EJBs, `SecuredEJB` and `IntermediateEJB`, to verify that the propagation and identity switching is correct and a `RemoteClient` standalone client.
 
@@ -44,27 +48,18 @@ In the real world, remote calls between servers in the servers-to-server scenari
 
 ## Note on EJB client interceptors
 
-${product.name} allows client side interceptors for EJB invocations. Such interceptors are expected to implement the `org.jboss.ejb.client.EJBClientInterceptor` interface.  Interceptors can be established in many ways, including the following:
+${product.name} allows client side interceptors for EJB invocations. Such interceptors are expected to implement the `org.jboss.ejb.client.EJBClientInterceptor` interface. User applications can then plug in such interceptors in the 'EJBClientContext' either programatically or through the ServiceLoader mechanism.
 
-- Using the `@ClientInterceptors` annotation, which exists in the `org.jboss.ejb.client.annotations` package of the EJB client API.  The annotation accepts a list of classes which implement the `EJBClientInterceptor` interface and each have a public, no-argument constructor, operating in much the same way as its server-side counterpart `@Interceptors` annotation in the standard `javax.interceptor` package.  The classes themselves may optionally be annotated with the `@ClientInterceptorPriority` annotation, which assigns a numerical priority used in sorting the interceptors for invocation.  The constant integer values on that annotation type represent standard values; if no priority is given, then the value of `APPLICATION` is chosen.
-- Establishing a list of interceptors in the `wildfly-client.xml` configuration file, which applies to standalone applications.
-- Using the `ServiceLoader`-based mechanism, which is an alternate approach which involves creating a `META-INF/services/org.jboss.ejb.client.EJBClientInterceptor` file and placing/packaging it in the classpath of the client application. The rules for such a file are dictated by the [Java ServiceLoader Mechanism](http://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html). This file is expected to contain on each separate line the fully qualified class name of the EJB client interceptor implementation, which is expected to be available in the classpath. EJB client interceptors follow the same ordering rules as annotated or configured interceptors.
+- The programmatic way involves calling the `org.jboss.ejb.client.EJBClientContext.registerInterceptor(int order, EJBClientInterceptor interceptor)` API and passing the 'order' and the 'interceptor' instance. The 'order' is used to decide where exactly in the client interceptor chain, this 'interceptor' is going to be placed.
+- The ServiceLoader mechanism is an alternate approach which involves creating a `META-INF/services/org.jboss.ejb.client.EJBClientInterceptor` file and placing/packaging it in the classpath of the client application. The rules for such a file are dictated by the [Java ServiceLoader Mechanism](http://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html). This file is expected to contain in each separate line the fully qualified class name of the EJB client interceptor implementation, which is expected to be available in the classpath. EJB client interceptors added via the ServiceLoader mechanism are added to the end of the client interceptor chain, in the order they were found in the classpath.
 
-This quickstart uses the annotation-based approach.
+This quickstart uses the ServiceLoader mechanism for registering the EJB client interceptor and places the `META-INF/services/org.jboss.ejb.client.EJBClientInterceptor` in the classpath, with the following content:
 
-### Ordering
+        # EJB client interceptor(s) that will be added to the end of the interceptor chain during an invocation
+        # on EJB. If these interceptors are to be added at a specific position, other than last, then use the
+        # programmatic API in the application to register it explicitly to the EJBClientContext
 
-Interceptors are ordered according to their assigned priority, which is `APPLICATION` if none is given.  Lower numbers come earlier, and higher numbers come later.  If more than one interceptor have the same priority, they are considered in the following order:
-
-- Method-level annotated interceptors
-- Class-level annotated interceptors
-- Configuration-declared method interceptors
-- Configuration-declared class interceptors
-- Configuration-declared global interceptors
-- `ServiceLoader`-based interceptors from the class path
-- System-installed JBoss interceptors
-
-If after these rules apply, more than one interceptor are still of equal priority, then they are applied in declaration or encounter order.
+        org.jboss.as.quickstarts.ejb_security_interceptors.ClientSecurityInterceptor
 
 ## System Requirements
 
@@ -116,25 +111,25 @@ For an example of how to use the add-user utility, see the instructions located 
 
 ## Configure the Server
 
-These steps assume you are running the server in standalone mode and using the default `standalone.xml` supplied with the distribution.
+These steps assume you are running the server in standalone mode and using the default standalone.xml supplied with the distribution.
 
-You configure the security domain by running JBoss CLI commands. For your convenience, this quickstart batches the commands into a `configure-elytron.cli` script provided in the root directory of this quickstart.
+You configure the security domain by running JBoss CLI commands. For your convenience, this quickstart batches the commands into a `configure-security-domain.cli` script provided in the root directory of this quickstart.
 
 1. Before you begin, back up your server configuration file
     * If it is running, stop the ${product.name} server.
-    * Back up the file: `${jboss.home.name}/standalone/configuration/standalone.xml`
+    * Backup the file: `${jboss.home.name}/standalone/configuration/standalone.xml`
     * After you have completed testing this quickstart, you can replace this file to restore the server to its original configuration.
 
 2. Start the ${product.name} server by typing the following:
 
         For Linux:  ${jboss.home.name}/bin/standalone.sh
         For Windows:  ${jboss.home.name}\bin\standalone.bat
-3. Review the `configure-elytron.cli` file in the root of this quickstart directory. This script adds the configuration that enables Elytron security for the quickstart deployment. Comments in the script describe the purpose of each block of commands.
+3. Review the `configure-security-domain.cli` file in the root of this quickstart directory. This script adds the `quickstart-domain` security domain to the `security` subsystem in the server configuration and configures authentication access. Comments in the script describe the purpose of each block of commands.
 
 4. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing ${jboss.home.name} with the path to your server:
 
-        For Linux: ${jboss.home.name}/bin/jboss-cli.sh --connect --file=configure-elytron.cli
-        For Windows: ${jboss.home.name}\bin\jboss-cli.bat --connect --file=configure-elytron.cli
+        For Linux: ${jboss.home.name}/bin/jboss-cli.sh --connect --file=configure-security-domain.cli
+        For Windows: ${jboss.home.name}\bin\jboss-cli.bat --connect --file=configure-security-domain.cli
     You should see the following result when you run the script:
 
         The batch executed successfully
@@ -151,68 +146,73 @@ You configure the security domain by running JBoss CLI commands. For your conven
 
 After stopping the server, open the `${jboss.home.name}/standalone/configuration/standalone.xml` file and review the changes.
 
-1. The following `application-security-domain` was added to the `ejb3` subsystem:
+1. The following `quickstart-domain` security-domain was added to the `security` subsystem.
 
-        <application-security-domains>
-            <application-security-domain name="quickstart-domain" security-domain="ApplicationDomain"/>
-        </application-security-domains>
+        <security-domain name="quickstart-domain" cache-type="default">
+            <authentication>
+                <login-module name="DelegationLoginModule" code="org.jboss.as.quickstarts.ejb_security_interceptors.DelegationLoginModule" flag="optional">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+                <login-module code="Remoting" flag="optional">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+                <login-module code="RealmDirect" flag="required">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+            </authentication>
+        </security-domain>
 
-    The `application-security-domain` essentially enables Elytron security for the quickstart EJBs. It maps the `quickstart-domain` that was set in the EJBs via annotation to the Elytron `ApplicationDomain` that will be responsible for authenticating and authorizing access to the EJBs.
-2. The following `ejb-outbound-configuration` authentication configuration and `ejb-outbound-context` authentication context were added to the `elytron` subsystem:
+    The EJB side of this quickstart makes use of a new security domain called `quickstart-domain`, which delegates to the `ApplicationRealm`. The `DelegationLoginModule` is used to support identity switching in this quickstart.
 
-        <authentication-configuration name="ejb-outbound-configuration" authentication-name="ConnectionUser" realm="ApplicationRealm" sasl-mechanism-selector="-JBOSS-LOCAL-USER #ALL">
-            <credential-reference clear-text="ConnectionPassword1!"/>
-        </authentication-configuration>
-        <authentication-context name="ejb-outbound-context">
-            <match-rule authentication-configuration="ejb-outbound-configuration"/>
-        </authentication-context>
+    The login module can either be added before or after the existing `Remoting` login module in the domain, but it MUST be somewhere before the existing `RealmDirect` login module. If the majority of requests will involve an identity switch, then it is recommended to have this module as the first module in the list. However, if the majority of requests will run as the connection user with occasional switches, it is recommended to place the `Remoting` login module first and this one second.
 
-    The `ejb-outbound-configuration` contains the authentication configuration that will be used when invoking a method on a remote EJB (i.e. when `IntermediateEJB` calls the methods on the `SecuredEJB`). It contains the user/credential pair that should be used when establishing the connection to the remote EJB and the `sasl-mechanism-selector` defines the SASL mechanisms that should be tried. In the configuration above it allows for all mechanisms except for `JBOSS-LOCAL-USER`.
+    The login module loads the properties file `delegation-mapping.properties` from the deployment. The location of this properties file can be overridden with the module-option `delegationProperties`. At runtime, this login module is used to decide if the user of the connection to the server is allowed to execute the request as the specified user.
 
-    The `ejb-outbound-context` is the authentiation context that is used by the remote outbound connection and it automatically selects the `ejb-outbound-configuration`.
-3. The following permissions were added to the `constant-permission-mapper` in the `elytron` subsystem:
+    There are four ways the key can be specified in the properties file:
 
-        <permission class-name="org.wildfly.security.auth.permission.RunAsPrincipalPermission" target-name="AppUserOne"/>
-        <permission class-name="org.wildfly.security.auth.permission.RunAsPrincipalPermission" target-name="AppUserTwo"/>
+        user@realm  - Exact match of user and realm.
+        user@*      - Allow a match of user for any realm.
+        *@realm     - Match for any user in the realm specified.
+        *           - Match for all users in all realms.
 
-    When switching identities via `createRunAsIdentity`, Elytron checks if the identity making the switch has permissions to do so. The above configuration essentially grants any identity permission to create a run-as identity. 
+    When a request is received to switch the user, the identity of the user that opened the connection is used to check the properties file for an entry. The check is performed in the order listed above until the first match is found. Once a match is found, further entries that could match are not read. The value in the properties file can either be a wildcard "*" or it can be a comma separated list of users. Be aware that in the value/mapping side there is no notion of the realm. For this quickstart we use the following entry:
 
-    For the purpose of this quickstart this permissions configuration is acceptable but in a real world scenario the recommendation would be to use a more fine-grained permissions configuration and grant the `RunAsPrincipalPermission`s only to the `ConnectionUser` identity. This could be done as follows:
-    Create a `simple-permission-mapper` that assigns the necessary permissions to the `ConnectionUser`.
+        ConnectionUser@ApplicationRealm=AppUserOne,AppUserTwo
 
-        <simple-permission-mapper name="run-as-permission-mapper">
-            <permission-mapping principals="ConnectionUser">
-                <permission class-name="org.wildfly.security.auth.permission.RunAsPrincipalPermission" target-name="AppUserOne"/>
-                <permission class-name="org.wildfly.security.auth.permission.RunAsPrincipalPermission" target-name="AppUserTwo"/>
-            </permission-mapping>
-        </simple-permission-mapper>
-    Create a `logical-permission-mapper` that expands the permissions of the `default-permission-mapper` to include the new `simple-permission-mapper`.
+    This means that the ConnectionUser added above can only ask that a request is executed as either AppUserOne or AppUserTwo. It is not allowed to ask to be executed as AppUserThree.
 
-        <logical-permission-mapper name="quickstart-permission-mapper" logical-operation="or" left="default-permission-mapper" right="run-as-permission-mapper"/>
-    Change the `ApplicationDomain` to use the extended mapper instead of the `default-permission-mapper`.
+    All users are permitted to execute requests as themselves. In that case, the login module is not called. This is the default behavior that exists without the addition of the interceptors in this quickstart.
 
-        <security-domain name="ApplicationDomain" default-realm="ApplicationRealm" permission-mapper="quickstart-permission-mapper" security-event-listener="local-audit">
+    Taking this further, the `DelegationLoginModule` can be extended to provide custom delegation checks. One thing not currently checked is if the user being switched to actually exists. If the module is extended, the following method can be overridden to provide a custom check.
 
-    By doing that the same result is achieved but in a more controlled way, without granting permissions to all identities in the `constant-permission-mapper`.
+         protected boolean delegationAcceptable(String requestedUser, OuterUserCredential connectionUser);
 
-4. The following `ejb-outbound` outbound-socket-binding connection was created within the `standard-sockets` socket-binding-group:
+     For the purpose of the quickstart we just need an outbound connection that loops back to the same server. This will be sufficient to demonstrate the server-to-server capabilities.
+2.  The following `ejb-outbound-realm` security-realm was added to the `management` security-realms. Note the Base64-encoded password is for the ConnectionUser account created above.
+
+        <security-realm name="ejb-outbound-realm">
+            <server-identities>
+                <secret value="Q29ubmVjdGlvblBhc3N3b3JkMSE="/>
+            </server-identities>
+        </security-realm>
+3. The following `ejb-outbound` outbound-socket-binding connection was created within the `standard-sockets` socket-binding-group:
 
         <outbound-socket-binding name="ejb-outbound">
             <remote-destination host="localhost" port="8080"/>
         </outbound-socket-binding>
-
-    For the purpose of the quickstart we just need an outbound connection that loops back to the same server. This will be sufficient to demonstrate the server-to-server capabilities.
-5. The following `ejb-outbound-connection` remote-outbound-connection was added to the outbound-connections within the `remoting` subsytem:
+4. The following `ejb-outbound-connection` remote-outbound-connection was added to the outbound-connections within the `remoting` subsytem:
 
         <outbound-connections>
-            <remote-outbound-connection name="ejb-outbound-connection" outbound-socket-binding-ref="ejb-outbound" authentication-context="ejb-outbound-context"/>
+            <remote-outbound-connection name="ejb-outbound-connection" outbound-socket-binding-ref="ejb-outbound" security-realm="ejb-outbound-realm" username="ConnectionUser">
+                <properties>
+                    <property name="SSL_ENABLED" value="false"/>
+                </properties>
+            </remote-outbound-connection>
         </outbound-connections>
-6. Finally the `http-connector` in the `remoting` subsystem was updated to use the `application-sasl-authentication` authentication factory. It allows for the identity that was established in the connection authentication to be propagated to the components.
-
-        <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm" sasl-authentication-factory="application-sasl-authentication"/>
-7. If you chose to run the script to suppress system exceptions, you should see the following configuration in the `ejb3` subsystem.
+5. If you chose to run the script to suppress system exceptions, you should see the following configuration in the `ejb3` subsystem.
 
         <log-system-exceptions value="false"/>
+
 
 ## Start the Server
 
@@ -308,10 +308,97 @@ When you run the `mvn exec:exec` command, you see the following output. Note the
     -------------------------------------------------
     Call as 'AppUserThree' correctly rejected.
 
+    This second round of tests is using the (PicketBox) ClientLoginModule with LoginContext API to set the desired Principal.
+
+    -------------------------------------------------
+    * * About to perform test as ConnectionUser * *
+
+
+    * Making Direct Calls to the SecuredEJB
+
+    * getSecurityInformation()=[Principal={ConnectionUser}, In role {User}=true, In role {RoleOne}=false, In role {RoleTwo}=false]
+    * Can call roleOneMethod()=false
+    * Can call roleTwoMethod()=false
+
+    * Calling the IntermediateEJB to repeat the test server to server
+
+    * * IntermediateEJB - Begin Testing * *
+    SecuredEJBRemote.getSecurityInformation()=[Principal={ConnectionUser}, In role {User}=true, In role {RoleOne}=false, In role {RoleTwo}=false]
+    Can call roleOneMethod=false
+    Can call roleTwoMethod=false
+    * * IntermediateEJB - End Testing * *
+    * * Test Complete * *
+
+    -------------------------------------------------
+    * * About to perform test as AppUserOne * *
+
+    * Making Direct Calls to the SecuredEJB
+
+    * getSecurityInformation()=[Principal={AppUserOne}, In role {User}=true, In role {RoleOne}=true, In role {RoleTwo}=false]
+    * Can call roleOneMethod()=true
+    * Can call roleTwoMethod()=false
+
+    * Calling the IntermediateEJB to repeat the test server to server
+
+    * * IntermediateEJB - Begin Testing * *
+    SecuredEJBRemote.getSecurityInformation()=[Principal={AppUserOne}, In role {User}=true, In role {RoleOne}=true, In role {RoleTwo}=false]
+    Can call roleOneMethod=true
+    Can call roleTwoMethod=false
+    * * IntermediateEJB - End Testing * *
+    * * Test Complete * *
+
+    -------------------------------------------------
+    * * About to perform test as AppUserTwo * *
+
+    * Making Direct Calls to the SecuredEJB
+
+    * getSecurityInformation()=[Principal={AppUserTwo}, In role {User}=true, In role {RoleOne}=false, In role {RoleTwo}=true]
+    * Can call roleOneMethod()=false
+    * Can call roleTwoMethod()=true
+
+    * Calling the IntermediateEJB to repeat the test server to server
+
+    * * IntermediateEJB - Begin Testing * *
+    SecuredEJBRemote.getSecurityInformation()=[Principal={AppUserTwo}, In role {User}=true, In role {RoleOne}=false, In role {RoleTwo}=true]
+    Can call roleOneMethod=false
+    Can call roleTwoMethod=true
+    * * IntermediateEJB - End Testing * *
+    * * Test Complete * *
+
+    -------------------------------------------------
+    * * About to perform test as AppUserThree * *
+
+    * Making Direct Calls to the SecuredEJB
+
+    * * Test Complete * *
+
+    -------------------------------------------------
+    Call as 'AppUserThree' correctly rejected.
+
+    * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
 ## Investigate the Server Console Output
 
 If you chose not to run the script to suppress system exceptions, you should see the following exceptions in the ${product.name} server console or log. The exceptions are logged for each of the tests where a request is rejected because the user is not authorized. The stacktraces were removed from this text for readability.
 
+    ERROR [org.jboss.as.ejb3.invocation] (EJB default - 3) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod(): javax.ejb.EJBAccessException: WFLYEJB0364: Invocation on method: public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod() of bean: SecuredEJB is not allowed
+    ...
+    ERROR [org.jboss.as.ejb3.invocation] (EJB default - 7) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleTwoMethod(): javax.ejb.EJBAccessException: WFLYEJB0364: Invocation on method: public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleTwoMethod() of bean: SecuredEJB is not allowed
+    ...
+    ERROR [org.jboss.as.ejb3.invocation] (EJB default - 6) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod(): javax.ejb.EJBAccessException: WFLYEJB0364: Invocation on method: public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod() of bean: SecuredEJB is not allowed
+    ...
+    ERROR [org.jboss.as.ejb3.invocation] (EJB default - 9) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleTwoMethod(): javax.ejb.EJBAccessException: WFLYEJB0364: Invocation on method: public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleTwoMethod() of bean: SecuredEJB is not allowed
+    ...
+    ERROR [org.jboss.as.ejb3.invocation] (EJB default - 1) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleTwoMethod(): javax.ejb.EJBAccessException: WFLYEJB0364: Invocation on method: public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleTwoMethod() of bean: SecuredEJB is not allowed
+    ...
+    ERROR [org.jboss.as.ejb3.invocation] (EJB default - 6) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleTwoMethod(): javax.ejb.EJBAccessException: WFLYEJB0364: Invocation on method: public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleTwoMethod() of bean: SecuredEJB is not allowed
+    ...
+    ERROR [org.jboss.as.ejb3.invocation] (EJB default - 5) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod(): javax.ejb.EJBAccessException: WFLYEJB0364: Invocation on method: public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod() of bean: SecuredEJB is not allowed
+    ...
+    ERROR [org.jboss.as.ejb3.invocation] (EJB default - 7) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod(): javax.ejb.EJBAccessException: WFLYEJB0364: Invocation on method: public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod() of bean: SecuredEJB is not allowed
+    ...
+    ERROR [org.jboss.as.ejb3.invocation] (EJB default - 9) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract java.lang.String org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.getSecurityInformation(): javax.ejb.EJBAccessException: WFLYSEC0027: Invalid User
+    ...
     ERROR [org.jboss.as.ejb3.invocation] (EJB default - 10) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod(): javax.ejb.EJBAccessException: WFLYEJB0364: Invocation on method: public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod() of bean: SecuredEJB is not allowed
     ...
     ERROR [org.jboss.as.ejb3.invocation] (EJB default - 5) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleTwoMethod(): javax.ejb.EJBAccessException: WFLYEJB0364: Invocation on method: public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleTwoMethod() of bean: SecuredEJB is not allowed
@@ -328,7 +415,7 @@ If you chose not to run the script to suppress system exceptions, you should see
     ...
     ERROR [org.jboss.as.ejb3.invocation] (EJB default - 5) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod(): javax.ejb.EJBAccessException: WFLYEJB0364: Invocation on method: public abstract boolean org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.roleOneMethod() of bean: SecuredEJB is not allowed
     ...
-    ERROR [org.jboss.as.ejb3.invocation] (default task-54) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract java.lang.String org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.getSecurityInformation(): org.wildfly.security.authz.AuthorizationFailureException: ELY01088: Attempting to run as "AppUserThree" authorization operation failed
+    ERROR [org.jboss.as.ejb3.invocation] (EJB default - 8) WFLYEJB0034: EJB Invocation failed on component SecuredEJB for method public abstract java.lang.String org.jboss.as.quickstarts.ejb_security_interceptors.SecuredEJBRemote.getSecurityInformation(): javax.ejb.EJBAccessException: WFLYSEC0027: Invalid User
 
 ## Server Log: Expected warnings and errors
 
@@ -346,7 +433,7 @@ _Note:_ You will see the following warning appear twice in the server log. You c
 
 ## Restore the Original Server Configuration
 
-You can restore the original server configuration by running the  `restore-configuration.cli` script provided in the root directory of this quickstart or by manually restoring the back-up copy the configuration file.
+You can remove the security domain configuration by running the  `remove-security-domain.cli` script provided in the root directory of this quickstart or by manually restoring the back-up copy the configuration file.
 
 ### Restore the Original Server Configuration by Running the JBoss CLI Script
 
@@ -354,8 +441,8 @@ You can restore the original server configuration by running the  `restore-confi
         For Windows:  ${jboss.home.name}\bin\standalone.bat
 2. Open a new command prompt, navigate to the root directory of this quickstart, and run the following command, replacing ${jboss.home.name} with the path to your server:
 
-        For Linux: ${jboss.home.name}/bin/jboss-cli.sh --connect --file=restore-configuration.cli
-        For Windows: ${jboss.home.name}\bin\jboss-cli.bat --connect --file=restore-configuration.cli
+        For Linux: ${jboss.home.name}/bin/jboss-cli.sh  --connect --file=remove-security-domain.cli
+        For Windows: ${jboss.home.name}\bin\jboss-cli.bat  --connect --file=remove-security-domain.cli
     This script removes the `test` queue from the `messaging` subsystem in the server configuration. You should see the following result when you run the script:
 
         The batch executed successfully
@@ -383,11 +470,12 @@ This quickstart requires additional configuration and deploys and runs different
 
 1. Be sure to [Add the Application Users](#add-the-application-users) as described above.
 2. Follow the steps above to [Configure the Server](#configure-the-server). Stop the server at the end of that step.
-3. To deploy the application to the ${product.name} server, right-click on the `ejb-security-interceptors` project and choose `Run As` --> `Run on Server`.
-4. To access the application, right-click on the `ejb-security-interceptors` project and choose `Run As` --> `Java Application`.
+3. To deploy the application to the ${product.name} server, right-click on the `${project.artifactId}` project and choose `Run As` --> `Run on Server`.
+4. To access the application, right-click on the `${project.artifactId}` project and choose `Run As` --> `Java Application`.
 5. Choose `RemoteClient - org.jboss.as.quickstarts.ejb_security_interceptors` and click `OK`.
 6. Review the output in the console window.
-7. Be sure to [Restore the Original Server Configuration](#restore-the-original-server-configuration) when you have completed testing this quickstart.
+7. To undeploy the project, right-click on the `${project.artifactId}` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
+8. Be sure to [Restore the Original Server Configuration](#restore-the-original-server-configuration) when you have completed testing this quickstart.
 
 ## Debug the Application
 

--- a/ejb-security-jaas/README.md
+++ b/ejb-security-jaas/README.md
@@ -213,7 +213,7 @@ When you access the application, you are presented with a browser login challeng
         For Linux: ${jboss.home.name}/bin/jboss-cli.sh --connect --file=enable-role-mappers.cli
         For Windows: ${jboss.home.name}\bin\jboss-cli.bat --connect --file=enable-role-mappers.cli
     You should see the following result when you run the script:
-    
+
         {
             "outcome" => "success",
             "response-headers" => {
@@ -292,6 +292,7 @@ You can also start the server and deploy the quickstarts or run the Arquillian t
 * You are presented with a browser login challenge. Enter the credentials as described above under [Access the Application](#access-the-application) to see the running application. Note that `Has admin permission` is `false`.
 * Leave the application running in JBoss Developer Studio. To configure the server to use the legacy role mappers, open a terminal, and run the `enable-role-mappers.cli` script as described above under [Access the Application](#access-the-application).
 * Go back to JBoss Developer Studio and click `Refresh the current page`. Note that `Has admin permission` is now `true`.
+* To undeploy the project, right-click on the `${project.artifactId}` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 * Be sure to [Restore the Server Configuration](#restore-the-server-configuration) when you have completed testing this quickstart.
 
 ## Debug the Application

--- a/ejb-security-programmatic-auth/README.md
+++ b/ejb-security-programmatic-auth/README.md
@@ -201,7 +201,7 @@ Enter `clean package wildfly:deploy` for the `Goals:` and click `Run`. This depl
             * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 * Enter `exec:exec` for the `Goals` and click `Run`.
-
+* To undeploy the project, right-click on the `${project.artifactId}` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 * Be sure to [Restore the Server Configuration](#restore-the-server-configuration) when you have completed testing this quickstart.
 
 ## Debug the Application

--- a/ejb-security/README.md
+++ b/ejb-security/README.md
@@ -18,7 +18,7 @@ This quickstart takes the following steps to implement EJB security:
 3. Add the `@RolesAllowed({ "guest" })` annotation to the EJB declaration to authorize access only to users with `guest` role access rights.
 4. Add the `@RolesAllowed({ "admin" })` annotation to the administrative method in the `SecuredEJB` to authorize access only
 to users with `admin` role access rights.
-5. Add an application user with `guest` role access rights to the EJB. This quickstart defines a user `quickstartUser` with 
+5. Add an application user with `guest` role access rights to the EJB. This quickstart defines a user `quickstartUser` with
 password `quickstartPwd1!` in the `guest` role. The `guest` role matches the allowed user role defined in the `@RolesAllowed`
 annotation in the EJB but it should not be granted access to the administrative method annotated with `RolesAllowed({"admin"})`.
 
@@ -83,7 +83,7 @@ You configure the security domain by running JBoss CLI commands. For your conven
     You should see the following result when you run the script:
 
         The batch executed successfully
-        process-state: reload-required 
+        process-state: reload-required
 
 5. Stop the ${product.name} server.
 
@@ -101,11 +101,11 @@ After stopping the server, open the `${jboss.home.name}/standalone/configuration
     domain that was set in the EJBs via annotation to the Elytron `ApplicationDomain` that will be responsible for authenticating
     and authorizing access to the EJBs.
 2. The `http-remoting-connector` in the `remoting` subsystem was updated to use the `application-sasl-authentication` factory:
-    
+
             <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm" sasl-authentication-factory="application-sasl-authentication"/>
 
     This config allows for the identity that was established at the connection level to be propagated to the components.
-    
+
 ## Start the Server
 
 1. Open a command prompt and navigate to the root of the ${product.name} directory.
@@ -138,13 +138,13 @@ Type this command to execute the client:
 When you run the `mvn exec:exec` command, you see the following output. Note there may be other log messages interspersed between these.
 
         * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-        
-        
+
+
         Successfully called secured bean, caller principal quickstartUser
-        
+
         Principal has admin permission: false
-        
-        
+
+
         * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 The username and credentials used to establish the connection to the application server are configured in the `wildfly-config.xml`
@@ -161,13 +161,13 @@ section but this time include the `admin` role as follows to grant `quickstartUs
 Running the client again should immediately reflect the new permission level of the user:
 
         * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-        
-        
+
+
         Successfully called secured bean, caller principal quickstartUser
-        
+
         Principal has admin permission: true
-        
-        
+
+
         * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 
@@ -212,6 +212,7 @@ You can also start the server and deploy the quickstarts or run the Arquillian t
 * To deploy the server project, right-click on the `${project.artifactId}` project and choose `Run As` --> `Run on Server`.
 * You are presented with a browser login challenge. Enter the credentials as described above to access and test the running application.
 * Be sure to [Restore the Server Configuration](#restore-the-server-configuration) when you have completed testing this quickstart.
+* To undeploy the project, right-click on the `${project.artifactId}` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 
 ## Debug the Application
 

--- a/helloworld-mbean/README.md
+++ b/helloworld-mbean/README.md
@@ -123,6 +123,8 @@ This quickstart consists of multiple projects and requires installation of the `
 3. Right-click on the `${project.artifactId}-service` project and choose `Run As` --> `Run on Server`.
 4. Right-click on the `${project.artifactId}-webapp` project and choose `Run As` --> `Run on Server`.
 5. [Start JConsole](#start-jconsole) and [Test the MBeans in JConsole](#test-the-mbeans-in-jconsole) as described above.
+6. To undeploy the web application, right-click on the `${project.artifactId}-wepapp` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
+7. To undeploy the web service, right-click on the `${project.artifactId}-service` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 
 ## Debug the Application
 

--- a/inter-app/README.md
+++ b/inter-app/README.md
@@ -89,6 +89,8 @@ This quickstart consists of multiple projects containing interdependencies on ea
     * `Batch` mode: In the `Servers` tab, right-click on the server and choose `Add and Remove`. If the `${project.artifactId}-app-shared`, `${project.artifactId}-app-appA`, and `${project.artifactId}-app-appB` projects are the only projects in the list, click `Add All`. Otherwise, use multi-select to select them and click `Add`. Then click `Finish`.
 3. Right-click on the `${project.artifactId}-app-appA` project and choose `Run As` --> `Run on Server`. A browser window appears that accesses the running `appA` application.
 4. Right-click on the `${project.artifactId}-app-appB` project and choose `Run As` --> `Run on Server`. A browser window appears that accesses the running `appB` application.
+5. To undeploy the `${project.artifactId}-app-appB`project, right-click on it and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
+6. To undeploy the `${project.artifactId}-app-appA`project, right-click on it and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 
 
 ## Debug the Application

--- a/jaxws-retail/README.md
+++ b/jaxws-retail/README.md
@@ -124,6 +124,7 @@ This quickstart requires that you first deploy the service, and then run the cli
     * Review the output in the console window. You should see the following message:
 
         `Jay Boss's discount is 10.00`
+3. To undeploy the project, right-click on the `${project.artifactId}-service` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 
 ## Debug the Application
 

--- a/kitchensink-ear/README.md
+++ b/kitchensink-ear/README.md
@@ -124,6 +124,7 @@ For this quickstart, follow the special instructions to build [Quickstarts Conta
 1. Right-click on the `${project.artifactId}-ear` subproject, and choose `Run As` --> `Run on Server`.
 2. Choose the server and click `Finish`.
 3. This starts the server, deploys the application, and opens a browser window that accesses the running application at <http://localhost:8080/kitchensink-ear-web>.
+4. To undeploy the project, right-click on the `${project.artifactId}-ear` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 
 
 ## Debug the Application

--- a/kitchensink-ml-ear/README.md
+++ b/kitchensink-ml-ear/README.md
@@ -198,7 +198,7 @@ For this quickstart, follow the special instructions to build [Quickstarts Conta
 1. Right-click on the `${project.artifactId}-web` subproject, and choose `Run As` --> `Run on Server`.
 2. Choose the server and click `Finish`.
 3. This starts the server, deploys the application, and opens a browser window that accesses the running application at <http://localhost:8080/${project.artifactId}-web/>.
-
+4. To undeploy the project, right-click on the `${project.artifactId}-web` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 
 ## Debug the Application
 

--- a/mail/README.md
+++ b/mail/README.md
@@ -164,6 +164,7 @@ _NOTE:_
 * Be sure to [Configure an SMTP Server on Your Local Machine](#configure-an-smtp-server-on-your-local-machine).
 * Be sure to configure the ${product.name} custom mail configuration as described above under [Configure the ${product.name} Server](#configure-the-server). Stop the server at the end of that step.
 * To deploy the server project, right-click on the `${project.artifactId}` project and choose `Run As` --> `Run on Server`.  A browser window appears that accesses the running application.
+* To undeploy the project, right-click on the `${project.artifactId}` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 * Be sure to [Remove the Mail Configuration](#remove-the-mail-configuration) when you have completed testing this quickstart.
 
 

--- a/resteasy-jaxrs-client/README.md
+++ b/resteasy-jaxrs-client/README.md
@@ -78,3 +78,4 @@ You can also start the server and deploy the quickstarts or run the Arquillian t
     * Right-click on the `${project.artifactId}` project and choose `Run As` --> `Maven build`.
     * Enter `clean package exec:java` for the `Goals:` and click `Run`.
     * The client output displays in the `Console` window.
+4. To undeploy the project, right-click on the `${project.artifactId}` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.

--- a/shopping-cart/README.md
+++ b/shopping-cart/README.md
@@ -191,6 +191,7 @@ This quickstart consists of multiple projects, so it deploys and runs differentl
 * Be sure to configure ${product.name} to suppress system exception logging as described above under [Configure the Server](#configure-the-server). Stop the server at the end of that step.
 * To deploy the server project, right-click on the `${project.artifactId}-server` project and choose `Run As` --> `Run on Server`.
 * To run the client, right-click on the `${project.artifactId}-client` project and choose `Run As` --> `Java Application`. In the `Select Java Application` window, choose `Client - org.jboss.as.quickstarts.client` and click `OK`. The client output displays in the `Console` window.
+* To undeploy the project, right-click on the `${project.artifactId}-server` project and choose `Run As` --> `Maven build`. Enter `wildfly:undeploy` for the `Goals` and click `Run`.
 * Be sure to [Restore the Server Configuration](#restore-the-server-configuration) when you have completed testing this quickstart.
 
 ## Debug the Application


### PR DESCRIPTION
@ctomc : This cherry-pick resulted in conflicts in the `ejb-security-interceptors` quickstart README file. There were so many differences, I just ended up copying the source from the README from the eap-quickstarts. If this is NOT what you want me to do, feel free to close this PR and create a different one. 