### PR TITLE
[WFLY-12141] Move import of javaee8-with-tools bom back to quickstart…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- importing the javaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-javaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- import the internal Quickstarts BOM, provides dependency management in sync with server -->
             <dependency>
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-quickstarts-bom</artifactId>


### PR DESCRIPTION
…s parent
Issue: https://issues.jboss.org/browse/WFLY-12141
Followup of https://github.com/wildfly/boms/pull/55 