### PR TITLE
[WFLY-11909] jaxws-tools-maven-plugin configuration fixes

### DIFF
--- a/jaxws-retail/service/pom.xml
+++ b/jaxws-retail/service/pom.xml
@@ -84,7 +84,7 @@
                     <wsdls>
                         <wsdl>${basedir}/src/main/webapp/WEB-INF/wsdl/ProfileMgmtService.wsdl</wsdl>
                     </wsdls>
-                    <fork>true</fork>
+                    <fork>false</fork>
                     <extension>true</extension>
                     <verbose>false</verbose>
                     <endpointClass></endpointClass>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-11909
Please note this PR only fixes plugin config for Windows with JDK8, JDK11 needs a plugin update or java command in PATH.