### PR TITLE
[WFLY-14720] move web functional tests to phantomjs browser

### DIFF
--- a/contacts-jquerymobile/functional-tests/src/test/resources/arquillian.xml
+++ b/contacts-jquerymobile/functional-tests/src/test/resources/arquillian.xml
@@ -32,13 +32,8 @@
 
     <!-- WebDriver extension -->
     <extension qualifier="webdriver">
-        <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
-        <property name="browser">firefox</property>
-        <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. -->
-        <!--
-        <property name="firefox_binary">/path/to/firefox/binary</property>
-        -->
+        <!-- By default, the browser you are going to use for your tests is set to Phantom. -->
+        <property name="browser">phantomjs</property>
     </extension>
 
 </arquillian>

--- a/helloworld-html5/functional-tests/src/test/resources/arquillian.xml
+++ b/helloworld-html5/functional-tests/src/test/resources/arquillian.xml
@@ -32,13 +32,8 @@
 
     <!-- WebDriver extension -->
     <extension qualifier="webdriver">
-        <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
-        <property name="browser">firefox</property>
-        <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. -->
-        <!--
-        <property name="firefox_binary">/path/to/firefox/binary</property>
-        -->
+        <!-- By default, the browser you are going to use for your tests is set to Phantom. -->
+        <property name="browser">phantomjs</property>
     </extension>
 
 </arquillian>

--- a/kitchensink-angularjs/functional-tests/src/test/resources/arquillian.xml
+++ b/kitchensink-angularjs/functional-tests/src/test/resources/arquillian.xml
@@ -32,13 +32,8 @@
 
     <!-- WebDriver extension -->
     <extension qualifier="webdriver">
-        <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
-        <property name="browser">firefox</property>
-        <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. -->
-        <!--
-        <property name="firefox_binary">/path/to/firefox/binary</property>
-        -->
+        <!-- By default, the browser you are going to use for your tests is set to Phantom. -->
+        <property name="browser">phantomjs</property>
     </extension>
 
 </arquillian>

--- a/spring-greeter/functional-tests/src/test/resources/arquillian.xml
+++ b/spring-greeter/functional-tests/src/test/resources/arquillian.xml
@@ -32,13 +32,8 @@
 
     <!-- WebDriver extension -->
     <extension qualifier="webdriver">
-        <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
-        <property name="browser">firefox</property>
-        <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. -->
-        <!--
-        <property name="firefox_binary">/path/to/firefox/binary</property>
-        -->
+        <!-- By default, the browser you are going to use for your tests is set to Phantom. -->
+        <property name="browser">phantomjs</property>
     </extension>
 
 </arquillian>

--- a/spring-kitchensink-basic/functional-tests/src/test/resources/arquillian.xml
+++ b/spring-kitchensink-basic/functional-tests/src/test/resources/arquillian.xml
@@ -32,13 +32,8 @@
 
     <!-- WebDriver extension -->
     <extension qualifier="webdriver">
-        <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
-        <property name="browser">firefox</property>
-        <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. -->
-        <!--
-        <property name="firefox_binary">/path/to/firefox/binary</property>
-        -->
+        <!-- By default, the browser you are going to use for your tests is set to Phantom. -->
+        <property name="browser">phantomjs</property>
     </extension>
 
 </arquillian>

--- a/spring-kitchensink-springmvctest/functional-tests/src/test/resources/arquillian.xml
+++ b/spring-kitchensink-springmvctest/functional-tests/src/test/resources/arquillian.xml
@@ -32,13 +32,8 @@
 
     <!-- WebDriver extension -->
     <extension qualifier="webdriver">
-        <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
-        <property name="browser">firefox</property>
-        <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver
-            will use the default one in your system otherwise. -->
-        <!--
-        <property name="firefox_binary">/path/to/firefox/binary</property>
-        -->
+        <!-- By default, the browser you are going to use for your tests is set to Phantom. -->
+        <property name="browser">phantomjs</property>
     </extension>
 
 </arquillian>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14720
This partial fix of the issue updates all Quickstarts functional tests to use PhantomJS WebDriver browser, instead of Firefox, which recent versions have issues with Arquillian Graphene.