### PR TITLE
[WFLY-12797/JBEAP-17133] adding elements based on XSD for not having errors in code ready

### DIFF
--- a/jts/application-component-2/src/main/resources/META-INF/jboss-ejb3.xml
+++ b/jts/application-component-2/src/main/resources/META-INF/jboss-ejb3.xml
@@ -19,15 +19,17 @@
                xmlns="http://java.sun.com/xml/ns/javaee"
                xmlns:iiop="urn:iiop"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
-                  http://java.sun.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd
-                  urn:iiop http://www.jboss.org/j2ee/schema/jboss-ejb-iiop_1_0.xsd"
+               xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_1.xsd
+                  http://java.sun.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_1.xsd
+                  urn:iiop http://www.jboss.org/j2ee/schema/jboss-ejb-iiop_1_2.xsd"
                version="3.1"
                impl-version="2.0">
     <assembly-descriptor>
         <iiop:iiop>
             <ejb-name>InvoiceManagerEJBImpl</ejb-name>
+            <iiop:ejb-name>InvoiceManagerEJBImpl</iiop:ejb-name>
             <iiop:binding-name>jts-quickstart/InvoiceManagerEJBImpl</iiop:binding-name>
+            <iiop:ior-security-config></iiop:ior-security-config>
         </iiop:iiop>
     </assembly-descriptor>
 </jboss:ejb-jar>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12797

The changes in xml descriptor of `jts` quickstart to avoid errors in Code Ready/Eclipse