### PR TITLE
[microprofile-config] Run Arquillian tests with Bootable Jar

### DIFF
--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -22,6 +22,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
       <version.server.bootable-jar>24.0.0.Final</version.server.bootable-jar>
       <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
+      <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
       <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
       <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>
@@ -69,6 +70,12 @@
       <artifactId>commons-logging-jboss-logging</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-bootable</artifactId>
+          <version>${version.org.wildfly.arquillian}</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <build>
@@ -111,6 +118,28 @@
                           <execution>
                               <goals>
                                   <goal>package</goal>
+                              </goals>
+                          </execution>
+                      </executions>
+                  </plugin>
+                  <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-failsafe-plugin</artifactId>
+                      <version>${version.failsafe.plugin}</version>
+                      <configuration>
+                          <environmentVariables>
+                              <JBOSS_HOME>${project.build.directory}/wildfly-it</JBOSS_HOME>
+                          </environmentVariables>
+                          <systemPropertyVariables>
+                              <install.dir>${project.build.directory}/wildfly-it</install.dir>
+                              <bootable.jar>${project.build.directory}/${project.build.finalName}-bootable.jar</bootable.jar>
+                          </systemPropertyVariables>
+                      </configuration>
+                      <executions>
+                          <execution>
+                              <goals>
+                                  <goal>integration-test</goal>
+                                  <goal>verify</goal>
                               </goals>
                           </execution>
                       </executions>

--- a/microprofile-config/src/test/resources/arquillian.xml
+++ b/microprofile-config/src/test/resources/arquillian.xml
@@ -18,18 +18,10 @@
             xsi:schemaLocation="http://jboss.org/schema/arquillian
     http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-  <!-- Uncomment to have test archives exported to the file system for inspection -->
-  <!-- <engine> -->
-  <!-- <property name="deploymentExportPath">target/</property> -->
-  <!-- </engine> -->
-
-  <!-- Example configuration for a managed ${product.name} instance -->
   <container qualifier="jboss" default="true">
-    <!-- By default, Arquillian will use the JBOSS_HOME environment variable to find the ${product.name} installation.
-         If you prefer not to define the JBOSS_HOME environment variable, alternatively you can uncomment the
-         following `jbossHome` property and replace ${jboss.home.name} with the path to your ${product.name} installation. -->
-    <!--<configuration>
-        <property name="jbossHome">${jboss.home.name}</property>
-    </configuration> -->
+    <configuration>
+      <property name="installDir">${install.dir}</property>
+      <property name="jarFile">${bootable.jar}</property>
+    </configuration>
   </container>
 </arquillian>


### PR DESCRIPTION
Switch to the arquillian bootable jar container to run the integration
tests. As the bootable jar contains the actual deployment, the tests
becomes a pure client tests (no @Deployment in the tests)

Tests can be run with `mvn clean verify -Pbootable-jar`

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>