### PR TITLE
Add new custom HTTP mechanism quickstart

### DIFF
--- a/http-custom-mechanism/README.adoc
+++ b/http-custom-mechanism/README.adoc
@@ -1,0 +1,357 @@
+= http-custom-mechanism: Create a custom HTTP authorization mechanism
+:author: Darran Lofthouse
+:productName: WildFly
+:productNameFull: WildFly Application Server
+:jbossHomeName: WILDFLY_HOME
+:productVersion: 12
+:buildRequirements: Java 8.0 (Java SDK 1.8) or later and Maven 3.3.1 or later
+include::../shared-doc/attributes.adoc[]
+
+:level: Intermediate
+:technologies: EJB, Security
+:source: {githubRepoUrl}
+
+[abstract]
+The `http-custom-mechanism` quickstart demonstrates how to implement a custom HTTP authentication mechanism that can be registered with Elytron.
+
+:standalone-server-type: default
+:archiveType: war
+:archiveName: {artifactId}-webapp
+:includes-cli-scripts:
+
+== What is it?
+
+The `http-custom-mechanism` quickstart demonstrates how to implement a custom HTTP mechanism and then register it with Elytron. This makes it possible to override the configuration within the deployment to make use of this mechanism without requiring modifications to the deployment. This example makes use of custom HTTP headers to receive a clear text `username` and `password` and use them for authentication.
+
+WARNING: Generally you should avoid passing clear text passwords. It is only done here to simplify the example.
+
+This example consists of the following Maven projects.
+
+[cols="20%,80%",options="headers"]
+|===
+|Project |Description
+
+| `webapp`
+a| The project in the `webapp/` folder contains a deployable web application consisting of a secured servlet that is used to test the configuration. It generates the `{archiveName}.war` archive that is used to test the secured application.
+
+| `custom-module`
+a| This project contains the source for a custom HTTP authentication module that overrides the deployment configuration. It contains of the following Java classes and resources.
+
+* `CustomMechanismFactory`: This class implements `HttpServerAuthenticationMechanismFactory` and creates the new custom `HttpServerAuthenticationMechanism`.
+* `CustomHeaderHttpAuthenticationMechanism`: This class implements `HttpServerAuthenticationMechanism` and contains the source code for the custom mechanism processing. An `HttpServerRequest` object is passed to the `evaluateRequest` method. The mechanism processes the requests and uses one of the following callback methods on the request to indicate the outcome:
+
+** `authenticationComplete` - The mechanism successfully authenticated the request.
+** `authenticationFailed` - Authentication was attempted but failed.
+** `authenticationInProgress` - Authentication started but an additional round trip is needed.
+** `badRequest` - The authentication for this mechanism failed validation of the request.
+** `noAuthenticationInProgress` - The mechanism did not attempt any stage of authentication.
+
+
+* `org.wildfly.security.examples.CustomMechanismFactory`: This resource file contains a single line of text that names the custom mechanism factory class, which in this case is `org.jboss.as.quickstart.http_custom_mechanism.CustomMechanismFactory`.
+|===
+
+You will follow these basic steps to test this quickstart:
+
+. xref:add_the_application_user[Add] the application user.
+. xref:back_up_standalone_server_configuration[Back up] the server configuration before xref:start_the_eap_standalone_server[starting] the server.
+. xref:configure_the_application_security_domain[Configure] the application security domain.
+. xref:build_and_deploy_the_quickstart[Build and deploy] the application.
+. xref:test_the_secured_servlet[Test] the secured servlet deployment.
+. xref:build_the_custom_http_mechanism[Build] the custom HTTP mechanism module and xref:add_the_custom_module_to_the_server[add] it to the server.
+. xref:configure_the_server_to_use_the_custom_module[Configure] the server to override the deployment and use the custom module.
+. xref:test_the_secured_servlet_using_the_custom_mechnism[Test] the secured servlet using the custom mechanism
+
+//*************************************************
+// Add System Requirements
+//*************************************************
+// == System Requirements
+include::../shared-doc/system-requirements.adoc[leveloffset=+1]
+
+//*************************************************
+// Add Use of JBoss Home Name
+//*************************************************
+// == Use of {jbossHomeName}
+include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
+
+
+[[add_the_application_user]]
+== Add the Application User
+
+Use the `add-user` utility script to add the following user to the `ApplicationRealm`.
+
+[cols="20%,20%,20%,40%",options="headers"]
+|===
+|UserName |Realm |Password |Roles
+
+|testuser |ApplicationRealm |Password1! |Users
+|===
+
+To add the application users open a terminal and type the following command.
+
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/add-user.sh -a -u 'testuser' -p 'Password1!' -g 'Users'
+----
+
+NOTE: For Windows, use the `__{jbossHomeName}__\bin\add-user.bat` script.
+
+If you prefer, you can use the `add-user` utility interactively.
+For an example of how to use the `add-user` utility, see the instructions located here: link:{addApplicationUserDocUrl}[Add an Application User].
+
+//*************************************************
+// Back up the server configuration files
+//*************************************************
+// == Back Up the {productName} Standalone Server Configuration
+include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
+
+//*************************************************
+// Start the server with the default profile
+//*************************************************
+// == Start the {productName} Standalone Server
+include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
+
+[[configure_the_application_security_domain]]
+== Configure the Application Security Domain
+
+By default, the deployed application uses the `other` security domain. You need to map this security domain to an Elytron HTTP authentication factory. For your convenience, this quickstart includes the command to configure the security domain in the `configure-security-domain.cli` script located in the root directory of this quickstart.
+
+In a terminal, navigate to the root directory of this quickstart, and run the following command, replacing `__{jbossHomeName}__` with the path to your server.
+
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=configure-security-domain.cli
+----
+
+You should see the following result.
+
+[source,options="nowrap"]
+----
+{"outcome" => "success"}
+----
+
+//*************************************************
+// Build and deploy the quickstart JAR
+//*************************************************
+// == Build and Deploy the Quickstart
+include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
+
+// These messages appear in the server log.
+
+[source,options="nowrap"]
+----
+WFLYUT0021: Registered web context: '/http-custom-mechanism-webapp' for server 'default-server'
+WFLYSRV0010: Deployed "http-custom-mechanism-webapp.war" (runtime-name : "http-custom-mechanism-webapp.war")
+----
+
+[[test_the_secured_servlet]]
+== Test the Secured Servlet
+
+Before you continue, you must test the secured servlet deployment to make sure it is working. Since this application uses a standard mechanism, it could be tested using a browser. However, after you implement the custom HTTP mechanism, the browser will not understand the request, so it is better to test the call using a client that will allow you to manipulate the headers yourself.
+
+Issue the following command to test the deployment.
+
+[source,options="nowrap"]
+----
+curl -v http://localhost:8080/http-custom-mechanism-webapp/secured -u testuser:Password1!
+----
+
+You should see the HTTP result `HTTP/1.1 200 OK`, along with some header information, then followed by this output.
+
+[source,xml,options="nowrap"]
+----
+<html>
+ <head><title>Secured Servlet</title></head>
+ <body>
+   <h1>Secured Servlet</h1>
+   <p>
+Current Principal 'testuser'    </p>
+ </body>
+</html>
+----
+
+[[build_the_custom_http_mechanism]]
+== Build the Custom HTTP Mechanism JAR
+
+Once the secured servlet is deployed and you have tested it to make sure it is working, you need to build the module for the custom HTTP mechanism.
+
+. Open a terminal and navigate to the `custom-module/` folder located in the root directory of this quickstart.
+. Type the following command to build the custom HTTP mechanism.
++
+[source,subs="attributes+",options="nowrap"]
+----
+$ mvn clean install
+----
+
+This creates the `target/{artifactId}.jar` file in the quickstart `custom-module/` directory.
+
+You should see `[INFO] BUILD SUCCESS` in the console output.
+
+[[add_the_custom_module_to_the_server]]
+== Add the Custom Module to the Server
+
+Now you must add the `{artifactId}.jar` as a custom module to the {productName} server. For your convenience, this quickstart includes the command to add the module in the `add-custom-module.cli` script located in the `custom-module/` directory of this quickstart.
+
+In a terminal, navigate to the `custom-module/` folder located in the root directory of this quickstart, and run the following command, replacing `__{jbossHomeName}__` with the path to your server.
+
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=add-custom-module.cli
+----
+
+NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat` script.
+
+This creates the custom `__{jbossHomeName}__/modules/modules/org/jboss/as/quickstart/http_custom_mechanism/main` folder, then copies in the `{artifactId}.jar` file and creates the required `module.xml` file.
+
+You can verify the module structure in your file manager.
+
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+.
+└── __{jbossHomeName}__
+    └── modules
+        └── org
+            └── jboss
+                └── as
+                    └── quickstart
+                        └── http_custom_mechanism
+                            └── main
+                                ├── {artifactId}.jar
+                                └── module.xml
+----
+
+[[configure_the_server_to_use_the_custom_module]]
+== Configure the Server to Use the Custom Module
+
+You configure the server to use the custom module by running CLI commands. For your convenience, this quickstart batches the commands into a `configure-elytron.cli` script provided in the root directory of this quickstart.
+
+. Before you begin, make sure you have done the following:
+
+* xref:back_up_standalone_server_configuration[Back up the {productName} standalone server configuration] as described above.
+* xref:start_the_eap_standalone_server[Start the {productName} server with the standalone default profile] as described above.
+
+. Review the `configure-elytron.cli` file in the root of this quickstart directory. This script adds the configuration that enables Elytron security fto use the custom HTTP module created by this quickstart . Comments in the script describe the purpose of each block of commands.
+. Open a new terminal, navigate to the root directory of this quickstart, and run the following command, replacing `__{jbossHomeName}__` with the path to your server.
++
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=configure-elytron.cli
+----
++
+NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat` script.
+
++
+You should see the following result when you run the script.
++
+[source,options="nowrap"]
+----
+The batch executed successfully
+process-state: reload-required
+----
+
+. Stop the {productName} server.
+
+[[review_the_modified_server_configuration]]
+== Review the Modified Server Configuration
+
+After stopping the server, open the `__{jbossHomeName}__/standalone/configuration/standalone.xml` file and review the changes.
+
+. The following `service-loader-http-server-mechanism-factory` was added to the `http` element of the `elytron` subsystem:
++
+[source,xml,options="nowrap"]
+----
+<http>
+    <http-authentication-factory name="custom-mechanism" http-server-mechanism-factory="custom-factory" security-domain="ApplicationDomain">
+        <mechanism-configuration>
+            <mechanism mechanism-name="CUSTOM_MECHANISM"/>
+          </mechanism-configuration>
+    </http-authentication-factory>
+    ...
+    <service-loader-http-server-mechanism-factory name="custom-factory" module="org.jboss.as.quickstart.http_custom_mechanism.custom-http-mechanism"/>
+</http>
+----
+
+. The `application-security-domain` in the `undertow` subsystem was updated to use the `custom-mechanism` authentication factory with `override-deployment-config` set to `true`.
++
+[source,xml,options="nowrap"]
+----
+<application-security-domains>
+    <application-security-domain name="other" http-authentication-factory="custom-mechanism" override-deployment-config="true"/>
+</application-security-domains>
+----
+
+[[test_the_secured_servlet_using_the_custom_mechnism]]
+== Test the Secured Servlet Using the Custom Mechanism
+
+Now you need to test the override of the deployment with the custom HTTP mechanism.
+
+If you use the same `curl` command as when you xref:test_the_secured_servlet[tested the servlet before implementing the custom HTTP mechanism], it will fail with the following error.
+[source,options="nowrap"]
+----
+< HTTP/1.1 401 Unauthorized
+....
+< X-MESSAGE: Please resubmit the request with a username specified using the X-USERNAME and a password specified using the X-PASSWORD header.
+----
+
+This is because the authentication mechanism rejected the call and subsequently added a header describing how to do authentication. You must modify the curl command to the following.
+
+
+[source,options="nowrap"]
+----
+curl -v http://localhost:8080/http-custom-mechanism-webapp/secured -H "X-USERNAME:testuser" -H "X-PASSWORD:password"
+
+----
+
+You should see the HTTP result `HTTP/1.1 200 OK`, along with some header information, then followed by this output.
+
+[source,xml,options="nowrap"]
+----
+<html>
+ <head><title>Secured Servlet</title></head>
+ <body>
+   <h1>Secured Servlet</h1>
+   <p>
+Current Principal 'testuser'    </p>
+ </body>
+</html>
+----
+
+//*************************************************
+// Undeploy the quickstart archive
+//*************************************************
+// == Undeploy the Quickstart
+include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
+
+//******************************************************
+// Restore the standalone server configuration manually
+//******************************************************
+// == Restore the {productName} Standalone Server Configuration Manually
+include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
+
+//*************************************************
+// Add JBoss Developer Studio instructions
+//*************************************************
+// == Run the Quickstart in Red Hat JBoss Developer Studio or Eclipse
+////
+
+Not how to do curl commands in JBDS
+// include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
+
+// Additional JBoss Developer Studio instructions
+* Make sure you xref:add_the_application_user[Add the Application User] as described above.
+* Make sure you configure the security domain on the server by running the JBoss CLI script as described above under xref:configure_the_application_security_domain[Configure the Application Security Domain].
+* Right-click on the *{artifactId}* project and choose *Run As* -> *Maven build*.
+Enter `clean package wildfly:deploy` for the *Goals* and click *Run*. This deploys the `{artifactId}` JAR to the {productName} server.
+* BUILD AND ADD the MODULE, configure, test
+----
+
+* To undeploy the project, right-click on the *{artifactId}* project and choose *Run As* -> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
+
+* Make sure you xref:restore_the_server_configuration[restore the {productName} standalone server configuration] when you have completed testing this quickstart.
+
+////
+
+//*************************************************
+// Add info to debug the application
+//*************************************************
+// == Debug the Application
+include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/http-custom-mechanism/configure-elytron.cli
+++ b/http-custom-mechanism/configure-elytron.cli
@@ -1,0 +1,22 @@
+# Batch script to configure Elytron to use the new custom HTTP authentication mechanism.
+
+# Start batching commands
+batch
+
+# Add the resource to discover the factory implementation for the custom module.
+/subsystem=elytron/service-loader-http-server-mechanism-factory=custom-factory:add(module=org.jboss.as.quickstart.http_custom_mechanism.custom-http-mechanism)
+
+# Add an `http-authentication-factory` to the mechanism factory to a `security-domain` that will be used for the authentication.
+/subsystem=elytron/http-authentication-factory=custom-mechanism:add(http-server-mechanism-factory=custom-factory,security-domain=ApplicationDomain,mechanism-configurations=[{mechanism-name=CUSTOM_MECHANISM}])
+
+# Add the http-authentication-factory to the mechanism factory to a security-domain that will be used for the authentication.
+/subsystem=undertow/application-security-domain=other:write-attribute(name=http-authentication-factory,value=custom-mechanism)
+
+# Update the application-security-domain resource to use this new http-authentication-factory.
+/subsystem=undertow/application-security-domain=other:write-attribute(name=override-deployment-config,value=true)
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+reload

--- a/http-custom-mechanism/configure-security-domain.cli
+++ b/http-custom-mechanism/configure-security-domain.cli
@@ -1,0 +1,12 @@
+# Batch script to configure Elytron to use the new custom HTTP authentication mechanism.
+
+# Start batching commands
+batch
+#  Map the application security domain to an Elytron HTTP authentication factory.
+/subsystem=undertow/application-security-domain=other:add(http-authentication-factory=application-http-authentication)
+
+# Run the batch command
+run-batch
+
+# Reload the server configuration
+reload

--- a/http-custom-mechanism/custom-module/add-custom-module.cli
+++ b/http-custom-mechanism/custom-module/add-custom-module.cli
@@ -1,0 +1,3 @@
+# Add the custom module to the server
+
+module add --name=org.jboss.as.quickstart.http_custom_mechanism.custom-http-mechanism --resources=target/http-custom-mechanism.jar --dependencies=org.wildfly.security.elytron,javax.api

--- a/http-custom-mechanism/custom-module/pom.xml
+++ b/http-custom-mechanism/custom-module/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2017, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on afn "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly.quickstarts</groupId>
+        <artifactId>quickstart-parent</artifactId>
+        <version>12.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>http-custom-mechanism</artifactId>
+    <packaging>jar</packaging>
+    <name>${qs.name.prefix} http-custom-mechanism</name>
+    <description>This project demonstrates how to implement a custom HTTP authentication mechanism</description>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <!-- Set the name of the JAR, used as the context root when the app is deployed -->
+        <finalName>${project.artifactId}</finalName>
+    </build>
+
+</project>

--- a/http-custom-mechanism/custom-module/remove-custom-module.cli
+++ b/http-custom-mechanism/custom-module/remove-custom-module.cli
@@ -1,0 +1,4 @@
+# Remove the custom module from the server
+
+module remove --name=org.jboss.as.quickstart.http_custom_mechanism
+

--- a/http-custom-mechanism/custom-module/src/main/java/org/jboss/as/quickstart/http_custom_mechanism/CustomHeaderHttpAuthenticationMechanism.java
+++ b/http-custom-mechanism/custom-module/src/main/java/org/jboss/as/quickstart/http_custom_mechanism/CustomHeaderHttpAuthenticationMechanism.java
@@ -1,0 +1,147 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstart.http_custom_mechanism;
+
+import static org.jboss.as.quickstart.http_custom_mechanism.CustomMechanismFactory.CUSTOM_NAME;
+
+import java.io.IOException;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
+
+import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
+import org.wildfly.security.auth.callback.EvidenceVerifyCallback;
+import org.wildfly.security.auth.callback.IdentityCredentialCallback;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
+import org.wildfly.security.http.HttpServerMechanismsResponder;
+import org.wildfly.security.http.HttpServerRequest;
+import org.wildfly.security.http.HttpServerResponse;
+import org.wildfly.security.password.interfaces.ClearPassword;
+
+/**
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class CustomHeaderHttpAuthenticationMechanism implements HttpServerAuthenticationMechanism {
+
+    /*
+     * As the mechanism is instantiated by a factory it is generally a good practice to minimise visibility.
+     */
+
+    private static final String USERNAME_HEADER = "X-USERNAME";
+    private static final String PASSWORD_HEADER = "X-PASSWORD";
+    private static final String MESSAGE_HEADER = "X-MESSAGE";
+
+    private static final HttpServerMechanismsResponder RESPONDER = new HttpServerMechanismsResponder() {
+        /*
+         * As the responses are always the same a static instance of the responder can be used.
+         */
+
+        public void sendResponse(HttpServerResponse response) throws HttpAuthenticationException {
+            response.addResponseHeader(MESSAGE_HEADER, "Please resubit the request with a username specified using the X-USERNAME and a password specified using the X-PASSWORD header.");
+            response.setStatusCode(401);
+        }
+    };
+
+    private final CallbackHandler callbackHandler;
+
+    CustomHeaderHttpAuthenticationMechanism(final CallbackHandler callbackHandler) {
+        this.callbackHandler = callbackHandler;
+    }
+
+    public void evaluateRequest(HttpServerRequest request) throws HttpAuthenticationException {
+        final String username = request.getFirstRequestHeaderValue(USERNAME_HEADER);
+        final String password = request.getFirstRequestHeaderValue(PASSWORD_HEADER);
+
+        if (username == null || username.length() == 0 || password == null || password.length() == 0) {
+            /*
+             * This mechanism is not performing authentication at this time however other mechanisms may be in use concurrently and could succeed so we register
+             */
+            request.noAuthenticationInProgress(RESPONDER);
+            return;
+        }
+
+        /*
+         * The first two callbacks are used to authenticate a user using the supplied username and password.
+         */
+
+        NameCallback nameCallback = new NameCallback("Remote Authentication Name", username);
+        nameCallback.setName(username);
+        final PasswordGuessEvidence evidence = new PasswordGuessEvidence(password.toCharArray());
+        EvidenceVerifyCallback evidenceVerifyCallback = new EvidenceVerifyCallback(evidence);
+
+        try {
+            callbackHandler.handle(new Callback[] { nameCallback, evidenceVerifyCallback });
+        } catch (IOException | UnsupportedCallbackException e) {
+            throw new HttpAuthenticationException(e);
+        }
+
+        if (evidenceVerifyCallback.isVerified() == false) {
+            request.authenticationFailed("Username / Password Validation Failed", RESPONDER);
+        }
+
+        /*
+         * This next callback is optional, as we have the users password we can associate it with the private credentials of the
+         * SecurityIdentity so it can be used again later.
+         */
+
+        try {
+            callbackHandler.handle(new Callback[] {new IdentityCredentialCallback(new PasswordCredential(ClearPassword.createRaw(ClearPassword.ALGORITHM_CLEAR, password.toCharArray())), true)});
+        } catch (IOException | UnsupportedCallbackException e) {
+            throw new HttpAuthenticationException(e);
+        }
+
+        /*
+         * The next callback is important, although at this stage they are authenticated an authorization check is now needed to
+         * ensure the user has the LoginPermission granted allowing them to login.
+         */
+
+        AuthorizeCallback authorizeCallback = new AuthorizeCallback(username, username);
+
+        try {
+            callbackHandler.handle(new Callback[] {authorizeCallback});
+
+            /*
+             * Finally this example is very simple so we can deduce the outcome from the callbacks so far, however some
+             * mechanisms may still go on to take additional information into account and make an alternative decision so a
+             * callback is required to report the final outcome.
+             */
+
+            if (authorizeCallback.isAuthorized()) {
+                callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.SUCCEEDED });
+                request.authenticationComplete();
+            } else {
+                callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.FAILED });
+                request.authenticationFailed("Authorization check failed.", RESPONDER);
+            }
+            return;
+        } catch (IOException | UnsupportedCallbackException e) {
+            throw new HttpAuthenticationException(e);
+        }
+    }
+
+    public String getMechanismName() {
+        return CUSTOM_NAME;
+    }
+
+}

--- a/http-custom-mechanism/custom-module/src/main/java/org/jboss/as/quickstart/http_custom_mechanism/CustomMechanismFactory.java
+++ b/http-custom-mechanism/custom-module/src/main/java/org/jboss/as/quickstart/http_custom_mechanism/CustomMechanismFactory.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstart.http_custom_mechanism;
+
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+
+import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
+import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
+
+public class CustomMechanismFactory implements HttpServerAuthenticationMechanismFactory {
+
+    /*
+     * This example uses service loader discovery to locate the factory, if a Provider was used instead visibility could be
+     * reduced to be only accessible by the provider.
+     */
+
+    static final String CUSTOM_NAME = "CUSTOM_MECHANISM";
+
+    public HttpServerAuthenticationMechanism createAuthenticationMechanism(String name, Map<String, ?> properties, CallbackHandler handler) throws HttpAuthenticationException {
+        if (CUSTOM_NAME.equals(name)) {
+            /*
+             * The properties could be used at this point to further customise the behaviour of the mechanism.
+             */
+            return new CustomHeaderHttpAuthenticationMechanism(handler);
+        }
+
+        return null;
+    }
+
+    public String[] getMechanismNames(Map<String, ?> properties) {
+        /*
+         * At this stage the properties could be queried to only return a mechanism if compatible with the properties provided.
+         */
+        return new String[] { CUSTOM_NAME };
+    }
+
+}

--- a/http-custom-mechanism/custom-module/src/main/resources/META-INF/services/org.wildfly.security.http.HttpServerAuthenticationMechanismFactory
+++ b/http-custom-mechanism/custom-module/src/main/resources/META-INF/services/org.wildfly.security.http.HttpServerAuthenticationMechanismFactory
@@ -1,0 +1,1 @@
+org.jboss.as.quickstart.http_custom_mechanism.CustomMechanismFactory

--- a/http-custom-mechanism/pom.xml
+++ b/http-custom-mechanism/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2017, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on afn "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly.quickstarts</groupId>
+        <artifactId>quickstart-parent</artifactId>
+        <version>12.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>http-custom-mechanism</artifactId>
+    <packaging>pom</packaging>
+    <name>${qs.name.prefix} http-custom-mechanism</name>
+    <description>This project demonstrates how to implement a custom HTTP authentication mechanism</description>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <modules>
+        <module>webapp</module>
+    </modules>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <!-- Set the name of the WAR, used as the context root when the app is deployed -->
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.wildfly.maven.plugin}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/http-custom-mechanism/webapp/pom.xml
+++ b/http-custom-mechanism/webapp/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2017, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on afn "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly.quickstarts</groupId>
+        <artifactId>http-custom-mechanism</artifactId>
+        <version>12.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>http-custom-mechanism-webapp</artifactId>
+    <packaging>war</packaging>
+    <name>${qs.name.prefix} http-custom-mechanism - webapp</name>
+    <description>This project demonstrates how to implement a custom HTTP authentication mechanism</description>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/http-custom-mechanism/webapp/src/main/java/org/jboss/as/quickstart/http_custom_mechanism/SecuredServlet.java
+++ b/http-custom-mechanism/webapp/src/main/java/org/jboss/as/quickstart/http_custom_mechanism/SecuredServlet.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstart.http_custom_mechanism;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.Principal;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HttpMethodConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A simple secured HTTP servlet.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@WebServlet("/secured")
+@ServletSecurity(httpMethodConstraints = { @HttpMethodConstraint(value = "GET", rolesAllowed = { "Users" }) })
+public class SecuredServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try (PrintWriter writer = resp.getWriter()) {
+            writer.println("<html>");
+            writer.println("  <head><title>Secured Servlet</title></head>");
+            writer.println("  <body>");
+            writer.println("    <h1>Secured Servlet</h1>");
+            writer.println("    <p>");
+            writer.print(" Current Principal '");
+            Principal user = req.getUserPrincipal();
+            writer.print(user != null ? user.getName() : "NO AUTHENTICATED USER");
+            writer.print("'");
+            writer.println("    </p>");
+            writer.println("  </body>");
+            writer.println("</html>");
+        }
+    }
+
+}

--- a/http-custom-mechanism/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/http-custom-mechanism/webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2016 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+   metadata-complete="false">
+
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>Simple Realm</realm-name>
+    </login-config>
+
+</web-app>

--- a/http-custom-mechanism/webapp/src/main/webapp/index.html
+++ b/http-custom-mechanism/webapp/src/main/webapp/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <h2>Hello World!</h2>
+    <a href="./secured">Access Secured Servlet</a>
+  </body>
+</html>


### PR DESCRIPTION
@ctomc: This was adapted from @darranl  blog: http://darranl.blogspot.com/

I used his source, which consisted of multiple projects and packaged so that is could all be done from the one `http-custom-mechanism` quickstart. I also changed the instructions a bit to flow with the steps you take to deploy, test, configure, retest.

I do need to add some details about the classes in the README file, but the basics are there. Let me know what you think.