### PR TITLE
jax-rs related test fixes to run on JDK 11

### DIFF
--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -101,17 +101,23 @@
 
         <!-- Optional, but highly recommended, Arquillian allows you to test enterprise code
               such as EJBs and Transactional(JTA) JPA from JUnit/TestNG -->
-         <dependency>
-             <groupId>org.jboss.arquillian.junit</groupId>
-             <artifactId>arquillian-junit-container</artifactId>
-             <scope>test</scope>
-         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-         <dependency>
-             <groupId>org.jboss.arquillian.protocol</groupId>
-             <artifactId>arquillian-protocol-servlet</artifactId>
-             <scope>test</scope>
-         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/managed-executor-service/pom.xml
+++ b/managed-executor-service/pom.xml
@@ -101,6 +101,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Import the Common Annotations API (JSR-250), we use provided scope
             as the API is included in JBoss EAP -->
         <dependency>


### PR DESCRIPTION
jax-rs related test fixes to run on JDK 11

QS identified via:
```bash
for i in `git grep jboss-jaxrs-api | cut -d: -f1`; do
    mvn -f $i -Dmaven.compiler.target=10 -Dmaven.compiler.source=10 clean install wildfly:deploy wildfly:undeploy
    read -n 1 -p "compiled and deployed $i, continue?"
    mvn -f $i verify -Parq-remote
    read -n 1 -p "arq-remote checked on $i, continue?"
done
```