### PR TITLE
[WFLY-15005] Update io.opentracing dependencies to match server version

### DIFF
--- a/microprofile-opentracing/README.adoc
+++ b/microprofile-opentracing/README.adoc
@@ -396,7 +396,7 @@ dependency providing the OpenTracing API:
 <dependency>
   <groupId>io.opentracing</groupId>
   <artifactId>opentracing-api</artifactId>
-  <version>0.31.0</version>
+  <version>0.33.0</version>
 </dependency>
 ----
 

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
-      <version>0.31.0</version>
+      <version>0.33.0</version>
     </dependency>
 
 
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-mock</artifactId>
-      <version>0.31.0</version>
+      <version>0.33.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-15005

There are incompatible changes in new io.opentracing artifacts so we need to use the updated ones (matching the ones included in server) for QS to work - some context https://github.com/opentracing/opentracing-java/issues/374