### PR TITLE
[WFLY-13713] Bootable JAR support for MicroProfile Quickstarts, upgrade jkube to 1.0.1

### DIFF
--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -21,10 +21,9 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
       <version.server.bootable-jar>21.0.0.Beta1</version.server.bootable-jar>
-      <version.wildfly-jar.maven.plugin>2.0.0.Beta7</version.wildfly-jar.maven.plugin>
-      <version.jkube.maven.plugin>1.0.0</version.jkube.maven.plugin>
-      <!-- not needed for WildFly, for XP 2.0, need a supported redhat builder image. Could be JDK8 or JDK11, us to choose -->
-      <jkube.generator.from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:latest</jkube.generator.from>
+      <version.wildfly-jar.maven.plugin>2.0.0.Beta9</version.wildfly-jar.maven.plugin>
+      <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
+      <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>
 
   <dependencies>
@@ -160,11 +159,6 @@
                                   </jkube-service>
                               </config>
                           </enricher>
-                          <resources>
-                              <env>
-                                  <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
-                              </env>
-                          </resources>
                       </configuration>
                   </plugin>
               </plugins>

--- a/microprofile-config/src/main/jkube/route.yml
+++ b/microprofile-config/src/main/jkube/route.yml
@@ -1,4 +1,3 @@
-apiVersion: route.openshift.io/v1 
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -52,10 +52,9 @@
 
     <properties>
         <version.server.bootable-jar>21.0.0.Beta1</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>2.0.0.Beta7</version.wildfly-jar.maven.plugin>
-        <version.jkube.maven.plugin>1.0.0</version.jkube.maven.plugin>
-        <!-- not needed for WildFly, for XP 2.0, need a supported redhat builder image. Could be JDK8 or JDK11, us to choose -->
-        <jkube.generator.from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:latest</jkube.generator.from>
+        <version.wildfly-jar.maven.plugin>2.0.0.Beta9</version.wildfly-jar.maven.plugin>
+        <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
+        <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>
 
     <dependencyManagement>
@@ -232,11 +231,6 @@
                                     </jkube-service>
                                 </config>
                             </enricher>
-                            <resources>
-                                <env>
-                                    <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
-                                </env>
-                            </resources>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/microprofile-fault-tolerance/src/main/jkube/route.yml
+++ b/microprofile-fault-tolerance/src/main/jkube/route.yml
@@ -1,4 +1,3 @@
-apiVersion: route.openshift.io/v1
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -22,10 +22,9 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <management.http.url>http://localhost:9990</management.http.url>
     <version.server.bootable-jar>21.0.0.Beta1</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>2.0.0.Beta7</version.wildfly-jar.maven.plugin>
-    <version.jkube.maven.plugin>1.0.0</version.jkube.maven.plugin>
-    <!-- not needed for WildFly, for XP 2.0, need a supported redhat builder image. Could be JDK8 or JDK11, us to choose -->
-    <jkube.generator.from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:latest</jkube.generator.from>
+    <version.wildfly-jar.maven.plugin>2.0.0.Beta9</version.wildfly-jar.maven.plugin>
+    <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
+    <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>
 
   <dependencies>
@@ -172,11 +171,6 @@
                   </jkube-service>
                 </config>
               </enricher>
-              <resources>
-                <env>
-                  <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
-                </env>
-              </resources>
             </configuration>
           </plugin>
         </plugins>

--- a/microprofile-health/src/main/jkube/route.yml
+++ b/microprofile-health/src/main/jkube/route.yml
@@ -1,4 +1,3 @@
-apiVersion: route.openshift.io/v1
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -44,10 +44,9 @@
     <properties>
         <version.glassfish.json>1.1.6</version.glassfish.json>
         <version.server.bootable-jar>21.0.0.Beta1</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>2.0.0.Beta7</version.wildfly-jar.maven.plugin>
-        <version.jkube.maven.plugin>1.0.0</version.jkube.maven.plugin>
-        <!-- not needed for WildFly, for XP 2.0, need a supported redhat builder image. Could be JDK8 or JDK11, us to choose -->
-        <jkube.generator.from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:latest</jkube.generator.from>
+        <version.wildfly-jar.maven.plugin>2.0.0.Beta9</version.wildfly-jar.maven.plugin>
+        <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
+        <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>
 
     <dependencyManagement>
@@ -231,11 +230,6 @@
                                     </jkube-service>
                                 </config>
                             </enricher>
-                            <resources>
-                                <env>
-                                    <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
-                                </env>
-                            </resources>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/microprofile-jwt/src/main/jkube/route.yml
+++ b/microprofile-jwt/src/main/jkube/route.yml
@@ -1,4 +1,3 @@
-apiVersion: route.openshift.io/v1
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -22,10 +22,9 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <version.server.bootable-jar>21.0.0.Beta1</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>2.0.0.Beta7</version.wildfly-jar.maven.plugin>
-    <version.jkube.maven.plugin>1.0.0</version.jkube.maven.plugin>
-    <!-- not needed for WildFly, for XP 2.0, need a supported redhat builder image. Could be JDK8 or JDK11, us to choose -->
-    <jkube.generator.from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:latest</jkube.generator.from>
+    <version.wildfly-jar.maven.plugin>2.0.0.Beta9</version.wildfly-jar.maven.plugin>
+    <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
+    <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>
 
   <dependencies>
@@ -166,11 +165,6 @@
                   </jkube-service>
                 </config>
               </enricher>
-              <resources>
-                <env>
-                  <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
-                </env>
-              </resources>
             </configuration>
           </plugin>
         </plugins>

--- a/microprofile-metrics/src/main/jkube/route.yml
+++ b/microprofile-metrics/src/main/jkube/route.yml
@@ -1,4 +1,3 @@
-apiVersion: route.openshift.io/v1
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect

--- a/microprofile-openapi/pom.xml
+++ b/microprofile-openapi/pom.xml
@@ -19,10 +19,9 @@
 
     <properties>
         <version.server.bootable-jar>21.0.0.Beta1</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>2.0.0.Beta7</version.wildfly-jar.maven.plugin>
-        <version.jkube.maven.plugin>1.0.0</version.jkube.maven.plugin>
-        <!-- not needed for WildFly, for XP 2.0, need a supported redhat builder image. Could be JDK8 or JDK11, us to choose -->
-        <jkube.generator.from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:latest</jkube.generator.from>
+        <version.wildfly-jar.maven.plugin>2.0.0.Beta9</version.wildfly-jar.maven.plugin>
+        <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
+        <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>
 
     <dependencies>
@@ -120,11 +119,6 @@
                                     </jkube-service>
                                 </config>
                             </enricher>
-                            <resources>
-                                <env>
-                                    <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
-                                </env>
-                            </resources>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/microprofile-openapi/src/main/jkube/route.yml
+++ b/microprofile-openapi/src/main/jkube/route.yml
@@ -1,4 +1,3 @@
-apiVersion: route.openshift.io/v1
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -22,10 +22,9 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <version.server.bootable-jar>21.0.0.Beta1</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>2.0.0.Beta7</version.wildfly-jar.maven.plugin>
-    <version.jkube.maven.plugin>1.0.0</version.jkube.maven.plugin>
-    <!-- not needed for WildFly, for XP 2.0, need a supported redhat builder image. Could be JDK8 or JDK11, us to choose -->
-    <jkube.generator.from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:latest</jkube.generator.from>
+    <version.wildfly-jar.maven.plugin>2.0.0.Beta9</version.wildfly-jar.maven.plugin>
+    <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
+    <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>
 
   <dependencies>
@@ -170,11 +169,6 @@
                   </jkube-service>
                 </config>
               </enricher>
-              <resources>
-                <env>
-                  <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
-                </env>
-              </resources>
             </configuration>
           </plugin>
         </plugins>

--- a/microprofile-opentracing/src/main/jkube/route.yml
+++ b/microprofile-opentracing/src/main/jkube/route.yml
@@ -1,4 +1,3 @@
-apiVersion: route.openshift.io/v1
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect

--- a/microprofile-rest-client/country-client/pom.xml
+++ b/microprofile-rest-client/country-client/pom.xml
@@ -153,11 +153,6 @@
                   </jkube-service>
                 </config>
               </enricher>
-              <resources>
-                <env>
-                  <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
-                </env>
-              </resources>
             </configuration>
           </plugin>
         </plugins>

--- a/microprofile-rest-client/country-client/src/main/jkube/route.yml
+++ b/microprofile-rest-client/country-client/src/main/jkube/route.yml
@@ -1,4 +1,3 @@
-apiVersion: route.openshift.io/v1
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect

--- a/microprofile-rest-client/country-server/pom.xml
+++ b/microprofile-rest-client/country-server/pom.xml
@@ -115,11 +115,6 @@
                   </jkube-service>
                 </config>
               </enricher>
-              <resources>
-                <env>
-                  <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
-                </env>
-              </resources>
             </configuration>
           </plugin>
         </plugins>

--- a/microprofile-rest-client/country-server/src/main/jkube/route.yml
+++ b/microprofile-rest-client/country-server/src/main/jkube/route.yml
@@ -1,4 +1,3 @@
-apiVersion: route.openshift.io/v1
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect

--- a/microprofile-rest-client/pom.xml
+++ b/microprofile-rest-client/pom.xml
@@ -41,10 +41,9 @@
 
   <properties>
     <version.server.bootable-jar>21.0.0.Beta1</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>2.0.0.Beta7</version.wildfly-jar.maven.plugin>
-    <version.jkube.maven.plugin>1.0.0</version.jkube.maven.plugin>
-    <!-- not needed for WildFly, for XP 2.0, need a supported redhat builder image. Could be JDK8 or JDK11, us to choose -->
-    <jkube.generator.from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:latest</jkube.generator.from>
+    <version.wildfly-jar.maven.plugin>2.0.0.Beta9</version.wildfly-jar.maven.plugin>
+    <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
+    <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>
 
   <modules>

--- a/shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc
+++ b/shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc
@@ -134,11 +134,6 @@ You can use the Maven plug-in to build a {productName} bootable JAR, and then yo
                                   </jkube-service>
                               </config>
                           </enricher>
-                          <resources>
-                              <env>
-                                  <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
-                              </env>
-                          </resources>
                       </configuration>
                   </plugin>
               </plugins>
@@ -181,7 +176,6 @@ The `route.yml` file, which is located in the _src/main/jkube_ directory, is an 
 
 [options="nowrap",subs="attributes"]
 ----
-apiVersion: route.openshift.io/v1
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
* Upgrade to JKube 1.0.1
* Upgrade to Bootable JAR 2.0.0.Beta9.
* Removed api version in route.yml
* Removed java.net.preferIPv4Stack system property, automatically added by JKube.
* Use registry.redhat.io/ubi8/openjdk-11:latest image in all bootable quickstarts.