### PR TITLE
adds whitespace between bullet point and text

### DIFF
--- a/guide/KitchensinkQuickstart.asciidoc
+++ b/guide/KitchensinkQuickstart.asciidoc
@@ -1078,9 +1078,9 @@ Now, we need to look at how we select between containers in the `pom.xml`:
     </dependencies>
 </profile>
 ------------------------------------------------------------------------
-<1>The profile needs an id so we can activate from Eclipse or the command line
-<2> Arquillian decides which container to use depending on your classpath. Here we define the managed container.
-<3> Arquillian decides which container to use depending on your classpath. Here we define the remote container.
+<1> The profile needs an id so we can activate from Eclipse or the command line
+<2> Arquillian decides which container to use depending on your classpath. Here we define the managed container
+<3> Arquillian decides which container to use depending on your classpath. Here we define the remote container
 
 And that's it! As you can see Arquillian delivers simple and true testing. You can concentrate on writing your test functionality, and run your tests in the same environment in which you will run your application.
 


### PR DESCRIPTION
The doc currently is malformatted and this should fix it.

How it appears:
![image](https://user-images.githubusercontent.com/20212334/132112608-d1a5ed4c-c47b-4eaa-a75f-09c001a02b5e.png)

This change should turn it like the others:
![image](https://user-images.githubusercontent.com/20212334/132112625-c3d914d6-905c-4971-8a35-02295e405e78.png)
