### PR TITLE
renames class MemberRegistrationIT -> MemberRegistrationTest

### DIFF
--- a/kitchensink/src/test/java/org/jboss/as/quickstarts/kitchensink/test/MemberRegistrationTest.java
+++ b/kitchensink/src/test/java/org/jboss/as/quickstarts/kitchensink/test/MemberRegistrationTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-public class MemberRegistrationIT {
+public class MemberRegistrationTest {
     @Deployment
     public static Archive<?> createTestArchive() {
         return ShrinkWrap.create(WebArchive.class, "test.war")


### PR DESCRIPTION
This change is needed to ensure `mvn clean test -Parq-remote` or `mvn clean test -Parq-managed` is able to run as instructed on kitchensink's quickstart `6.2.1. Arquillian` section. This change might be needed for all the other classes listed below, but I have just found out about wildfly and have only experimented with this project. If interest is shown, I could test and update the other ones too.

```
bean-validation/src/test/java/org/jboss/as/quickstarts/bean_validation/test/MemberValidationIT.java
bean-validation-custom-constraint/src/test/java/org/jboss/as/quickstarts/bean_validation_custom_constraint/MyPersonIT.java
contacts-jquerymobile/src/test/java/org/jboss/quickstarts/contact/test/ContactRegistrationIT.java
ejb-in-war/src/test/java/org/jboss/as/quickstarts/ejbinwar/test/GreeterEJBIT.java
ejb-in-war/src/test/java/org/jboss/as/quickstarts/ejbinwar/test/GreeterIT.java
helloworld-mbean/helloworld-mbean-service/src/test/java/org/jboss/as/quickstarts/mbeanhelloworld/mbean/JMXPojoHelloWorldIT.java
helloworld-mbean/helloworld-mbean-webapp/src/test/java/org/jboss/as/quickstarts/mbeanhelloworld/mbean/AnnotatedComponentHelloWorldIT.java
helloworld-mbean/helloworld-mbean-webapp/src/test/java/org/jboss/as/quickstarts/mbeanhelloworld/mbean/MXComponentHelloWorldIT.java
helloworld-mbean/helloworld-mbean-webapp/src/test/java/org/jboss/as/quickstarts/mbeanhelloworld/mbean/MXPojoHelloWorldIT.java
helloworld-ws/src/test/java/org/jboss/as/quickstarts/wshelloworld/ClientArqIT.java
jaxrs-client/src/test/java/org/jboss/as/quickstarts/jaxrsclient/test/ContactsRestClientIT.java
kitchensink-angularjs/src/test/java/org/jboss/as/quickstarts/kitchensink/test/MemberRegistrationIT.java
kitchensink-ear/ejb/src/test/java/org/jboss/as/quickstarts/kitchensink_ear/test/MemberRegistrationIT.java
kitchensink-jsp/src/test/java/org/jboss/as/quickstarts/helloworldjsp/test/MemberRegistrationIT.java
kitchensink-ml/src/test/java/org/jboss/as/quickstarts/kitchensink/test/MemberRegistrationIT.java
managed-executor-service/src/test/java/org/jboss/as/quickstarts/managedexecutorservice/test/ProductsRestClientIT.java
microprofile-config/src/test/java/org/wildfly/quickstarts/microprofile/config/MicroProfileConfigIT.java
microprofile-fault-tolerance/src/test/java/org/wildfly/quickstarts/microprofile/faulttolerance/MicroProfileFaultToleranceIT.java
microprofile-health/src/test/java/org/wildfly/quickstarts/microprofile/health/MicroProfileHealthIT.java
microprofile-jwt/src/test/java/org/wildfly/quickstarts/mpjwt/JWTClientIT.java
microprofile-metrics/src/test/java/org/wildfly/quickstarts/microprofile/metrics/MicroProfileMetricsIT.java
microprofile-opentracing/src/test/java/org/wildfly/quickstarts/microprofile/opentracing/MicroProfileOpenTracingIT.java
microprofile-reactive-messaging-kafka/src/test/java/org/wildfly/quickstarts/microprofile/reactive/messaging/test/ReactiveMessagingKafkaIT.java
microprofile-rest-client/country-client/src/test/java/org/wildfly/quickstarts/microprofile/rest/client/MicroProfileRESTClientIT.java
spring-resteasy/src/test/java/org/jboss/as/quickstarts/resteasyspring/test/ResteasySpringIT.java
tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/ResourcesIT.java
tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskDaoIT.java
tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskListBeanIT.java
tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/UserDaoIT.java
tasks-rs/src/test/java/org/jboss/as/quickstarts/tasksrs/TaskDaoIT.java
tasks-rs/src/test/java/org/jboss/as/quickstarts/tasksrs/UserDaoIT.java
todo-backend/src/test/java/org/wildfly/quickstarts/todos/ToDoIT.java
wsat-simple/src/test/java/org/jboss/as/quickstarts/wsat/simple/ClientIT.java
wsba-coordinator-completion-simple/src/test/java/org/jboss/as/quickstarts/wsba/coordinatorcompletion/simple/ClientIT.java
wsba-participant-completion-simple/src/test/java/org/jboss/as/quickstarts/wsba/participantcompletion/simple/ClientIT.java
```