### PR TITLE
[WFLY-14650] Warn message SRMSG18216: No `group.id` set during microp…

### DIFF
--- a/microprofile-reactive-messaging-kafka/src/main/resources/META-INF/microprofile-config.properties
+++ b/microprofile-reactive-messaging-kafka/src/main/resources/META-INF/microprofile-config.properties
@@ -8,3 +8,7 @@ mp.messaging.outgoing.to-kafka.value.serializer=org.wildfly.quickstarts.micropro
 mp.messaging.incoming.from-kafka.connector=smallrye-kafka
 mp.messaging.incoming.from-kafka.topic=testing
 mp.messaging.incoming.from-kafka.value.deserializer=org.wildfly.quickstarts.microprofile.reactive.messaging.TimedEntryDeserializer
+
+# Configure Kafka group.id to prevent warn message - if not set, some default value is generated automatically.
+mp.messaging.connector.smallrye-kafka.group.id="microprofile-reactive-messaging-kafka-group-id"
+


### PR DESCRIPTION
…rofile-reactive-messaging-kafka QS

https://issues.redhat.com/browse/WFLY-14650