### PR TITLE
correct default value of java.naming.provider.url in README.adoc

### DIFF
--- a/helloworld-jms/README.adoc
+++ b/helloworld-jms/README.adoc
@@ -162,7 +162,7 @@ The example provides for a certain amount of customization for the `mvn:exec` pl
 | The content of the JMS `TextMessage`.
 
 | java.naming.provider.url
-| "localhost"
+| "http-remoting://127.0.0.1:8080"
 | This property allows configuration of the JNDI directory used to look up the JMS destination. This is useful when the client resides on another host.
 |===
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13861

In code https://github.com/wildfly/quickstart/blob/master/helloworld-jms/src/main/java/org/jboss/as/quickstarts/jms/HelloWorldJMSClient.java#L41. The default value of `java.naming.provider.url` is more than just the hostname.
