### PR TITLE
Upgrade wildfly-maven-plugin and fix WildFly version

### DIFF
--- a/deltaspike-authorization/pom.xml
+++ b/deltaspike-authorization/pom.xml
@@ -191,7 +191,6 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.wildfly.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/http-custom-mechanism/pom.xml
+++ b/http-custom-mechanism/pom.xml
@@ -75,7 +75,6 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.wildfly.maven.plugin}</version>
             </plugin>
         </plugins>
     </build>

--- a/microprofile-fault-tolerance/README.adoc
+++ b/microprofile-fault-tolerance/README.adoc
@@ -134,7 +134,7 @@ Add the following section under configuration:
       <groupId>org.wildfly.plugins</groupId>
       <artifactId>wildfly-maven-plugin</artifactId>
       <configuration>
-        <version>${version.server.bom}</version>
+        <version>${version.server}</version>
       </configuration>
     </plugin>
   </plugins>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -102,7 +102,6 @@
                     <groupId>org.wildfly.plugins</groupId>
                     <artifactId>wildfly-maven-plugin</artifactId>
                     <configuration>
-                        <version>${version.server.bom}</version>
                         <serverConfig>standalone-microprofile.xml</serverConfig>
                     </configuration>
                 </plugin>

--- a/microprofile-openapi/pom.xml
+++ b/microprofile-openapi/pom.xml
@@ -38,9 +38,6 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
-                <configuration>
-                    <version>19.0.0.Final</version>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
 
         <jboss.developer.drupal.url>http://rhdp-drupal.stage.redhat.com/</jboss.developer.drupal.url>
         <linkXRef>false</linkXRef>
+
+        <!-- We use this property name as the org.wildfly.plugins:wildfly-maven-plugin uses this property name to be
+             overridden from the command line.
+         -->
+        <version.server>19.0.0.Final</version.server>
     </properties>
 
     <dependencyManagement>
@@ -220,6 +225,9 @@
                     <groupId>org.wildfly.plugins</groupId>
                     <artifactId>wildfly-maven-plugin</artifactId>
                     <version>${version.wildfly.maven.plugin}</version>
+                    <configuration>
+                        <version>${version.server}</version>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <jboss.home.name>WILDFLY_HOME</jboss.home.name>
         <product.name>WildFly</product.name>
         <!-- A base list of dependency and plug-in version used in the various quick starts. -->
-        <version.wildfly.maven.plugin>2.0.0.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>2.0.2.Final</version.wildfly.maven.plugin>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.quickstarts.documentation.plugin>2.0.0.Final</version.org.wildfly.quickstarts.documentation.plugin>
         <!-- other plug-in versions -->


### PR DESCRIPTION
JIRA's:

- https://issues.redhat.com/browse/WFLY-13271
- https://issues.redhat.com/browse/WFLY-13272

Note that I wasn't sure if we should target 20.0.0.Beta1-SNAPSHOT for this or 19.0.0.Final. Let me know if we prefer a snapshot or if we should wait for beta1 to change this.