### PR TITLE
JBEAP-15215,WFLY-11209: Change instructions for jaxws-* quickstarts to build and deploy a JAR instead of a WAR; add client class to JBDS instructions for those quickstarts where missing

### DIFF
--- a/jaxws-addressing/README.adoc
+++ b/jaxws-addressing/README.adoc
@@ -9,7 +9,7 @@ include::../shared-doc/attributes.adoc[]
 The `jaxws-addressing` quickstart is a working example of the web service using WS-Addressing.
 
 :standalone-server-type: default
-:archiveType: war
+:archiveType: jar
 // Override the archive directory
 :archiveDir: {artifactId}/service/target
 // Override the archive name
@@ -88,6 +88,7 @@ This is a known Eclipse issue. For more information, see Eclipse Bugzilla - http
 ** You also see the "404 - Not Found" error in the application window. This is because there is no user interface for this quickstart. You can ignore this error.
 . To access the application:
 ** Right-click on the *{artifactId}-client* subproject and choose *Run As* –> *Java Application*.
+** Choose the *AddressingClient* class and click *OK*.
 ** You should see the following message in the *Console* tab:
 +
 [source,options="nowrap"]

--- a/jaxws-ejb/README.adoc
+++ b/jaxws-ejb/README.adoc
@@ -9,7 +9,7 @@ include::../shared-doc/attributes.adoc[]
 The `jaxws-ejb` quickstart is a working example of the web service endpoint created from an EJB.
 
 :standalone-server-type: default
-:archiveType: war
+:archiveType: jar
 // Override the archive directory
 :archiveDir: {artifactId}/service/target
 // Override the archive name
@@ -76,6 +76,7 @@ For this quickstart, follow the special instructions to link:{useEclipseDeployJa
 ** This starts the server and deploys the service to the server.
 . To access the application:
 ** Right-click on the *{artifactId}-client* subproject and choose *Run As* –> *Java Application*.
+** Choose the *Client* class and click *OK*.
 ** You should see the following message in the *Console* tab:
 +
 [source,options="nowrap"]

--- a/jaxws-pojo/README.adoc
+++ b/jaxws-pojo/README.adoc
@@ -9,7 +9,7 @@ include::../shared-doc/attributes.adoc[]
 The `jaxws-pojo` quickstart is a working example of the web service endpoint created from a POJO.
 
 :standalone-server-type: default
-:archiveType: war
+:archiveType: jar
 // Override the archive directory
 :archiveDir: {artifactId}/service/target
 // Override the archive name
@@ -76,6 +76,7 @@ For this quickstart, follow the special instructions to link:{useEclipseDeployJa
 ** This starts the server and deploys the service to the server.
 . To access the application:
 ** Right-click on the *{artifactId}-client* subproject and choose *Run As* –> *Java Application*.
+** Choose the *Client* class and click *OK*.
 ** You should see the following message in the *Console* tab:
 +
 [source,options="nowrap"]

--- a/jaxws-retail/README.adoc
+++ b/jaxws-retail/README.adoc
@@ -9,7 +9,7 @@ include::../shared-doc/attributes.adoc[]
 The `jaxws-retail` quickstart is a working example of a simple web service endpoint.
 
 :standalone-server-type: default
-:archiveType: war
+:archiveType: jar
 // Override the archive directory
 :archiveDir: {artifactId}/service/target
 // Override the archive name


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11209
JIRA: https://issues.jboss.org/browse/JBEAP-15215

@emmartins : This fix needs to be ported to 7.2.0.GA