### PR TITLE
Fix for WFLY-14463, Make bootable JAR to fork provisioning and CLI execution

### DIFF
--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -103,6 +103,9 @@
                               <layer>jaxrs-server</layer>
                               <layer>microprofile-platform</layer>
                           </layers>
+                          <plugin-options>
+                              <jboss-fork-embedded>true</jboss-fork-embedded>
+                          </plugin-options>
                       </configuration>
                       <executions>
                           <execution>
@@ -129,6 +132,9 @@
                               <layer>jaxrs-server</layer>
                               <layer>microprofile-platform</layer>
                           </layers>
+                          <plugin-options>
+                              <jboss-fork-embedded>true</jboss-fork-embedded>
+                          </plugin-options>
                           <cloud/>
                       </configuration>
                       <executions>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -175,6 +175,9 @@
                                 <layer>jaxrs-server</layer>
                                 <layer>microprofile-platform</layer>
                             </layers>
+                            <plugin-options>
+                                <jboss-fork-embedded>true</jboss-fork-embedded>
+                            </plugin-options>
                         </configuration>
                         <executions>
                             <execution>
@@ -201,6 +204,9 @@
                                 <layer>jaxrs-server</layer>
                                 <layer>microprofile-platform</layer>
                             </layers>
+                            <plugin-options>
+                                <jboss-fork-embedded>true</jboss-fork-embedded>
+                            </plugin-options>
                             <cloud/>
                         </configuration>
                         <executions>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -115,6 +115,9 @@
                 <layer>jaxrs-server</layer>
                 <layer>microprofile-platform</layer>
               </layers>
+              <plugin-options>
+                <jboss-fork-embedded>true</jboss-fork-embedded>
+              </plugin-options>
             </configuration>
             <executions>
               <execution>
@@ -141,6 +144,9 @@
                 <layer>jaxrs-server</layer>
                 <layer>microprofile-platform</layer>
               </layers>
+              <plugin-options>
+                <jboss-fork-embedded>true</jboss-fork-embedded>
+              </plugin-options>
               <cloud/>
             </configuration>
             <executions>

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -173,6 +173,9 @@
                                 <layer>jaxrs-server</layer>
                                 <layer>microprofile-platform</layer>
                             </layers>
+                            <plugin-options>
+                                <jboss-fork-embedded>true</jboss-fork-embedded>
+                            </plugin-options>
                         </configuration>
                         <executions>
                             <execution>
@@ -200,6 +203,9 @@
                                 <layer>jaxrs-server</layer>
                                 <layer>microprofile-platform</layer>
                             </layers>
+                            <plugin-options>
+                                <jboss-fork-embedded>true</jboss-fork-embedded>
+                            </plugin-options>
                             <cloud/>
                         </configuration>
                         <executions>

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -109,6 +109,9 @@
                 <layer>jaxrs-server</layer>
                 <layer>microprofile-platform</layer>
               </layers>
+              <plugin-options>
+                <jboss-fork-embedded>true</jboss-fork-embedded>
+              </plugin-options>
             </configuration>
             <executions>
               <execution>
@@ -135,6 +138,9 @@
                 <layer>jaxrs-server</layer>
                 <layer>microprofile-platform</layer>
               </layers>
+              <plugin-options>
+                <jboss-fork-embedded>true</jboss-fork-embedded>
+              </plugin-options>
               <cloud/>
             </configuration>
             <executions>

--- a/microprofile-openapi/pom.xml
+++ b/microprofile-openapi/pom.xml
@@ -63,6 +63,9 @@
                                 <layer>jaxrs-server</layer>
                                 <layer>microprofile-platform</layer>
                             </layers>
+                            <plugin-options>
+                                <jboss-fork-embedded>true</jboss-fork-embedded>
+                            </plugin-options>
                         </configuration>
                         <executions>
                             <execution>
@@ -89,6 +92,9 @@
                                 <layer>jaxrs-server</layer>
                                 <layer>microprofile-platform</layer>
                             </layers>
+                            <plugin-options>
+                                <jboss-fork-embedded>true</jboss-fork-embedded>
+                            </plugin-options>
                             <cloud/>
                         </configuration>
                         <executions>

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -113,6 +113,9 @@
                 <layer>jaxrs-server</layer>
                 <layer>microprofile-platform</layer>
               </layers>
+              <plugin-options>
+                <jboss-fork-embedded>true</jboss-fork-embedded>
+              </plugin-options>
             </configuration>
             <executions>
               <execution>
@@ -139,6 +142,9 @@
                 <layer>jaxrs-server</layer>
                 <layer>microprofile-platform</layer>
               </layers>
+              <plugin-options>
+                <jboss-fork-embedded>true</jboss-fork-embedded>
+              </plugin-options>
               <cloud/>
             </configuration>
             <executions>

--- a/microprofile-rest-client/country-client/pom.xml
+++ b/microprofile-rest-client/country-client/pom.xml
@@ -99,6 +99,9 @@
                 <layer>jaxrs-server</layer>
                 <layer>microprofile-platform</layer>
               </layers>
+              <plugin-options>
+                <jboss-fork-embedded>true</jboss-fork-embedded>
+              </plugin-options>
             </configuration>
             <executions>
               <execution>
@@ -124,6 +127,9 @@
                 <layer>jaxrs-server</layer>
                 <layer>microprofile-platform</layer>
               </layers>
+              <plugin-options>
+                <jboss-fork-embedded>true</jboss-fork-embedded>
+              </plugin-options>
               <cloud/>
             </configuration>
             <executions>

--- a/microprofile-rest-client/country-server/pom.xml
+++ b/microprofile-rest-client/country-server/pom.xml
@@ -61,6 +61,9 @@
                 <layer>jaxrs-server</layer>
                 <layer>microprofile-platform</layer>
               </layers>
+              <plugin-options>
+                <jboss-fork-embedded>true</jboss-fork-embedded>
+              </plugin-options>
             </configuration>
             <executions>
               <execution>
@@ -86,6 +89,9 @@
                 <layer>jaxrs-server</layer>
                 <layer>microprofile-platform</layer>
               </layers>
+              <plugin-options>
+                <jboss-fork-embedded>true</jboss-fork-embedded>
+              </plugin-options>
               <cloud/>
             </configuration>
             <executions>

--- a/shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc
+++ b/shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc
@@ -22,6 +22,9 @@ You can use the Maven plug-in to build a {productName} bootable JAR, and then yo
                               <layer>jaxrs-server</layer>
                               <layer>microprofile-platform</layer>
                           </layers>
+                          <plugin-options>
+                              <jboss-fork-embedded>true</jboss-fork-embedded>
+                          </plugin-options>
                       </configuration>
                       <executions>
                           <execution>
@@ -105,6 +108,9 @@ You can use the Maven plug-in to build a {productName} bootable JAR, and then yo
                               <layer>jaxrs-server</layer>
                               <layer>microprofile-platform</layer>
                           </layers>
+                          <plugin-options>
+                              <jboss-fork-embedded>true</jboss-fork-embedded>
+                          </plugin-options>
                           <cloud/>
                       </configuration>
                       <executions>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14463

Forked CLI execution and Galleon provisioning implies much less memory consumed, required for s2i build on Openshift.