### PR TITLE
Fix for WFLY-14911, Upgrade quickstarts to use Bootable JAR plugin 5.0.0.Final

### DIFF
--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
       <version.server.bootable-jar>24.0.0.Beta1</version.server.bootable-jar>
-      <version.wildfly-jar.maven.plugin>5.0.0.Beta1</version.wildfly-jar.maven.plugin>
+      <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
       <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
       <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -52,7 +52,7 @@
 
     <properties>
         <version.server.bootable-jar>24.0.0.Beta1</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>5.0.0.Beta1</version.wildfly-jar.maven.plugin>
+        <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
         <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -22,7 +22,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <management.http.url>http://localhost:9990</management.http.url>
     <version.server.bootable-jar>24.0.0.Beta1</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>5.0.0.Beta1</version.wildfly-jar.maven.plugin>
+    <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -44,7 +44,7 @@
     <properties>
         <version.glassfish.json>1.1.6</version.glassfish.json>
         <version.server.bootable-jar>24.0.0.Beta1</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>5.0.0.Beta1</version.wildfly-jar.maven.plugin>
+        <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
         <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -22,7 +22,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <version.server.bootable-jar>24.0.0.Beta1</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>5.0.0.Beta1</version.wildfly-jar.maven.plugin>
+    <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>

--- a/microprofile-openapi/pom.xml
+++ b/microprofile-openapi/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <version.server.bootable-jar>24.0.0.Beta1</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>5.0.0.Beta1</version.wildfly-jar.maven.plugin>
+        <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
         <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -22,7 +22,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <version.server.bootable-jar>24.0.0.Beta1</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>5.0.0.Beta1</version.wildfly-jar.maven.plugin>
+    <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>

--- a/microprofile-reactive-messaging-kafka/pom.xml
+++ b/microprofile-reactive-messaging-kafka/pom.xml
@@ -41,7 +41,7 @@
         <version.org.springframework.kafka>2.6.4</version.org.springframework.kafka>
         <!-- Plugin versions -->
         <version.server.bootable-jar>24.0.0.Beta1</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>5.0.0.Beta1</version.wildfly-jar.maven.plugin>
+        <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
         <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>

--- a/microprofile-rest-client/pom.xml
+++ b/microprofile-rest-client/pom.xml
@@ -41,7 +41,7 @@
 
   <properties>
     <version.server.bootable-jar>24.0.0.Beta1</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>5.0.0.Beta1</version.wildfly-jar.maven.plugin>
+    <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>

--- a/todo-backend/pom.xml
+++ b/todo-backend/pom.xml
@@ -44,8 +44,8 @@
 
     <properties>
         <version.server.bootable-jar>24.0.0.Beta1</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>5.0.0.Beta1</version.wildfly-jar.maven.plugin>
-        <version.wildfly-datasources-galleon-pack>2.0.1.Final</version.wildfly-datasources-galleon-pack>
+        <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
+        <version.wildfly-datasources-galleon-pack>2.0.2.Final</version.wildfly-datasources-galleon-pack>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
In addition upgraded wildfly-datasources-galleon-pack to 2.0.2.Final
