### PR TITLE
[WFLY-12904] s2i build fix for quickstart ejb-txn-remote-call

### DIFF
--- a/ejb-txn-remote-call/client/client-cr.yaml
+++ b/ejb-txn-remote-call/client/client-cr.yaml
@@ -11,7 +11,7 @@ spec:
     - name: DB_SERVICE_PREFIX_MAPPING
       value: test-postgresql=TEST
     - name: TEST_NONXA
-      value: false
+      value: 'false'
     - name: TEST_JNDI
       value: java:jboss/datasources/ejbJtaDs
     - name: TEST_POSTGRESQL_SERVICE_HOST

--- a/ejb-txn-remote-call/client/pom.xml
+++ b/ejb-txn-remote-call/client/pom.xml
@@ -20,9 +20,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.wildfly.quickstarts</groupId>
-        <artifactId>ejb-txn-remote-call</artifactId>
+        <artifactId>quickstart-parent</artifactId>
         <version>24.0.0.Beta1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>ejb-txn-remote-call-client</artifactId>

--- a/ejb-txn-remote-call/server/pom.xml
+++ b/ejb-txn-remote-call/server/pom.xml
@@ -20,9 +20,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.wildfly.quickstarts</groupId>
-        <artifactId>ejb-txn-remote-call</artifactId>
+        <artifactId>quickstart-parent</artifactId>
         <version>24.0.0.Beta1-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>ejb-txn-remote-call-server</artifactId>

--- a/ejb-txn-remote-call/server/server-cr.yaml
+++ b/ejb-txn-remote-call/server/server-cr.yaml
@@ -9,7 +9,7 @@ spec:
     - name: DB_SERVICE_PREFIX_MAPPING
       value: test-postgresql=TEST
     - name: TEST_NONXA
-      value: false
+      value: 'false'
     - name: TEST_JNDI
       value: java:jboss/datasources/ejbJtaDs
     - name: TEST_POSTGRESQL_SERVICE_HOST


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-12904

Fixing s2i build issue for the quickstart. The s2i works only with the context dir project which is an issue for this multi module quickstart. With that the quickstart does not publish all artifacts to maven central and thus issue with dependency lookup happens in s2i build.

