### PR TITLE
[WFLY-14173] set asciidoc plugin output directory to .

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -644,6 +644,7 @@
                             <sourceDirectory>.</sourceDirectory>
                             <sourceDocumentName>README.adoc</sourceDocumentName>
                             <outputFile>README.html</outputFile>
+                            <outputDirectory>.</outputDirectory>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14173