### PR TITLE
[WFLY-13908] pom.xml wildfly-checkstyle-config update to 1.0.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <!-- A base list of dependency and plug-in version used in the various quick starts. -->
         <version.org.asciidoctor.asciidoctor-maven-plugin>2.1.0</version.org.asciidoctor.asciidoctor-maven-plugin>
         <version.wildfly.maven.plugin>2.0.2.Final</version.wildfly.maven.plugin>
-        <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
+        <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.quickstarts.documentation.plugin>2.3.0.Final</version.org.wildfly.quickstarts.documentation.plugin>
         <!-- other plug-in versions -->
         <version.com.mycyla.license>3.0</version.com.mycyla.license>


### PR DESCRIPTION
Based on a reported issue [WFLY-13908](https://issues.redhat.com/browse/WFLY-13908) Eclipse m2e mapping for checkstyle uses version 8.35, while quickstart uses version 8.5 with maven CLI. As a result, running inside Eclipse has the error _(with any checkstyle >= 8.19)_: TreeWalker has no cacheFile property.
 This checkstyle config was updated in wildfly-config-checkstyle 1.0.8.Final to be >= 8.19 compatible, therefore an update of pom.xml is needed to be aligned with latest wildfly checkstyle config.