### PR TITLE
[WFLY-15741] Dead HTML link to Helm CLI in MicroProfile Reactive Mess…

### DIFF
--- a/microprofile-reactive-messaging-kafka/README.adoc
+++ b/microprofile-reactive-messaging-kafka/README.adoc
@@ -998,7 +998,7 @@ The sub-sections describe how to deploy the application to OpenShift interacting
 
 NOTE: For the purposes of this Quickstart, you should choose one of these approaches, not both. Your choice should match the type of Kafka instance you selected earlier in <<installing-kafka-on-openshift, Installing Kafka on OpenShift>>.
 
-In both cases we will use Helm to install the application. Make sure you have downloaded the https://docs.openshift.com/container-platform/4.8/cli_reference/helm_cli/getting-started-with-helm-on-openshift-container-platform.html[Helm CLI Tool].
+In both cases we will use Helm to install the application. Make sure you have downloaded the https://docs.openshift.com/container-platform/4.9/applications/working_with_helm_charts/installing-helm.html[Helm CLI Tool].
 
 [[xp-deploy-project-amq-streams]]
 === Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift with AMQ Streams
@@ -1034,7 +1034,7 @@ Run `oc get route` to find the URL of our application.
 === Deploy the {ProductShortName} Source-to-Image (S2I) Quickstart to OpenShift with RHOSAK
 This section describes how to deploy the application to OpenShift interacting with Kafka provided by AMQ Streams. If you want to use AMQ Streams instead, see the <<xp-deploy-project-amq-streams,AMQ Streams instructions>>.
 
-To deploy your application make sure you have downloaded the https://docs.openshift.com/container-platform/4.8/cli_reference/helm_cli/getting-started-with-helm-on-openshift-container-platform.html[Helm CLI Tool]. `./helm-rhosak.yml` contains the information to deploy the application to be backed by Kafka provided by RHOSAK.
+To deploy your application make sure you have downloaded the https://docs.openshift.com/container-platform/4.9/applications/working_with_helm_charts/installing-helm.html[Helm CLI Tool]. `./helm-rhosak.yml` contains the information to deploy the application to be backed by Kafka provided by RHOSAK.
 
 First add the Helm repository if you have not done so already:
 


### PR DESCRIPTION
…aging Kafka quickstart

Let's update the link with a working one. Pointing to OCP4.9 now.

https://issues.redhat.com/browse/WFLY-15741