### PR TITLE
[WFLY-15074] Fix EAPQuickStartRepoTag doc attribute

### DIFF
--- a/shared-doc/attributes.adoc
+++ b/shared-doc/attributes.adoc
@@ -99,7 +99,7 @@ endif::[]
 // OpenShift repository and reference for quickstarts
 :EAPQuickStartRepo: https://github.com/jboss-developer/jboss-eap-quickstarts
 :EAPQuickStartRepoRef: 7.4.x
-:EAPQuickStartRepoTag: EAP_7.4.0.Final
+:EAPQuickStartRepoTag: EAP_7.4.0.GA
 // Links to the OpenShift documentation
 :LinkOpenShiftGuide: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/getting_started_with_jboss_eap_for_openshift_container_platform/
 :LinkOpenShiftOnlineGuide: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/getting_started_with_jboss_eap_for_openshift_online/


### PR DESCRIPTION
Set its value to EAP_7.4.0.GA

JIRA: https://issues.redhat.com/browse/WFLY-15074

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>