### PR TITLE
[WFLY-12142] move dependency management to each quickstart project

### DIFF
--- a/app-client/pom.xml
+++ b/app-client/pom.xml
@@ -50,6 +50,23 @@
         <module>ear</module>
     </modules>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>

--- a/batch-processing/pom.xml
+++ b/batch-processing/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in

--- a/bean-validation-custom-constraint/pom.xml
+++ b/bean-validation-custom-constraint/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- First declare the APIs we depend on and need for compilation.

--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- First declare the APIs we depend on and need for compilation.

--- a/bmt/pom.xml
+++ b/bmt/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Import the injection annotations -->
         <dependency>

--- a/contacts-jquerymobile/functional-tests/pom.xml
+++ b/contacts-jquerymobile/functional-tests/pom.xml
@@ -34,7 +34,22 @@
     <properties>
         <!-- To disable warning of missing beans.xml file in JBoss Tools -->
         <m2e.cdi.activation>false</m2e.cdi.activation>
+        <version.org.json>20150729</version.org.json>
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/contacts-jquerymobile/pom.xml
+++ b/contacts-jquerymobile/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>commons-io</groupId>
@@ -188,7 +205,7 @@
                     <plugin>
                         <groupId>ro.isdc.wro4j</groupId>
                         <artifactId>wro4j-maven-plugin</artifactId>
-                        <version>${version.ro.isdc.wro4j}</version>
+                        <version>1.7.9</version>
                         <configuration>
                             <targetGroups>app.min,formSetup.min,namespace.min,submissions.min,theming.min,util.min,validation.min,app-style.min,validator.min
                             </targetGroups>

--- a/deltaspike-authorization/pom.xml
+++ b/deltaspike-authorization/pom.xml
@@ -41,9 +41,21 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.deltaspike.core>1.5.1</version.deltaspike.core>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
-
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Deltaspike API. We use compile scope as we need it to compile the project against the API -->
             <dependency>
                 <groupId>org.apache.deltaspike.core</groupId>
@@ -51,7 +63,6 @@
                 <version>${version.deltaspike.core}</version>
                 <scope>compile</scope>
             </dependency>
-
             <!-- Deltaspike Impl. We use runtime scope as we only need the implementation
                 classes at runtime -->
             <dependency>

--- a/deltaspike-beanbuilder/pom.xml
+++ b/deltaspike-beanbuilder/pom.xml
@@ -41,9 +41,21 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.deltaspike.core>1.5.1</version.deltaspike.core>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
-
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Deltaspike API. We use compile scope as we need it to compile the project against the API -->
             <dependency>
                 <groupId>org.apache.deltaspike.core</groupId>
@@ -51,7 +63,6 @@
                 <version>${version.deltaspike.core}</version>
                 <scope>compile</scope>
             </dependency>
-
             <!-- Deltaspike Impl. We use runtime scope as we only need the implementation
                 classes at runtime -->
             <dependency>
@@ -61,7 +72,6 @@
                 <version>${version.deltaspike.core}</version>
             </dependency>
         </dependencies>
-
     </dependencyManagement>
 
     <dependencies>

--- a/deltaspike-projectstage/pom.xml
+++ b/deltaspike-projectstage/pom.xml
@@ -41,9 +41,21 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.deltaspike.core>1.5.1</version.deltaspike.core>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
-
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Deltaspike API. We use compile scope as we need it to compile the project against the API -->
             <dependency>
                 <groupId>org.apache.deltaspike.core</groupId>
@@ -51,7 +63,6 @@
                 <version>${version.deltaspike.core}</version>
                 <scope>compile</scope>
             </dependency>
-
             <!-- Deltaspike Impl. We use runtime scope as we only need the implementation
                 classes at runtime -->
             <dependency>
@@ -61,7 +72,6 @@
                 <version>${version.deltaspike.core}</version>
             </dependency>
         </dependencies>
-
     </dependencyManagement>
 
     <dependencies>

--- a/ee-security/pom.xml
+++ b/ee-security/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Dependencies are included with a scope of 'provided' as they 

--- a/ejb-asynchronous/pom.xml
+++ b/ejb-asynchronous/pom.xml
@@ -46,9 +46,20 @@
         <module>client</module>
     </modules>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
-
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Specify the version of the ejb-client jar of the deployed
                 ejb jar -->
             <dependency>

--- a/ejb-in-ear/pom.xml
+++ b/ejb-in-ear/pom.xml
@@ -47,8 +47,20 @@
         <module>ear</module>
     </modules>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Define the version of the EJB jar so that we don't need
                 to repeat ourselves in every module -->
             <dependency>

--- a/ejb-in-war/pom.xml
+++ b/ejb-in-war/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/ejb-multi-server/pom.xml
+++ b/ejb-multi-server/pom.xml
@@ -44,6 +44,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>app-one</module>
         <module>app-two</module>

--- a/ejb-remote/pom.xml
+++ b/ejb-remote/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <!-- This quickstart consists of a server side component and a client that accesses
      the server side component. Each component has its own self contain pom. However,
      you can add these modules here to keep things modular.

--- a/ejb-security-context-propagation/pom.xml
+++ b/ejb-security-context-propagation/pom.xml
@@ -42,11 +42,23 @@
     </licenses>
 
     <properties>
-
         <!-- To run this quickstart in Eclipse, we must turn on JDT APT to activate annotation processing-->
         <m2e.apt.activation>jdt_apt</m2e.apt.activation>
-
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- The EJB Client BOM provides application server-compatible dependency management,

--- a/ejb-security-jaas/pom.xml
+++ b/ejb-security-jaas/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- The EJB Client BOM provides application server-compatible dependency management,
         used for building, testing or debugging EJB client applications. Import the BOM to the

--- a/ejb-security-programmatic-auth/pom.xml
+++ b/ejb-security-programmatic-auth/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.wildfly.security</groupId>

--- a/ejb-security/pom.xml
+++ b/ejb-security/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- The EJB Client BOM provides application server-compatible dependency management,
         used for building, testing or debugging EJB client applications. Import the BOM to the

--- a/ejb-throws-exception/pom.xml
+++ b/ejb-throws-exception/pom.xml
@@ -48,8 +48,20 @@
         <module>ejb-api</module>
     </modules>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 
             <!-- Define the version of the EJB jar so that we don't need
                 to repeat ourselves in every module -->

--- a/ejb-timer/pom.xml
+++ b/ejb-timer/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <!-- Dependencies. -->
     <dependencies>
         <!-- "provided" scope used for API's included in JBoss EAP. -->

--- a/ejb-txn-remote-call/client/pom.xml
+++ b/ejb-txn-remote-call/client/pom.xml
@@ -30,6 +30,23 @@
     <name>Quickstart: ejb-txn-remote-call-client</name>
     <description>The project is the application to be deployed on the client server to call the second server</description>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Import the CDI API -->
         <dependency>

--- a/ejb-txn-remote-call/server/pom.xml
+++ b/ejb-txn-remote-call/server/pom.xml
@@ -32,7 +32,21 @@
 
     <properties>
         <version.narayana>5.10.6.Final</version.narayana>
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Import the WS/JAX-RS -->

--- a/greeter/pom.xml
+++ b/greeter/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/ha-singleton-deployment/pom.xml
+++ b/ha-singleton-deployment/pom.xml
@@ -48,6 +48,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>

--- a/ha-singleton-service/pom.xml
+++ b/ha-singleton-service/pom.xml
@@ -43,6 +43,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.msc</groupId>

--- a/helloworld-classfiletransformer/pom.xml
+++ b/helloworld-classfiletransformer/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
 

--- a/helloworld-html5/functional-tests/pom.xml
+++ b/helloworld-html5/functional-tests/pom.xml
@@ -34,8 +34,22 @@
     <properties>
         <!-- To disable warning of missing beans.xml file in JBoss Tools -->
         <m2e.cdi.activation>false</m2e.cdi.activation>
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
-    
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.arquillian.graphene</groupId>

--- a/helloworld-html5/pom.xml
+++ b/helloworld-html5/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -41,6 +41,24 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+
     <dependencies>
         <!-- The JMS Client BOM provides application server-compatible dependency management,
         used for building, testing or debugging JMS client applications. Import the BOM to the

--- a/helloworld-mbean/pom.xml
+++ b/helloworld-mbean/pom.xml
@@ -46,6 +46,24 @@
         <module>helloworld-mbean-webapp</module>
         <module>helloworld-mbean-service</module>
     </modules>
+
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->
         <dependency>

--- a/helloworld-mdb-propertysubstitution/pom.xml
+++ b/helloworld-mdb-propertysubstitution/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.enterprise</groupId>

--- a/helloworld-mdb/pom.xml
+++ b/helloworld-mdb/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.enterprise</groupId>

--- a/helloworld-mutual-ssl-secured/pom.xml
+++ b/helloworld-mutual-ssl-secured/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss WildFly -->

--- a/helloworld-mutual-ssl/pom.xml
+++ b/helloworld-mutual-ssl/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss WildFly -->

--- a/helloworld-rf/pom.xml
+++ b/helloworld-rf/pom.xml
@@ -42,8 +42,21 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.org.richfaces>4.5.7.Final</version.org.richfaces>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Similarly to the JBoss Jakarta EE 8 BOM above, the RichFaces BOM specifies the
                 versions of artifacts required for using RichFaces in your project. -->
             <dependency>
@@ -51,7 +64,6 @@
                 <artifactId>richfaces</artifactId>
                 <version>${version.org.richfaces}</version>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 

--- a/helloworld-rs/pom.xml
+++ b/helloworld-rs/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->
         <dependency>

--- a/helloworld-ssl/pom.xml
+++ b/helloworld-ssl/pom.xml
@@ -43,6 +43,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss WildFly -->

--- a/helloworld-ws/pom.xml
+++ b/helloworld-ws/pom.xml
@@ -44,7 +44,21 @@
     <properties>
         <!-- Remote Server URL -->
         <remote.server.url>http://localhost:8080/</remote.server.url>
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Import the CDI API, we use provided scope as the API is included

--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -40,7 +40,24 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
     </licenses>
-    
+
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in WildFly -->

--- a/hibernate/pom.xml
+++ b/hibernate/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- First declare the APIs we depend on and need for compilation.

--- a/hibernate4/pom.xml
+++ b/hibernate4/pom.xml
@@ -42,8 +42,22 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.hibernate4>4.2.21.Final</version.hibernate4>
+        <version.hibernate4.validator>4.3.2.Final</version.hibernate4.validator>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>

--- a/http-custom-mechanism/pom.xml
+++ b/http-custom-mechanism/pom.xml
@@ -46,6 +46,23 @@
         <module>webapp</module>
     </modules>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>

--- a/inter-app/pom.xml
+++ b/inter-app/pom.xml
@@ -48,9 +48,20 @@
         <module>appB</module>
     </modules>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
-
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Define the version of the shared API jar, so that we can
                 reference it in both appA and appB easily -->
             <dependency>

--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
    
         <!-- First declare the APIs we depend on and need for compilation. All

--- a/jaxrs-jwt/pom.xml
+++ b/jaxrs-jwt/pom.xml
@@ -33,7 +33,6 @@
     <name>Quickstart: jaxrs-jwt</name>
     <description>JWT authentication using Elytron</description>
 
-
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -46,4 +45,22 @@
         <module>client</module>
         <module>service</module>
     </modules>
+
+    <properties>
+        <version.com.nimbusds.jose.jwt>5.4</version.com.nimbusds.jose.jwt>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/jaxws-addressing/pom.xml
+++ b/jaxws-addressing/pom.xml
@@ -45,8 +45,21 @@
         <module>service</module>
         <module>client</module>
     </modules>
+
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jaxws-addressing-service</artifactId>

--- a/jaxws-ejb/pom.xml
+++ b/jaxws-ejb/pom.xml
@@ -46,6 +46,23 @@
         <module>client</module>
     </modules>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>

--- a/jaxws-pojo/pom.xml
+++ b/jaxws-pojo/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>service</module>
         <module>client</module>

--- a/jaxws-retail/pom.xml
+++ b/jaxws-retail/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>service</module>
         <module>client</module>

--- a/jsonp/pom.xml
+++ b/jsonp/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->
         <dependency>

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -49,8 +49,20 @@
         <module>application-component-1</module>
     </modules>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Client stub for the application-component-2 -->
             <dependency>
                 <groupId>${project.groupId}</groupId>

--- a/kitchensink-angularjs/functional-tests/pom.xml
+++ b/kitchensink-angularjs/functional-tests/pom.xml
@@ -43,6 +43,25 @@
         </testResources>
     </build>
 
+    <properties>
+        <version.arquillian.angularjs.graphene>1.2.0.Beta1</version.arquillian.angularjs.graphene>
+        <version.org.json>20150729</version.org.json>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.arquillian.graphene</groupId>

--- a/kitchensink-angularjs/pom.xml
+++ b/kitchensink-angularjs/pom.xml
@@ -41,6 +41,24 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- First declare the APIs we depend on and need for compilation. 

--- a/kitchensink-ear/pom.xml
+++ b/kitchensink-ear/pom.xml
@@ -47,9 +47,20 @@
         <module>ear</module>
     </modules>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
-
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Define the version of the EJB jar so that we don't need
                 to repeat ourselves in every module -->
             <dependency>

--- a/kitchensink-jsp/pom.xml
+++ b/kitchensink-jsp/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- First declare the APIs we depend on and need for compilation.

--- a/kitchensink-ml/pom.xml
+++ b/kitchensink-ml/pom.xml
@@ -37,8 +37,22 @@
     <properties>
         <!--JBEAP-9389 workaround for buggy eclipse -->
         <m2e.apt.activation>jdt_apt</m2e.apt.activation>
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
-    
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>

--- a/kitchensink-utjs-angularjs/pom.xml
+++ b/kitchensink-utjs-angularjs/pom.xml
@@ -44,6 +44,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- First declare the APIs we depend on and need for compilation. 

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- First declare the APIs we depend on and need for compilation. All

--- a/logging-tools/pom.xml
+++ b/logging-tools/pom.xml
@@ -36,7 +36,21 @@
     <properties>
         <!--JBEAP-9389 workaround for buggy eclipse -->
         <m2e.apt.activation>jdt_apt</m2e.apt.activation>
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <licenses>
         <license>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!--  jboss-logging API -->
         <dependency>

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>

--- a/managed-executor-service/pom.xml
+++ b/managed-executor-service/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Import the CDI API, we use provided scope as the API is included in
             JBoss EAP -->

--- a/messaging-clustering-singleton/pom.xml
+++ b/messaging-clustering-singleton/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.enterprise</groupId>

--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -18,15 +18,38 @@
   <name>Quickstart: microprofile-config</name>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <version.microprofile.bom>24.0.0.Final</version.microprofile.bom>
+      <version.server.bom>24.0.1.Final</version.server.bom>
       <version.server.bootable-jar>24.0.0.Final</version.server.bootable-jar>
       <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
       <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
       <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>
 
-  <dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the microprofile BOM adds MicroProfile specs -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-microprofile</artifactId>
+                <version>${version.microprofile.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
     <!-- Import the MicroProfile Config API, we use provided scope as the API is included in the server -->
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -51,6 +51,8 @@
     </licenses>
 
     <properties>
+        <version.microprofile.bom>24.0.0.Final</version.microprofile.bom>
+        <version.server.bom>24.0.1.Final</version.server.bom>
         <version.server.bootable-jar>24.0.0.Final</version.server.bootable-jar>
         <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -21,11 +21,34 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <management.http.url>http://localhost:9990</management.http.url>
+    <version.microprofile.bom>24.0.0.Final</version.microprofile.bom>
+    <version.server.bom>24.0.1.Final</version.server.bom>
     <version.server.bootable-jar>24.0.0.Final</version.server.bootable-jar>
     <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- importing the microprofile BOM adds MicroProfile specs -->
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-microprofile</artifactId>
+        <version>${version.microprofile.bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+        <version>${version.server.bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- Import the MicroProfile Health API, we use provided scope as the API is included in WildFly -->

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -42,7 +42,10 @@
     </licenses>
 
     <properties>
+        <version.com.nimbusds.jose.jwt>5.4</version.com.nimbusds.jose.jwt>
         <version.glassfish.json>1.1.6</version.glassfish.json>
+        <version.microprofile.bom>24.0.0.Final</version.microprofile.bom>
+        <version.server.bom>24.0.1.Final</version.server.bom>
         <version.server.bootable-jar>24.0.0.Final</version.server.bootable-jar>
         <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
@@ -58,6 +61,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- importing the microprofile BOM adds MicroProfile specs -->
             <dependency>
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-microprofile</artifactId>

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -21,11 +21,34 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <failOnMissingWebXml>false</failOnMissingWebXml>
+    <version.microprofile.bom>24.0.0.Final</version.microprofile.bom>
+    <version.server.bom>24.0.1.Final</version.server.bom>
     <version.server.bootable-jar>24.0.0.Final</version.server.bootable-jar>
     <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- importing the microprofile BOM adds MicroProfile specs -->
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-microprofile</artifactId>
+        <version>${version.microprofile.bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+        <version>${version.server.bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- Import the MicroProfile Metrics API, we use provided scope as the API is included in the server -->

--- a/microprofile-openapi/pom.xml
+++ b/microprofile-openapi/pom.xml
@@ -18,11 +18,25 @@
     <name>Quickstart: microprofile-openapi</name>
 
     <properties>
+        <version.microprofile.bom>24.0.0.Final</version.microprofile.bom>
         <version.server.bootable-jar>24.0.0.Final</version.server.bootable-jar>
         <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
         <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the microprofile BOM adds MicroProfile specs -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-microprofile</artifactId>
+                <version>${version.microprofile.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -21,11 +21,34 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <failOnMissingWebXml>false</failOnMissingWebXml>
+    <version.microprofile.bom>24.0.0.Final</version.microprofile.bom>
+    <version.server.bom>24.0.1.Final</version.server.bom>
     <version.server.bootable-jar>24.0.0.Final</version.server.bootable-jar>
     <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- importing the microprofile BOM adds MicroProfile specs -->
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-microprofile</artifactId>
+        <version>${version.microprofile.bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+        <version>${version.server.bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- Import the MicroProfile OpenTracing API, we use provided scope as the API is included in the server -->

--- a/microprofile-reactive-messaging-kafka/pom.xml
+++ b/microprofile-reactive-messaging-kafka/pom.xml
@@ -34,6 +34,9 @@
     <name>Quickstart: microprofile-reactive-messaging-kafka</name>
 
     <properties>
+        <!-- BOM versions -->
+        <version.microprofile.bom>24.0.0.Final</version.microprofile.bom>
+        <version.server.bom>24.0.1.Final</version.server.bom>
         <!-- Test dependencies versions -->
         <version.io.rest-assured>4.3.1</version.io.rest-assured>
         <version.org.apache.kafka>2.7.0</version.org.apache.kafka>
@@ -45,6 +48,27 @@
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
         <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the microprofile BOM adds MicroProfile specs -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-microprofile</artifactId>
+                <version>${version.microprofile.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
 

--- a/microprofile-rest-client/pom.xml
+++ b/microprofile-rest-client/pom.xml
@@ -40,6 +40,8 @@
   </licenses>
 
   <properties>
+    <version.microprofile.bom>24.0.0.Final</version.microprofile.bom>
+    <version.server.bom>24.0.1.Final</version.server.bom>
     <version.server.bootable-jar>24.0.0.Final</version.server.bootable-jar>
     <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
@@ -50,6 +52,27 @@
     <module>country-client</module>
     <module>country-server</module>
   </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- importing the microprofile BOM adds MicroProfile specs -->
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-microprofile</artifactId>
+        <version>${version.microprofile.bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+      <dependency>
+        <groupId>org.wildfly.bom</groupId>
+        <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+        <version>${version.server.bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <pluginManagement>

--- a/numberguess/pom.xml
+++ b/numberguess/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/payment-cdi-event/pom.xml
+++ b/payment-cdi-event/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/pom.xml
+++ b/pom.xml
@@ -74,47 +74,9 @@
         <!-- https://access.redhat.com/maven-repository -->
         <maven.redhat.repository.url>${maven.repository.protocol}://maven.repository.redhat.com/ga/</maven.redhat.repository.url>
 
-        <!-- Version of BOMs
-        note: a SNAPSHOT version *requires* checkout of BOMs at https://github.com/wildfly/boms and build through "mvn clean install"
-        -->
-        <version.server.bom>24.0.0.Final</version.server.bom>
-        <version.microprofile.bom>24.0.0.Final</version.microprofile.bom>
-
-        <!-- Versions of unmanaged dependencies -->
-        <version.arquillian.angularjs.graphene>1.2.0.Beta1</version.arquillian.angularjs.graphene>
-        <version.com.nimbusds.jose.jwt>5.4</version.com.nimbusds.jose.jwt>
-        <version.deltaspike.core>1.5.1</version.deltaspike.core>
-        <version.org.apache.wicket>7.3.0</version.org.apache.wicket>
-        <version.hibernate4>4.2.21.Final</version.hibernate4>
-        <version.hibernate4.validator>4.3.2.Final</version.hibernate4.validator>
-        <version.org.json>20150729</version.org.json>
-        <version.org.richfaces>4.5.7.Final</version.org.richfaces>
-        <version.ro.isdc.wro4j>1.7.9</version.ro.isdc.wro4j>
-
         <jboss.developer.drupal.url>http://rhdp-drupal.stage.redhat.com/</jboss.developer.drupal.url>
         <linkXRef>false</linkXRef>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
-            <dependency>
-                <groupId>org.wildfly.bom</groupId>
-                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
-                <version>${version.server.bom}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- importing the microprofile BOM adds MicroProfile specs -->
-            <dependency>
-                <groupId>org.wildfly.bom</groupId>
-                <artifactId>wildfly-microprofile</artifactId>
-                <version>${version.microprofile.bom}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <repositories>
         <repository>
@@ -358,103 +320,100 @@
                 </property>
             </activation>
             <modules>
-                <!-- All the modules that require nothing but JBoss Enterprise
-                    Application Platform or JBoss EAP -->
-                <module>app-client</module>
-                <module>batch-processing</module>
-                <module>bean-validation</module>
-                <module>bean-validation-custom-constraint</module>
-                <module>bmt</module>
-                <module>cmt</module>
-                <module>contacts-jquerymobile</module>
-                <module>deltaspike-authorization</module>
-                <module>deltaspike-beanbuilder</module>
-                <module>deltaspike-projectstage</module>
-                <module>ee-security</module>
-                <module>ejb-asynchronous</module>
-                <module>ejb-in-ear</module>
-                <module>ejb-in-war</module>
-                <module>ejb-multi-server</module>
-                <module>ejb-security</module>
-                <module>ejb-security-context-propagation</module>
-                <module>ejb-security-jaas</module>
-                <module>ejb-security-programmatic-auth</module>
-                <module>ejb-throws-exception</module>
-                <module>ejb-timer</module>
-                <module>ejb-txn-remote-call</module>
-                <module>greeter</module>
-                <module>ha-singleton-deployment</module>
-                <module>ha-singleton-service</module>
-                <module>helloworld</module>
-                <module>helloworld-classfiletransformer</module>
-                <module>helloworld-html5</module>
-                <module>helloworld-jms</module>
-                <module>helloworld-mbean</module>
-                <module>helloworld-mdb</module>
-                <module>helloworld-mdb-propertysubstitution</module>
-                <module>helloworld-mutual-ssl</module>
-                <module>helloworld-mutual-ssl-secured</module>
-                <module>helloworld-rf</module>
-                <module>helloworld-rs</module>
-                <module>helloworld-singleton</module>
-                <module>helloworld-ssl</module>
-                <module>helloworld-ws</module>
-                <module>hibernate4</module>
-                <module>hibernate</module>
-                <module>http-custom-mechanism</module>
-                <module>inter-app</module>
-                <module>jaxrs-client</module>
-                <module>jaxrs-jwt</module>
-                <module>jaxws-addressing</module>
-                <module>jaxws-ejb</module>
-                <module>jaxws-pojo</module>
-                <module>jaxws-retail</module>
-                <module>jsonp</module>
-                <module>kitchensink</module>
-                <module>kitchensink-angularjs</module>
-                <module>kitchensink-ear</module>
-                <module>kitchensink-jsp</module>
-                <module>kitchensink-ml</module>
-                <module>kitchensink-utjs-angularjs</module>
-                <module>kitchensink-utjs-mustache</module>
-                <module>logging</module>
-                <module>logging-tools</module>
-                <module>mail</module>
-                <module>managed-executor-service</module>
-                <module>messaging-clustering-singleton</module>
-                <module>microprofile-config</module>
-                <module>microprofile-fault-tolerance</module>
-                <module>microprofile-health</module>
-                <module>microprofile-jwt</module>
-                <module>microprofile-metrics</module>
-                <module>microprofile-openapi</module>
-                <module>microprofile-opentracing</module>
-                <module>microprofile-reactive-messaging-kafka</module>
-                <module>microprofile-rest-client</module>
-                <module>numberguess</module>
-                <module>payment-cdi-event</module>
-                <module>resteasy-jaxrs-client</module>
-                <module>security-domain-to-domain</module>
-                <module>servlet-async</module>
-                <module>servlet-filterlistener</module>
-                <module>servlet-security</module>
-                <module>shopping-cart</module>
-                <module>spring-greeter</module>
-                <module>spring-kitchensink-basic</module>
-                <module>spring-kitchensink-springmvctest</module>
-                <module>spring-resteasy</module>
-                <module>tasks-jsf</module>
-                <module>tasks-rs</module>
-                <module>temperature-converter</module>
-                <module>todo-backend</module>
-                <module>thread-racing</module>
-                <module>websocket-client</module>
-                <module>websocket-endpoint</module>
-                <module>websocket-hello</module>
-                <module>wicket-ear</module>
-                <module>wicket-war</module>
-                <module>xml-jaxp</module>
-            </modules>
+    <!-- All the modules that require nothing but JBoss Enterprise
+        Application Platform or JBoss EAP -->
+    <module>app-client</module>
+    <module>batch-processing</module>
+    <module>bean-validation</module>
+    <module>bean-validation-custom-constraint</module>
+    <module>bmt</module>
+    <module>cmt</module>
+    <module>contacts-jquerymobile</module>
+    <module>deltaspike-authorization</module>
+    <module>deltaspike-beanbuilder</module>
+    <module>deltaspike-projectstage</module>
+    <module>ee-security</module>
+    <module>ejb-asynchronous</module>
+    <module>ejb-in-ear</module>
+    <module>ejb-in-war</module>
+    <module>ejb-multi-server</module>
+    <module>ejb-security</module>
+    <!--
+    <module>ejb-security-context-propagation</module>
+    <module>ejb-security-jaas</module>
+    <module>ejb-security-programmatic-auth</module>
+    -->
+    <module>ejb-throws-exception</module>
+    <module>ejb-timer</module>
+    <!--
+    <module>ejb-txn-remote-call</module>
+    -->
+    <module>greeter</module>
+    <module>ha-singleton-deployment</module>
+    <!--
+    <module>ha-singleton-service</module>
+    -->
+    <module>helloworld</module>
+    <module>helloworld-classfiletransformer</module>
+    <module>helloworld-html5</module>
+    <module>helloworld-jms</module>
+    <module>helloworld-mbean</module>
+    <module>helloworld-mdb</module>
+    <!-- <module>helloworld-mdb-propertysubstitution</module> -->
+    <module>helloworld-mutual-ssl</module>
+    <!-- <module>helloworld-mutual-ssl-secured</module> -->
+    <module>helloworld-rf</module>
+    <module>helloworld-rs</module>
+    <module>helloworld-singleton</module>
+    <module>helloworld-ssl</module>
+    <module>helloworld-ws</module>
+    <module>hibernate4</module>
+    <module>hibernate</module>
+    <module>http-custom-mechanism</module>
+    <!-- <module>inter-app</module> -->
+    <module>jaxrs-client</module>
+    <!-- <module>jaxrs-jwt</module> -->
+    <module>jaxws-addressing</module>
+    <module>jaxws-ejb</module>
+    <module>jaxws-pojo</module>
+    <module>jaxws-retail</module>
+    <module>jsonp</module>
+    <module>kitchensink</module>
+    <module>kitchensink-angularjs</module>
+    <module>kitchensink-ear</module>
+    <module>kitchensink-jsp</module>
+    <module>kitchensink-ml</module>
+    <module>kitchensink-utjs-angularjs</module>
+    <module>kitchensink-utjs-mustache</module>
+    <module>logging</module>
+    <module>logging-tools</module>
+    <!-- <module>mail</module> -->
+    <module>managed-executor-service</module>
+    <!-- <module>messaging-clustering-singleton</module> -->
+    <module>numberguess</module>
+    <module>payment-cdi-event</module>
+    <module>resteasy-jaxrs-client</module>
+    <!-- <module>security-domain-to-domain</module> -->
+    <module>servlet-async</module>
+    <module>servlet-filterlistener</module>
+    <!-- <module>servlet-security</module> -->
+    <module>shopping-cart</module>
+    <module>spring-greeter</module>
+    <module>spring-kitchensink-basic</module>
+    <module>spring-kitchensink-springmvctest</module>
+    <module>spring-resteasy</module>
+    <module>tasks-jsf</module>
+    <module>tasks-rs</module>
+    <module>temperature-converter</module>
+    <module>thread-racing</module>
+    <module>websocket-client</module>
+    <module>websocket-endpoint</module>
+    <module>websocket-hello</module>
+    <module>wicket-ear</module>
+    <module>wicket-war</module>
+    <module>xml-jaxp</module>
+</modules>
+
         </profile>
         <profile>
             <!-- All the quickstarts that require Postgres to be running -->
@@ -532,66 +491,6 @@
             </modules>
         </profile>
 
-        <profile>
-            <!-- An optional Arquillian testing profile that executes tests in your JBoss EAP instance.
-                 This profile will start a new JBoss EAP instance, and execute the test, shutting it down when done.
-                 Run with: mvn clean verify -Parq-managed -->
-            <id>arq-managed</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${version.failsafe.plugin}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <!-- An optional Arquillian testing profile that executes tests in a remote JBoss EAP instance.
-                 Run with: mvn clean verify -Parq-remote -->
-            <id>arq-remote</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-remote</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${version.failsafe.plugin}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>docs</id>
             <activation>

--- a/resteasy-jaxrs-client/pom.xml
+++ b/resteasy-jaxrs-client/pom.xml
@@ -41,6 +41,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
  
         <!-- Now we declare the dependencies needed by the client -->

--- a/security-domain-to-domain/pom.xml
+++ b/security-domain-to-domain/pom.xml
@@ -48,10 +48,22 @@
         <module>ear</module>
     </modules>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Define the version of the EJB jar so that we don't need
-                to repeat ourselves in every module -->
+            to repeat ourselves in every module -->
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>security-domain-to-domain-ejb</artifactId>

--- a/servlet-async/pom.xml
+++ b/servlet-async/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/servlet-filterlistener/pom.xml
+++ b/servlet-filterlistener/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/shopping-cart/pom.xml
+++ b/shopping-cart/pom.xml
@@ -50,9 +50,20 @@
         <module>client</module>
     </modules>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
-
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- We depend on the server side EJBs of this application -->
             <dependency>
                 <groupId>${project.groupId}</groupId>

--- a/spring-greeter/functional-tests/pom.xml
+++ b/spring-greeter/functional-tests/pom.xml
@@ -32,7 +32,23 @@
     <name>Quickstart: Spring Greeter test via WebDriver with Arquillian</name>
     <description>This project tests a Spring Greeter on JBoss EAP by WebDriver</description>
 
-    
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.arquillian.graphene</groupId>

--- a/spring-greeter/pom.xml
+++ b/spring-greeter/pom.xml
@@ -44,10 +44,19 @@
 
     <properties>
         <version.spring.framework>5.2.4.RELEASE</version.spring.framework>
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Define the version of the Spring Framework we want to import.
                  Any dependencies from org.springframework.* will have their version defined by this BOM
             -->

--- a/spring-kitchensink-basic/functional-tests/pom.xml
+++ b/spring-kitchensink-basic/functional-tests/pom.xml
@@ -32,6 +32,24 @@
     <name>Quickstart: Spring Kitchensink Basic test via WebDriver with Arquillian</name>
     <description>This project tests a Spring Kitchensink Basic for use on JBoss EAP by WebDriver</description>
 
+    <properties>
+        <version.org.json>20150729</version.org.json>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.arquillian.graphene</groupId>

--- a/spring-kitchensink-basic/pom.xml
+++ b/spring-kitchensink-basic/pom.xml
@@ -44,12 +44,21 @@
 
     <properties>
         <version.spring.framework>5.2.4.RELEASE</version.spring.framework>
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Define the version of the Spring Framework we want to import.
-                 Any dependencies from org.springframework.* will have their version defined by this BOM
+             Any dependencies from org.springframework.* will have their version defined by this BOM
             -->
             <dependency>
                 <groupId>org.springframework</groupId>
@@ -197,7 +206,6 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/spring-kitchensink-springmvctest/functional-tests/pom.xml
+++ b/spring-kitchensink-springmvctest/functional-tests/pom.xml
@@ -33,6 +33,24 @@
     <name>Quickstart: Spring Kitchensink SpringMvcTest test via WebDriver with Arquillian</name>
     <description>This project tests a Spring Kitchensink SpringMvcTest for use on JBoss EAP by WebDriver</description>
 
+    <properties>
+        <version.org.json>20150729</version.org.json>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.arquillian.graphene</groupId>

--- a/spring-kitchensink-springmvctest/pom.xml
+++ b/spring-kitchensink-springmvctest/pom.xml
@@ -45,10 +45,19 @@
     <properties>
         <version.spring.framework>5.2.4.RELEASE</version.spring.framework>
         <version.json.path>2.0.0</version.json.path>
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- JSON Path for MockMVCTest -->
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>

--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -44,10 +44,19 @@
 
     <properties>
         <version.spring.framework>5.2.4.RELEASE</version.spring.framework>
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Define the version of the Spring Framework we want to import.
                           Any dependencies from org.springframework.* will have their version defined by this BOM
                      -->

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/tasks-rs/pom.xml
+++ b/tasks-rs/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->
         <dependency>

--- a/temperature-converter/pom.xml
+++ b/temperature-converter/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -38,16 +38,11 @@
             message: [WARNING] Using platform encoding (UTF-8 actually) to copy 
             filtered resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
         <!-- JBoss dependency versions -->
-
         <version.wildfly.maven.plugin>2.0.2.Final</version.wildfly.maven.plugin>
-
         <version.server.bom>24.0.0.Final-SNAPSHOT</version.server.bom>
-
         <!-- other plug-in versions -->
         <version.war.plugin>2.6</version.war.plugin>
-
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/thread-racing/pom.xml
+++ b/thread-racing/pom.xml
@@ -42,8 +42,24 @@
         </license>
     </licenses>
 
-    <dependencies>
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->
         <dependency>
             <groupId>jakarta.enterprise</groupId>

--- a/todo-backend/pom.xml
+++ b/todo-backend/pom.xml
@@ -46,7 +46,21 @@
         <version.server.bootable-jar>24.0.0.Final</version.server.bootable-jar>
         <version.wildfly-jar.maven.plugin>5.0.0.Final</version.wildfly-jar.maven.plugin>
         <version.wildfly-datasources-galleon-pack>2.0.2.Final</version.wildfly-datasources-galleon-pack>
+        <version.server.bom>24.0.1.Final</version.server.bom>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/websocket-client/pom.xml
+++ b/websocket-client/pom.xml
@@ -43,6 +43,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in

--- a/websocket-endpoint/pom.xml
+++ b/websocket-endpoint/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in

--- a/websocket-hello/pom.xml
+++ b/websocket-hello/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec.javax.websocket</groupId>

--- a/wicket-ear/pom.xml
+++ b/wicket-ear/pom.xml
@@ -50,9 +50,21 @@
         <module>ear</module>
     </modules>
 
+    <properties>
+        <version.org.apache.wicket>7.3.0</version.org.apache.wicket>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
-           
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Wicket -->
             <dependency>
                 <groupId>org.apache.wicket</groupId>

--- a/wicket-war/pom.xml
+++ b/wicket-war/pom.xml
@@ -45,8 +45,21 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.org.apache.wicket>7.3.0</version.org.apache.wicket>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Wicket -->
             <dependency>
                 <groupId>org.apache.wicket</groupId>

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- Import the CDI API, we use provided scope as the API is included in JBoss EAP -->

--- a/xml-jaxp/pom.xml
+++ b/xml-jaxp/pom.xml
@@ -42,6 +42,23 @@
         </license>
     </licenses>
 
+    <properties>
+        <version.server.bom>24.0.1.Final</version.server.bom>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <dependency>
+                <groupId>org.wildfly.bom</groupId>
+                <artifactId>wildfly-jakartaee8-with-tools</artifactId>
+                <version>${version.server.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- First declare the APIs we depend on and need for compilation. All


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-12142