### PR TITLE
[WFLY-14927] Use standalone-microprofile.xml in MicroProfile quicksta…

### DIFF
--- a/microprofile-config/README.adoc
+++ b/microprofile-config/README.adoc
@@ -8,7 +8,7 @@ include::../shared-doc/attributes.adoc[]
 [abstract]
 The `microprofile-config` quickstart demonstrates the use of the MicroProfile Config specification in {productName}.
 
-:standalone-server-type: default
+:standalone-server-type: microprofile
 :archiveType: war
 :archiveName: {artifactId}
 :arq-prerequisities: These tests require that JBOSS_HOME environment variable is set.

--- a/microprofile-health/README.adoc
+++ b/microprofile-health/README.adoc
@@ -8,7 +8,7 @@ include::../shared-doc/attributes.adoc[]
 [abstract]
 The `microprofile-health` quickstart demonstrates the use of the MicroProfile Health specification in {productName}.
 
-:standalone-server-type: default
+:standalone-server-type: microprofile
 :archiveType: war
 :archiveName: {artifactId}
 :include-management-port: http://localhost:9990/health/live

--- a/microprofile-metrics/README.adoc
+++ b/microprofile-metrics/README.adoc
@@ -8,7 +8,7 @@ include::../shared-doc/attributes.adoc[]
 [abstract]
 The `microprofile-metrics` quickstart demonstrates the use of the MicroProfile Metrics specification use in {productName}.
 
-:standalone-server-type: default
+:standalone-server-type: microprofile
 :archiveType: jar
 :archiveName: {artifactId}
 

--- a/microprofile-opentracing/README.adoc
+++ b/microprofile-opentracing/README.adoc
@@ -8,7 +8,7 @@ include::../shared-doc/attributes.adoc[]
 [abstract]
 The `microprofile-opentracing` quickstart demonstrates the use of the MicroProfile OpenTracing specification in {productName}.
 
-:standalone-server-type: default
+:standalone-server-type: microprofile
 :archiveType: war
 :archiveName: {artifactId}
 :uses-jaeger:

--- a/microprofile-rest-client/README.adoc
+++ b/microprofile-rest-client/README.adoc
@@ -8,7 +8,7 @@ include::../shared-doc/attributes.adoc[]
 [abstract]
 The `microprofile-rest-client` quickstart demonstrates the use of the MicroProfile REST Client specification in {productName}.
 
-:standalone-server-type: default
+:standalone-server-type: microprofile
 :archiveType: jar
 :archiveName: {artifactId}
 :rest-client-qs:


### PR DESCRIPTION
…rts by default

Issue: https://issues.redhat.com/browse/WFLY-14927 
downstream issue: https://issues.redhat.com/browse/JBEAP-22093

`fault-tolerance`, `jwt` and `openapi` have already used `microprofile` in standalone server type

`microprofile-reactive-messaging-kafka` enables required extension and subsystem from a CLI script. 
