### PR TITLE
[WFLY-11492] Quickstart http-custom-mechanism: documentation step fails

### DIFF
--- a/http-custom-mechanism/README.adoc
+++ b/http-custom-mechanism/README.adoc
@@ -69,7 +69,7 @@ include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 [[configure_the_application_security_domain]]
 == Configure the Application Security Domain
 
-By default, the deployed application uses the `other` security domain. You need to map this security domain to an Elytron HTTP authentication factory. For your convenience, this quickstart includes the command to configure the security domain in the `configure-security-domain.cli` script located in the root directory of this quickstart.
+By default, the deployed application uses the `other` security domain. You need to map this security domain to an Elytron Security Domain. For your convenience, this quickstart includes the command to configure the security domain in the `configure-security-domain.cli` script located in the root directory of this quickstart.
 
 In a terminal, navigate to the root directory of this quickstart, and run the following command, replacing `__{jbossHomeName}__` with the path to your server.
 

--- a/http-custom-mechanism/configure-elytron.cli
+++ b/http-custom-mechanism/configure-elytron.cli
@@ -9,6 +9,9 @@ batch
 # Add an `http-authentication-factory` to the mechanism factory to a `security-domain` that will be used for the authentication.
 /subsystem=elytron/http-authentication-factory=custom-mechanism:add(http-server-mechanism-factory=custom-factory,security-domain=ApplicationDomain,mechanism-configurations=[{mechanism-name=CUSTOM_MECHANISM}])
 
+# Undefine Elytron security domain mapping we previously used
+/subsystem=undertow/application-security-domain=other:undefine-attribute(name=security-domain)
+
 # Add the http-authentication-factory to the mechanism factory to a security-domain that will be used for the authentication.
 /subsystem=undertow/application-security-domain=other:write-attribute(name=http-authentication-factory,value=custom-mechanism)
 

--- a/http-custom-mechanism/configure-security-domain.cli
+++ b/http-custom-mechanism/configure-security-domain.cli
@@ -2,8 +2,9 @@
 
 # Start batching commands
 batch
-#  Map the application security domain to an Elytron HTTP authentication factory.
-/subsystem=undertow/application-security-domain=other:add(http-authentication-factory=application-http-authentication)
+
+#  Map the application security domain to an Elytron Security Domain.
+/subsystem=undertow/application-security-domain=other:add(security-domain=ApplicationDomain)
 
 # Run the batch command
 run-batch


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-11492