### PR TITLE
[WFLY-11035] ejb-remote quickstart fat client jar is not multi-release

### DIFF
--- a/ejb-remote/client/pom.xml
+++ b/ejb-remote/client/pom.xml
@@ -92,6 +92,9 @@
                         <manifest>
                             <mainClass>org.jboss.as.quickstarts.ejb.remote.client.RemoteEJBClient</mainClass>
                         </manifest>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
* Adding Multi-Release: true to configuration for Maven Assembly Plugin for ejb-remote-client