### PR TITLE
Add SE 17 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,54 @@ jobs:
       with:
         name: surefire-reports-JDK${{ matrix.jdk }}-${{ matrix.os }}
         path: '**/surefire-reports/*.txt'
+  test-later-jdk-matrix:
+    name: JDK${{ matrix.jdk }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [17]
+        os: [ubuntu-20.04, windows-latest]
+    steps:
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v2
+      with:
+        repository: wildfly/wildfly
+        path: wildfly
+    - uses: actions/checkout@v2
+      with:
+        repository: wildfly/boms
+        path: boms
+    - uses: actions/checkout@v2
+      with:
+        path: quickstarts
+    - name: Set up JDK 8
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: 8
+        impl: hotspot
+    - name: Build Wildfly
+      run: |
+        cd wildfly
+        mvn -U -B -fae -DskipTests clean install
+    - name: Build Boms
+      run: |
+        cd boms
+        mvn -U -B -fae clean install
+    - name: Set up JDK ${{ matrix.java }}
+      uses: AdoptOpenJDK/install-jdk@v1
+      with:
+        version: ${{ matrix.jdk }}
+        impl: hotspot
+    - name: Build Quickstarts
+      run: |
+        cd quickstarts
+        mvn -U -B -fae clean install -Drelease
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: surefire-reports-JDK${{ matrix.jdk }}-${{ matrix.os }}
+        path: '**/surefire-reports/*.txt'
 


### PR DESCRIPTION
I added an entire new job section because the existing test-matrix would try and build WF with SE17 and that won't work. I went ahead and used a matrix for the new section even though it's just SE 17 as that will make it easier to add later SEs if wanted.

Using SE 17 to just build the quickstarts, this works locally:

mvn clean install -Drelease