### PR TITLE
WFLY-12864: Update CodeReady Studio correct name in Quickstarts docs.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -221,9 +221,9 @@ $ mvn wildfly:undeploy
 ----
 
 [[run_the_quickstarts_in_jboss_developer_studio_or_eclipse]]
-== Run the Quickstarts in Red Hat Developer Studio or Eclipse
+== Run the Quickstarts in Red Hat CodeReady Studio or Eclipse
 
-You can also start the server and deploy the quickstarts or run the Arquillian tests from Eclipse using JBoss tools. For general information about how to import a quickstart, add a WildFly server, and build and deploy a quickstart, see https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/USE_JBDS.adoc#use_red_hat_jboss_developer_studio_or_eclipse_to_run_the_quickstarts[Use Red Hat Developer Studio or Eclipse to Run the Quickstarts].
+You can also start the server and deploy the quickstarts or run the Arquillian tests from Eclipse using JBoss tools. For general information about how to import a quickstart, add a WildFly server, and build and deploy a quickstart, see https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/USE_JBDS.adoc#use_red_hat_jboss_developer_studio_or_eclipse_to_run_the_quickstarts[Use Red Hat CodeReady Studio or Eclipse to Run the Quickstarts].
 
 [[optional_components]]
 == Configure Optional Components

--- a/batch-processing/README.adoc
+++ b/batch-processing/README.adoc
@@ -154,7 +154,7 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/bean-validation-custom-constraint/README.adoc
+++ b/bean-validation-custom-constraint/README.adoc
@@ -65,7 +65,7 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/bean-validation/README.adoc
+++ b/bean-validation/README.adoc
@@ -67,7 +67,7 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/bmt/README.adoc
+++ b/bmt/README.adoc
@@ -71,7 +71,7 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/cmt/README.adoc
+++ b/cmt/README.adoc
@@ -92,10 +92,10 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 NOTE: Within {JBDSProductName}, make sure you define a server runtime environment that uses the `standalone-full.xml` configuration file.
 
 // Debug the Application

--- a/contacts-jquerymobile/README.adoc
+++ b/contacts-jquerymobile/README.adoc
@@ -141,7 +141,7 @@ For more information on QUnit tests, see http://qunitjs.com/.
 
 // Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/deltaspike-authorization/README.adoc
+++ b/deltaspike-authorization/README.adoc
@@ -45,7 +45,7 @@ When you click on the `Admin Method` button, you are redirected to an error page
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/deltaspike-beanbuilder/README.adoc
+++ b/deltaspike-beanbuilder/README.adoc
@@ -53,7 +53,7 @@ Results :
 Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/deltaspike-projectstage/README.adoc
+++ b/deltaspike-projectstage/README.adoc
@@ -61,7 +61,7 @@ Review the _List of available CDI instances for MyBean_ table to verify that the
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/ejb-asynchronous/README.adoc
+++ b/ejb-asynchronous/README.adoc
@@ -80,10 +80,10 @@ action 'fireAndForget' finished
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 This quickstart consists of multiple projects, so it deploys and runs differently in {JBDSProductName} than the other quickstarts.
 
 . Install the required Maven artifacts and deploy the asynchronous EJB quickstart project.

--- a/ejb-in-ear/README.adoc
+++ b/ejb-in-ear/README.adoc
@@ -68,10 +68,10 @@ Enter a name in the input field and click the *Greet* button to see the response
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 For this quickstart, follow the special instructions to build link:{useEclipseDeployEARDocUrl}[Quickstarts Containing an EAR].
 
 . Right-click on the *{artifactId}-ear* subproject, and choose *Run As* -> *Run on Server*.

--- a/ejb-in-war/README.adoc
+++ b/ejb-in-war/README.adoc
@@ -76,7 +76,7 @@ INFO  [org.jboss.as.server.deployment] (MSC service thread 1-3) WFLYSRV0028: Sto
 INFO  [org.jboss.as.server] (management-handler-thread - 30) WFLYSRV0009: Undeployed "test.war" (runtime-name: "test.war")
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/ejb-multi-server/README.adoc
+++ b/ejb-multi-server/README.adoc
@@ -241,10 +241,10 @@ NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat`.
 
 // Restore the {productName} Managed Domain Configuration Manually
 include::../shared-doc/restore-managed-domain-configuration-manual.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 EJB Client (ejb-client) currently has limited support in the Eclipse Web Tools Platform (WTP).
 
 // Debug the Application

--- a/ejb-remote/README.adoc
+++ b/ejb-remote/README.adoc
@@ -163,10 +163,10 @@ Before you can use it, you need to set up a user on the server as HTTP does not 
 
 // Add the Authorized Application User
 include::../shared-doc/add-application-user.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 This quickstart consists of multiple projects, so it deploys and runs differently in {JBDSProductName} than the other quickstarts.
 
 . Install the required Maven artifacts and deploy the server side of the quickstart project.

--- a/ejb-security-context-propagation/README.adoc
+++ b/ejb-security-context-propagation/README.adoc
@@ -308,10 +308,10 @@ The batch executed successfully
 
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 This quickstart requires additional configuration and deploys and runs differently in {JBDSProductName} than the other quickstarts.
 
 . Make sure you xref:add_the_application_users[Add the Application Users] as described above.

--- a/ejb-security-jaas/README.adoc
+++ b/ejb-security-jaas/README.adoc
@@ -340,10 +340,10 @@ include::../shared-doc/restore-standalone-server-configuration-manual.adoc[level
 After you are done with this quickstart, remember to remove the `users.properties` and `roles.properties` files from the
 server configuration directory (`__{jbossHomeName}__/standalone/configuration/`).
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 * Make sure you xref:create_the_properties_files_for_the_jaas_security_domain[Create the Properties Files for the JAAS Security Domain] as described above.
 * Make sure you configure the server by running the JBoss CLI script as described above under xref:configure_the_server[Configure the Server]. Stop the server at the end of that step.
 * To deploy the application to the {productName} server, right-click on the *{artifactId}* project and choose *Run As* -> *Run on Server*.

--- a/ejb-security-programmatic-auth/README.adoc
+++ b/ejb-security-programmatic-auth/README.adoc
@@ -135,10 +135,10 @@ process-state: reload-required
 
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 * Make sure you xref:add_the_application_management_users[add the authorized application and management users] as described above.
 * Make sure you configure the server by running the JBoss CLI script as described above under xref:configure_the_server[Configure the Server].
 * Right-click on the *{artifactId}* project and choose *Run As* -> *Maven build*.

--- a/ejb-security/README.adoc
+++ b/ejb-security/README.adoc
@@ -181,10 +181,10 @@ process-state: reload-required
 
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 . Make sure you xref:add_the_application_user[Add the authorized application user] as described above.
 . Make sure you configure the server by running the JBoss CLI script as described above under xref:configure_the_server[Configure the Server].
 . To deploy the server project, right-click on the *{artifactId}* project and choose *Run As* –> *Maven build*. Enter *clean package wildfly:deploy* for the *Goals* and click *Run*. This deploys the `{artifactId}` JAR to the {productName} server.

--- a/ejb-throws-exception/README.adoc
+++ b/ejb-throws-exception/README.adoc
@@ -79,10 +79,10 @@ If the *Name* input text box is empty, then the *Response* output text will disp
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 For this quickstart, follow the special instructions to build link:{useEclipseDeployEARDocUrl}[Quickstarts Containing an EAR].
 
 . Right-click on the *{artifactId}-ear* subproject, and choose *Run As* -> *Run on Server*.

--- a/ejb-timer/README.adoc
+++ b/ejb-timer/README.adoc
@@ -68,7 +68,7 @@ Existing threads in the thread pool handle the invocations. They are rotated and
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/greeter/README.adoc
+++ b/greeter/README.adoc
@@ -64,7 +64,7 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/ha-singleton-deployment/README.adoc
+++ b/ha-singleton-deployment/README.adoc
@@ -261,7 +261,7 @@ $ mvn wildfly:undeploy
 $ mvn wildfly:undeploy -Dwildfly.port=10090
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/ha-singleton-service/README.adoc
+++ b/ha-singleton-service/README.adoc
@@ -488,7 +488,7 @@ $ __{jbossHomeName}_2__/bin/jboss-cli.sh --connect --controller=localhost:10090 
 +
 NOTE: For Windows, use the `__{jbossHomeName}_1__\bin\jboss-cli.bat` and `__{jbossHomeName}_2__\bin\jboss-cli.bat` scripts.
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/helloworld-html5/README.adoc
+++ b/helloworld-html5/README.adoc
@@ -108,7 +108,7 @@ Date: Tue, 13 Oct 2015 06:32:20 GMT
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/helloworld-jms/README.adoc
+++ b/helloworld-jms/README.adoc
@@ -179,10 +179,10 @@ The batch executed successfully
 
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 This quickstart consists of multiple projects, so it deploys and runs differently in {JBDSProductName} than the other quickstarts.
 
 . Make sure you xref:add_the_application_user[add the authorized application user] as described above.

--- a/helloworld-mbean/README.adoc
+++ b/helloworld-mbean/README.adoc
@@ -91,10 +91,10 @@ image:jconsole.png[MBeans in JConsole]
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 This quickstart consists of multiple projects and requires installation of the `JBoss Tools Maven Packaging Configurator`, so it deploys and runs differently in {JBDSProductName} than the other quickstarts.
 
 . Install the JBoss Tools Maven Packaging Configurator

--- a/helloworld-mdb-propertysubstitution/README.adoc
+++ b/helloworld-mdb-propertysubstitution/README.adoc
@@ -143,10 +143,10 @@ The batch executed successfully
 
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 * Make sure you enable MDB property substitution by running the JBoss CLI commands as described above under xref:configure_the_server[Configure the Server]. Stop the server at the end of that step.
 * Within {JBDSProductName}, make sure you define a server runtime environment that uses the `standalone-full.xml` configuration file.
 * Make sure you xref:restore_the_server_configuration[restore the server configuration] when you have completed testing this quickstart.

--- a/helloworld-mdb/README.adoc
+++ b/helloworld-mdb/README.adoc
@@ -78,10 +78,10 @@ INFO  [class org.jboss.as.quickstarts.mdb.HelloWorldQueueMDB] (Thread-4 (ActiveM
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 NOTE: Within {JBDSProductName}, make sure you define a server runtime environment that uses the `standalone-full.xml` configuration file.
 
 

--- a/helloworld-mutual-ssl-secured/README.adoc
+++ b/helloworld-mutual-ssl-secured/README.adoc
@@ -388,10 +388,10 @@ After you are done with this quickstart, remember to remove the certificate that
 . Select the *quickstartUser* certificate and click the *Delete* button.
 . The certificate has now been removed from the Mozilla Firefox browser.
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 * Make sure you configure the keystores and client certificates as described under xref:set_up_client_and_server_keystores_using_java_keytool[Set Up Client and Server Keystores Using Java Keytool].
 * Depending on the browser you choose, make sure you either xref:import_the_client_certificate_into_google_chrome[import the certificate into Google Chrome] or xref:import_the_client_certificate_into_mozilla_firefox[import the certificate into Mozilla Firefox].
 * Make sure you configure the server by running the JBoss CLI commands as described above under xref:configure_the_server[Configure the Server]. Stop the server at the end of that step.

--- a/helloworld-mutual-ssl/README.adoc
+++ b/helloworld-mutual-ssl/README.adoc
@@ -328,10 +328,10 @@ After you are done with this quickstart, remember to remove the certificate that
 . Select the `quickstartUser` certificate and click the `Delete` button.
 . The certificate has now been removed from the Mozilla Firefox browser.
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat  Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 * Make sure you configure the keystores and client certificates as described under xref:set_up_client_and_server_keystores_using_java_keytool[Set Up Client and Server Keystores Using Java Keytool].
 * Depending on the browser you choose, make sure you either xref:import_the_client_certificate_into_google_chrome[import the certificate into Google Chrome] or xref:import_the_client_certificate_into_mozilla_firefox[import the certificate into Mozilla Firefox].
 * Make sure you configure the server by running the JBoss CLI commands as described above under xref:configure_the_server[Configure the Server]. Stop the server at the end of that step.

--- a/helloworld-rf/README.adoc
+++ b/helloworld-rf/README.adoc
@@ -32,7 +32,7 @@ The application will be running at the following URL: http://localhost:8080/{art
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/helloworld-rs/README.adoc
+++ b/helloworld-rs/README.adoc
@@ -48,7 +48,7 @@ The application is deployed to http://localhost:8080/{artifactId}/.
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/helloworld-singleton/README.adoc
+++ b/helloworld-singleton/README.adoc
@@ -46,7 +46,7 @@ To test the singleton bean, click on either *Increment A* or *Increment B*. The 
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/helloworld-ssl/README.adoc
+++ b/helloworld-ssl/README.adoc
@@ -182,10 +182,10 @@ $ cd __{jbossHomeName}__/standalone/configuration/
 
 . Remove the keystore generated for this quickstart.
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 * Make sure you configure the server by running the JBoss CLI commands as described above under xref:configure_the_server[Configure the Server]. Stop the server at the end of that step.
 * Make sure you xref:restore-the-server-configuration[restore the server configuration] when you have completed testing this quickstart.
 

--- a/helloworld-ws/README.adoc
+++ b/helloworld-ws/README.adoc
@@ -66,10 +66,10 @@ Running org.jboss.as.quickstarts.wshelloworld.ClientArqTest
 Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.988 sec
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 When you deploy this quickstart, you are presented with a window that explains there is no user interface for this quickstart and directs you to click on a link to view the WSDL definition. However, the Eclipse browser does not support the display of WSDL definitions. Instead, open an external browser and access the following URL: http://localhost:8080/{artifactId}/HelloWorldService?wsdl. This URL will display the deployed WSDL endpoint for the Web Service.
 
 // Debug the Application

--- a/helloworld/README.adoc
+++ b/helloworld/README.adoc
@@ -41,7 +41,7 @@ The application will be running at the following URL: http://localhost:8080/{art
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/hibernate/README.adoc
+++ b/hibernate/README.adoc
@@ -78,7 +78,7 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/hibernate4/README.adoc
+++ b/hibernate4/README.adoc
@@ -62,7 +62,7 @@ The application will be running at the following URL: http://localhost:8080/{art
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/http-custom-mechanism/README.adoc
+++ b/http-custom-mechanism/README.adoc
@@ -278,7 +278,7 @@ include::../shared-doc/restore-standalone-server-configuration-manual.adoc[level
 Not how to do curl commands in JBDS
 // include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 * Make sure you xref:add_the_application_user[Add the application user] as described above.
 * Make sure you configure the security domain on the server by running the JBoss CLI script as described above under xref:configure_the_application_security_domain[Configure the Application Security Domain].
 * Right-click on the *{artifactId}* project and choose *Run As* -> *Maven build*.

--- a/inter-app/README.adoc
+++ b/inter-app/README.adoc
@@ -95,10 +95,10 @@ $ mvn wildfly:undeploy -pl appA,appB
 $ mvn wildfly:undeploy -pl shared
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 This quickstart consists of multiple projects containing interdependencies on each other, so it deploys and runs differently in {JBDSProductName} than the other quickstarts.
 
 . In the *Servers* tab, right-click on the {productName} server and choose *Start*.

--- a/jaxrs-client/README.adoc
+++ b/jaxrs-client/README.adoc
@@ -110,10 +110,10 @@ Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 To run the tests in {JBDSProductName}:
 
 . You must first set the active Maven profile in project properties to be either `arq-managed` for running on managed server or `arq-remote` for running on remote server.

--- a/jaxws-addressing/README.adoc
+++ b/jaxws-addressing/README.adoc
@@ -64,10 +64,10 @@ Hello World!
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 For this quickstart, follow the special instructions to link:{useEclipseDeployJavaClientDocUrl}[Deploy and Undeploy a Quickstart Containing Server and Java Client Projects]
 
 [NOTE]

--- a/jaxws-ejb/README.adoc
+++ b/jaxws-ejb/README.adoc
@@ -63,10 +63,10 @@ EJB3Bean returning: ejbClient calling
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 For this quickstart, follow the special instructions to link:{useEclipseDeployJavaClientDocUrl}[Deploy and Undeploy a Quickstart Containing Server and Java Client Projects]
 
 . To build all of the artifacts, right-click on the *{artifactId}* parent project, and choose *Run As* –> *Maven install*.

--- a/jaxws-pojo/README.adoc
+++ b/jaxws-pojo/README.adoc
@@ -63,10 +63,10 @@ JSEBean pojo: pojoClient calling
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 For this quickstart, follow the special instructions to link:{useEclipseDeployJavaClientDocUrl}[Deploy and Undeploy a Quickstart Containing Server and Java Client Projects]
 
 . To build all of the artifacts, right-click on the *{artifactId}* parent project, and choose *Run As* –> *Maven install*.

--- a/jaxws-retail/README.adoc
+++ b/jaxws-retail/README.adoc
@@ -73,10 +73,10 @@ Jay Boss's discount is 10.00
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 This quickstart is dependent on a WSDL file that is included in the `{artifactId}-service` project, so it deploys and runs differently in {JBDSProductName} than the other quickstarts.
 
 [NOTE]

--- a/jsonp/README.adoc
+++ b/jsonp/README.adoc
@@ -50,7 +50,7 @@ Note that the JSON string contains String, number, boolean and array values.
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/jta-crash-rec/README.adoc
+++ b/jta-crash-rec/README.adoc
@@ -183,7 +183,7 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 

--- a/jts-distributed-crash-rec/README.adoc
+++ b/jts-distributed-crash-rec/README.adoc
@@ -276,5 +276,5 @@ __{jbossHomeName}_2__/standalone/data/tx-object-store
 //*************************************************
 // Add {JBDSProductName} instructions
 //*************************************************
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]

--- a/jts/README.adoc
+++ b/jts/README.adoc
@@ -334,5 +334,5 @@ NOTE: For Windows, use the `__{jbossHomeName}_1__\bin\jboss-cli.bat` script.
 </subsystem>
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]

--- a/kitchensink-angularjs/README.adoc
+++ b/kitchensink-angularjs/README.adoc
@@ -46,10 +46,10 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
 // Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 NOTE: If you have not installed the https://github.com/angelozerr/angularjs-eclipse[AngularJS Eclipse plugin] into {JBDSProductName}, you may see one or more of the following warnings when you import this project. You can ignore these warnings.
 
 [source,options="nowrap"]

--- a/kitchensink-ear/README.adoc
+++ b/kitchensink-ear/README.adoc
@@ -87,10 +87,10 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 For this quickstart, follow the special instructions to build link:{useEclipseDeployEARDocUrl}[Quickstarts Containing an EAR].
 
 . Right-click on the *{artifactId}-ear* subproject, and choose *Run As* –> *Run on Server*.

--- a/kitchensink-jsp/README.adoc
+++ b/kitchensink-jsp/README.adoc
@@ -61,10 +61,10 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 You may see the following warnings for the `index.jsp` file when you import this quickstart into {JBDSProductName}.
 
 [source,options="nowrap"]

--- a/kitchensink-ml/README.adoc
+++ b/kitchensink-ml/README.adoc
@@ -149,7 +149,7 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/kitchensink-utjs-angularjs/README.adoc
+++ b/kitchensink-utjs-angularjs/README.adoc
@@ -29,7 +29,7 @@ The application will be running at the following URL: http://localhost:8080/{art
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/kitchensink-utjs-mustache/README.adoc
+++ b/kitchensink-utjs-mustache/README.adoc
@@ -32,7 +32,7 @@ The application will be running at the following URL: http://localhost:8080/{art
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/kitchensink/README.adoc
+++ b/kitchensink/README.adoc
@@ -59,7 +59,7 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 //  Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/logging-tools/README.adoc
+++ b/logging-tools/README.adoc
@@ -103,10 +103,10 @@ Note that `WebApplicationException` cannot be directly localized by JBoss Loggin
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 You might see the following warning when you import this quickstart into {JBDSProductName}. You can ignore this warning as it occurs in a generated file.
 
 [source,options="nowrap"]

--- a/logging/README.adoc
+++ b/logging/README.adoc
@@ -233,10 +233,10 @@ The batch executed successfully
 
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 * Make sure you configure {productName} server logging as described above under xref:configure_the_server[Configure the Server]. Stop the server at the end of that step.
 * Make sure you xref:remove_the_logging_configuration[Remove the Logging Configuration] when you have completed testing this quickstart.
 

--- a/mail/README.adoc
+++ b/mail/README.adoc
@@ -135,10 +135,10 @@ process-state: reload-required
 
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 * Make sure you xref:configure_an_smtp_server_on_your_local_machine[Configure an SMTP Server on Your Local Machine].
 * Make sure you configure the {productName} custom mail configuration as described above under xref:configure_the_server[Configure the {productName} Server]. Stop the server at the end of that step.
 * To deploy the server project, right-click on the *{artifactId}* project and choose *Run As* –&gt; *Run on Server*. A browser window appears that accesses the running application.

--- a/managed-executor-service/README.adoc
+++ b/managed-executor-service/README.adoc
@@ -119,10 +119,10 @@ WFLYJCA0091: -ds.xml file deployments are deprecated. Support may be removed in 
 HHH000431: Unable to determine H2 database version, certain features may not work
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 To run the tests in {JBDSProductName}, you must first set the active Maven profile in project properties to one of the following:
 
 * `arq-remote`: This setting is used for a remote server. {JBDSProductName} starts the server for you.

--- a/messaging-clustering-singleton/README.adoc
+++ b/messaging-clustering-singleton/README.adoc
@@ -471,5 +471,5 @@ The batch executed successfully
 . If it is running, stop the second instance of the {productName} server.
 . Delete the cloned directory.
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]

--- a/messaging-clustering/README.adoc
+++ b/messaging-clustering/README.adoc
@@ -348,5 +348,5 @@ The batch executed successfully
 . If it is running, stop the second instance of the {productName} server.
 . Delete the cloned directory.
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]

--- a/numberguess/README.adoc
+++ b/numberguess/README.adoc
@@ -42,7 +42,7 @@ The application will be running at the following URL: http://localhost:8080/{art
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/payment-cdi-event/README.adoc
+++ b/payment-cdi-event/README.adoc
@@ -69,7 +69,7 @@ The application will be running at the following URL: http://localhost:8080/{art
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/resteasy-jaxrs-client/README.adoc
+++ b/resteasy-jaxrs-client/README.adoc
@@ -71,10 +71,10 @@ MediaType: application/json
 ===============================================
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 . Before you run this quickstart, make sure you import, deploy, and test the `helloworld-rs` quickstart as described in the xref:prerequisites[Prerequisites] section of this file.
 
 . Import this quickstart into {JBDSProductName}.

--- a/security-domain-to-domain/README.adoc
+++ b/security-domain-to-domain/README.adoc
@@ -277,7 +277,7 @@ process-state: reload-required
 
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional JBDS instructions

--- a/servlet-async/README.adoc
+++ b/servlet-async/README.adoc
@@ -45,7 +45,7 @@ The application will be running at the following URL http://localhost:8080/{arti
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/servlet-filterlistener/README.adoc
+++ b/servlet-filterlistener/README.adoc
@@ -91,7 +91,7 @@ INFO  [io.undertow.servlet] (default task-50) ParameterDumpingRequestListener: r
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/servlet-security/README.adoc
+++ b/servlet-security/README.adoc
@@ -223,10 +223,10 @@ process-state: reload-required
 
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 * Make sure you configure the server by running the JBoss CLI commands as described above under xref:configure_the_server{Configure the Server]. Stop the server at the end of that step.
 * Make sure you xref:restore_the_server_configuration[restore the {productName} server configuration] when you have completed testing this quickstart.
 

--- a/shopping-cart/README.adoc
+++ b/shopping-cart/README.adoc
@@ -174,10 +174,10 @@ The batch executed successfully
 
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 This quickstart consists of multiple projects, so it deploys and runs differently in {JBDSProductName} than the other quickstarts.
 
 * Make sure you configure {productName} to suppress system exception logging as described above under xref:configure_the_server[Configure the Server]. Stop the server at the end of that step.

--- a/spring-greeter/README.adoc
+++ b/spring-greeter/README.adoc
@@ -82,7 +82,7 @@ Or you can manually remove the application by removing `{artifactId}.war` from t
 
 // Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/spring-kitchensink-basic/README.adoc
+++ b/spring-kitchensink-basic/README.adoc
@@ -62,7 +62,7 @@ WARN  [org.jboss.as.ee] (MSC service thread 1-5) WFLYEE0007: Not installing opti
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/spring-kitchensink-springmvctest/README.adoc
+++ b/spring-kitchensink-springmvctest/README.adoc
@@ -65,7 +65,7 @@ WARN  [org.jboss.as.ee] (MSC service thread 1-5) WFLYEE0007: Not installing opti
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Run the Arquillian Functional Tests
 include::../shared-doc/run-arquillian-functional-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/spring-resteasy/README.adoc
+++ b/spring-resteasy/README.adoc
@@ -71,7 +71,7 @@ WARN  [org.jboss.as.ee] (MSC service thread 1-5) WFLYEE0007: Not installing opti
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 endif::[]

--- a/tasks-jsf/README.adoc
+++ b/tasks-jsf/README.adoc
@@ -67,7 +67,7 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/tasks-rs/README.adoc
+++ b/tasks-rs/README.adoc
@@ -257,10 +257,10 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 //  Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 Make sure you xref:add_the_application_user[add the authorized application user].
 
 // Debug the Application

--- a/temperature-converter/README.adoc
+++ b/temperature-converter/README.adoc
@@ -55,7 +55,7 @@ You will be presented with a simple form for temperature conversion.
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/thread-racing/README.adoc
+++ b/thread-racing/README.adoc
@@ -71,10 +71,10 @@ HHH000431: Unable to determine H2 database version, certain features may not wor
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 NOTE: Within {JBDSProductName}, make sure you define a server runtime environment that uses the `standalone-full.xml` configuration file.
 
 // Debug the Application

--- a/websocket-client/README.adoc
+++ b/websocket-client/README.adoc
@@ -73,7 +73,7 @@ RECV: This is a test
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/websocket-endpoint/README.adoc
+++ b/websocket-endpoint/README.adoc
@@ -52,7 +52,7 @@ You can restart the bidding if you click on `Reset bidding` button.
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/websocket-hello/README.adoc
+++ b/websocket-hello/README.adoc
@@ -58,7 +58,7 @@ WebSocket connection is not established. Please click the Open Connection button
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 // Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]

--- a/wicket-ear/README.adoc
+++ b/wicket-ear/README.adoc
@@ -49,7 +49,7 @@ The application will be running at the following URL: http://localhost:8080/{art
 
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 == Debug the Application

--- a/wsat-simple/README.adoc
+++ b/wsat-simple/README.adoc
@@ -147,10 +147,10 @@ INFO  [stdout] (TaskWorker-2) [SERVICE] commit called on backend resource.
 
 NOTE: You can ignore the warning message `ARJUNA043219: Could not save recovery state for non-serializable durable WS-AT participant restaurantServiceAT` that is printed in the server console. This quickstart does not implement the required recovery hooks in the interest of making it easy to follow. In a real world production application, you should provide the required recovery code. For more information, see http://narayana.io/docs/product.
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 This quickstart is more complex than the others. It requires that you configure the {productName} server to use the _standalone-xts.xml_ configuration file, which is located in an external configuration directory.
 
 . Import the quickstart into {JBDSProductName}.

--- a/wsba-coordinator-completion-simple/README.adoc
+++ b/wsba-coordinator-completion-simple/README.adoc
@@ -144,10 +144,10 @@ INFO  [stdout] (TaskWorker-3) [SERVICE] Compensate the backend resource by remov
 INFO  [stdout] (TaskWorker-3) [SERVICE] Compensate the backend resource by removing '2' from the set (e.g. undo any changes to databases that were previously made visible to others)
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 This quickstart is more complex than the others. It requires that you configure the {productName} server to use the _standalone-xts.xml_ configuration file, which is located in an external configuration directory.
 
 . Make sure you import the quickstart into {JBDSProductName}.

--- a/wsba-participant-completion-simple/README.adoc
+++ b/wsba-participant-completion-simple/README.adoc
@@ -141,10 +141,10 @@ INFO  [stdout] (http-localhost-127.0.0.1-8080-1) [SERVICE] Prepare successful, n
 INFO  [stdout] (http-localhost-127.0.0.1-8080-1) [SERVICE] Participant.confirmCompleted('true') (This tells the participant that compensation information has been logged and that it is safe to commit any changes.)
 ----
 
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
-// Additional Red Hat Developer Studio instructions
+// Additional Red Hat CodeReady Studio instructions
 This quickstart is more complex than the others. It requires that you configure the {productName} server to use the _standalone-xts.xml_ configuration file, which is located in an external configuration directory.
 
 . Import the quickstart into {JBDSProductName}.

--- a/xml-jaxp/README.adoc
+++ b/xml-jaxp/README.adoc
@@ -69,7 +69,7 @@ INFO  [stdout] (http-/127.0.0.1:8080-1) Parsing the document using the SAXXMLPar
 
 //  Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat Developer Studio or Eclipse
+// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 //  Debug the Application
 include::../shared-doc/debug-the-application.adoc[leveloffset=+1]


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-12864