### PR TITLE
Update quickstart source GitHub repo URL for CD releases

### DIFF
--- a/shared-doc/attributes.adoc
+++ b/shared-doc/attributes.adoc
@@ -22,7 +22,7 @@ ifdef::EAPCDRelease[]
 :productName: JBoss EAP Continuous Delivery
 :productNameFull: JBoss Enterprise Application Platform continuous delivery
 :productVersion: 15
-:githubRepoUrl: https://github.com/jboss-developer/jboss-eap-quickstarts/openshift/
+:githubRepoUrl: https://github.com/jboss-developer/jboss-eap-quickstarts/tree/openshift/
 :jbossHomeName: EAP_HOME
 :DocInfoProductNameURL: jboss_enterprise_application_platform_continuous_delivery
 :DocInfoProductName: JBoss Enterprise Application Platform Continuous Delivery


### PR DESCRIPTION
@emmartins : This fix needs to be applied to the CD15 quickstart repo.