### PR TITLE
WFLY-13268 MP Fault Tolerance quickstart cannot resolve dependencies …

### DIFF
--- a/microprofile-fault-tolerance/README.adoc
+++ b/microprofile-fault-tolerance/README.adoc
@@ -71,6 +71,15 @@ The first thing to do is to setup our dependencies. Add the following section to
 ----
 <dependencyManagement>
     <dependencies>
+        <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+        <dependency>
+            <groupId>org.wildfly.bom</groupId>
+            <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+            <version>${version.server.bom}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <!-- importing the microprofile BOM adds MicroProfile specs -->
         <dependency>
             <groupId>org.wildfly.bom</groupId>
             <artifactId>wildfly-microprofile</artifactId>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -52,6 +52,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- importing the microprofile BOM adds MicroProfile specs -->
             <dependency>
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-microprofile</artifactId>


### PR DESCRIPTION
…with wildlfy-microprofile BOM

Jira
https://issues.redhat.com/browse/WFLY-13268

Downstream
https://github.com/wildfly/quickstart/pull/402

