### PR TITLE
[WFLY-14178]: Deprecated using of TracerResolver.resolve() in MP OpenTracing Quickstart.

### DIFF
--- a/microprofile-opentracing/src/test/java/org/wildfly/quickstarts/microprofile/opentracing/MicroProfileOpenTracingIT.java
+++ b/microprofile-opentracing/src/test/java/org/wildfly/quickstarts/microprofile/opentracing/MicroProfileOpenTracingIT.java
@@ -17,7 +17,7 @@
 package org.wildfly.quickstarts.microprofile.opentracing;
 
 import io.opentracing.Tracer;
-import io.opentracing.contrib.tracerresolver.TracerResolver;
+import io.opentracing.contrib.tracerresolver.TracerFactory;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -82,7 +82,7 @@ public class MicroProfileOpenTracingIT {
         return ShrinkWrap.create(WebArchive.class)
             .addPackages(true, JaxRsApplication.class.getPackage())
             .addPackages(true, MockTracer.class.getPackage())
-            .addAsServiceProvider(TracerResolver.class, MockTracerResolver.class)
+            .addAsServiceProvider(TracerFactory.class, MockTracerFactory.class)
             // enable CDI
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }

--- a/microprofile-opentracing/src/test/java/org/wildfly/quickstarts/microprofile/opentracing/MockTracerFactory.java
+++ b/microprofile-opentracing/src/test/java/org/wildfly/quickstarts/microprofile/opentracing/MockTracerFactory.java
@@ -1,13 +1,13 @@
 package org.wildfly.quickstarts.microprofile.opentracing;
 
 import io.opentracing.Tracer;
-import io.opentracing.contrib.tracerresolver.TracerResolver;
+import io.opentracing.contrib.tracerresolver.TracerFactory;
 import io.opentracing.mock.MockTracer;
 
-public class MockTracerResolver extends TracerResolver {
+public class MockTracerFactory implements TracerFactory {
 
     @Override
-    protected Tracer resolve() {
+    public Tracer getTracer() {
         return new MockTracer();
     }
 }


### PR DESCRIPTION
* Using non depercated API.

Jira: https://issues.redhat.com/browse/WFLY-14178