### PR TITLE
[WFLY-12797] removing xsi schema location

### DIFF
--- a/jts/application-component-2/src/main/resources/META-INF/jboss-ejb3.xml
+++ b/jts/application-component-2/src/main/resources/META-INF/jboss-ejb3.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xsd>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
@@ -19,9 +20,6 @@
                xmlns="http://java.sun.com/xml/ns/javaee"
                xmlns:iiop="urn:iiop"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
-                  http://java.sun.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd
-                  urn:iiop http://www.jboss.org/j2ee/schema/jboss-ejb-iiop_1_0.xsd"
                version="3.1"
                impl-version="2.0">
     <assembly-descriptor>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-12797

Changes in jts quickstart to remove errors in Code Ready. Removed xsi schema location and iiop elements.