### PR TITLE
[WFLY-11909] upgrade jaxws-tools-maven-plugin to version 1.2.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <!-- other plug-in versions -->
         <version.com.mycyla.license>3.0</version.com.mycyla.license>
         <version.checkstyle>8.5</version.checkstyle>
-        <version.jaxws-tools-maven-plugin>1.2.2.Final</version.jaxws-tools-maven-plugin>
+        <version.jaxws-tools-maven-plugin>1.2.3.Final</version.jaxws-tools-maven-plugin>
         <!-- Explicitly declaring the source encoding eliminates the following
             message: [WARNING] Using platform encoding (UTF-8 actually) to copy
             filtered resources, i.e. build is platform dependent! -->


### PR DESCRIPTION
Issue:  https://issues.jboss.org/browse/WFLY-11909
The issue's 2nd PR, upgrades the plugin with proper support for Windows OS with JDK 11