### PR TITLE
[WFLY-14702] Quickstart ejb-multi-server failing on client invocation…

### DIFF
--- a/ejb-multi-server/app-main/ejb/pom.xml
+++ b/ejb-multi-server/app-main/ejb/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>jboss-annotations-api_1.3_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.ejb3</groupId>
+            <artifactId>jboss-ejb3-ext-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ejb-multi-server/app-main/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/MainAppBean.java
+++ b/ejb-multi-server/app-main/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/MainAppBean.java
@@ -28,6 +28,8 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
+import org.jboss.ejb3.annotation.SecurityDomain;
+
 import org.jboss.logging.Logger;
 
 /**
@@ -38,6 +40,7 @@ import org.jboss.logging.Logger;
  * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
  */
 @Stateless
+@SecurityDomain("other")
 public class MainAppBean implements MainApp {
     private static final Logger LOGGER = Logger.getLogger(MainAppBean.class);
     @Resource

--- a/ejb-multi-server/app-one/ejb/pom.xml
+++ b/ejb-multi-server/app-one/ejb/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.ejb3</groupId>
+            <artifactId>jboss-ejb3-ext-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ejb-multi-server/app-one/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppOneBean.java
+++ b/ejb-multi-server/app-one/ejb/src/main/java/org/jboss/as/quickstarts/ejb/multi/server/app/AppOneBean.java
@@ -22,6 +22,8 @@ import javax.annotation.Resource;
 import javax.ejb.SessionContext;
 import javax.ejb.Stateless;
 
+import org.jboss.ejb3.annotation.SecurityDomain;
+
 import org.jboss.logging.Logger;
 
 /**
@@ -37,6 +39,7 @@ import org.jboss.logging.Logger;
  * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
  */
 @Stateless
+@SecurityDomain("other")
 public class AppOneBean implements AppOne {
     private static final Logger LOGGER = Logger.getLogger(AppOneBean.class);
 

--- a/ejb-multi-server/install-domain.cli
+++ b/ejb-multi-server/install-domain.cli
@@ -21,6 +21,7 @@ batch
 /host=master/core-service=management/security-realm=ApplicationRealm/authentication=local:remove
 
 /profile=default/subsystem=ejb3:write-attribute(name=default-missing-method-permissions-deny-access, value=false)
+/profile=full/subsystem=ejb3:write-attribute(name=default-missing-method-permissions-deny-access, value=false)
 /profile=ha/subsystem=ejb3:write-attribute(name=default-missing-method-permissions-deny-access, value=false)
 
 # Set the property for unique Tx node identifier
@@ -236,6 +237,12 @@ batch
 /server-group=quickstart-ejb-multi-appWeb-server/jvm=default:add()
 /host=master/server-config=app-web:add(auto-start=true, group=quickstart-ejb-multi-appWeb-server, socket-binding-port-offset=300)
 /host=master/server-config=app-web/system-property=txNodeIdentifier:add(value=web)
+
+# update interface bind addresses from '127.0.0.1' to 'localhost' to workaround an authentication issue
+/host=master/interface=management:write-attribute(name=inet-address, value="${jboss.bind.address.management:localhost}"
+/host=master/interface=public:write-attribute(name=inet-address, value="${jboss.bind.address:localhost}"
+/interface=private:write-attribute(name=inet-address, value="${jboss.bind.address.private:localhost}")
+/interface=unsecure:write-attribute(name=inet-address, value="${jboss.bind.address.unsecure:localhost}")
 
 # Run the batch
 run-batch


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14702

- fixed quickstart by adding the missing @SecurityDomain("other")
  annotation on the SLSBs
  This fixes the issue of the principal 'anonymous' seen in the output
- added the workaround to provide a default Elytron
  'authentication-context' for the transaction handling