### PR TITLE
Documentation clarification and script fix

### DIFF
--- a/http-custom-mechanism/README.adoc
+++ b/http-custom-mechanism/README.adoc
@@ -67,6 +67,27 @@ include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=
 // Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
+[[assign_role_to_the_application_user]]
+== Assign the appropriate Role to the Application User
+
+By default, the application user created in the "Add the application user" step will have no roles assigned. However, users must have a role of `Users` assigned to them in order to access the web appplication in this quickstart. In order to assign this role, edit the role assignment file:
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ vi __{jbossHomeName}__/standalone/configuration/application-users.properties
+----
+
+Add the following line at the end of the file:
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+quickstartUser=Users
+----
+
+Do the same for the domain configuration file:
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ vi __{jbossHomeName}__/domain/configuration/application-users.properties
+----
+
 [[configure_the_application_security_domain]]
 == Configure the Application Security Domain
 

--- a/http-custom-mechanism/custom-module/remove-custom-module.cli
+++ b/http-custom-mechanism/custom-module/remove-custom-module.cli
@@ -1,5 +1,4 @@
 # Remove the custom module from the server
 
-#module remove --name=org.jboss.as.quickstart.http_custom_mechanism.http-custom-mechanism
 module remove --name=org.jboss.as.quickstart.http_custom_mechanism.custom-http-mechanism
 

--- a/http-custom-mechanism/custom-module/remove-custom-module.cli
+++ b/http-custom-mechanism/custom-module/remove-custom-module.cli
@@ -1,4 +1,5 @@
 # Remove the custom module from the server
 
-module remove --name=org.jboss.as.quickstart.http_custom_mechanism
+#module remove --name=org.jboss.as.quickstart.http_custom_mechanism.http-custom-mechanism
+module remove --name=org.jboss.as.quickstart.http_custom_mechanism.custom-http-mechanism
 


### PR DESCRIPTION
This pull request:

- Documents the need to assign role 'Users' to the quickstart user in order for it to be able to access the servlet via curl
- fixes the module name in remove-custom-module.cli so that it matches that of the added module