### PR TITLE
Upgrade qs to bootable JAR 6.1.1.Final

### DIFF
--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -25,7 +25,7 @@
       <version.microprofile.bom>25.0.0.Final</version.microprofile.bom>
       <version.server.bom>25.0.0.Final</version.server.bom>
       <version.server.bootable-jar>25.0.0.Final</version.server.bootable-jar>
-      <version.wildfly-jar.maven.plugin>6.0.0.Final</version.wildfly-jar.maven.plugin>
+      <version.wildfly-jar.maven.plugin>6.1.1.Final</version.wildfly-jar.maven.plugin>
       <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
       <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -56,7 +56,7 @@
         <version.microprofile.bom>25.0.0.Final</version.microprofile.bom>
         <version.server.bom>25.0.0.Final</version.server.bom>
         <version.server.bootable-jar>25.0.0.Final</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>6.0.0.Final</version.wildfly-jar.maven.plugin>
+        <version.wildfly-jar.maven.plugin>6.1.1.Final</version.wildfly-jar.maven.plugin>
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
         <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -26,7 +26,7 @@
     <version.microprofile.bom>25.0.0.Final</version.microprofile.bom>
     <version.server.bom>25.0.0.Final</version.server.bom>
     <version.server.bootable-jar>25.0.0.Final</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>6.0.0.Final</version.wildfly-jar.maven.plugin>
+    <version.wildfly-jar.maven.plugin>6.1.1.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -49,7 +49,7 @@
         <version.microprofile.bom>25.0.0.Final</version.microprofile.bom>
         <version.server.bom>25.0.0.Final</version.server.bom>
         <version.server.bootable-jar>25.0.0.Final</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>6.0.0.Final</version.wildfly-jar.maven.plugin>
+        <version.wildfly-jar.maven.plugin>6.1.1.Final</version.wildfly-jar.maven.plugin>
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
         <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>

--- a/microprofile-metrics/pom.xml
+++ b/microprofile-metrics/pom.xml
@@ -26,7 +26,7 @@
     <version.microprofile.bom>25.0.0.Final</version.microprofile.bom>
     <version.server.bom>25.0.0.Final</version.server.bom>
     <version.server.bootable-jar>25.0.0.Final</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>6.0.0.Final</version.wildfly-jar.maven.plugin>
+    <version.wildfly-jar.maven.plugin>6.1.1.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>

--- a/microprofile-openapi/pom.xml
+++ b/microprofile-openapi/pom.xml
@@ -23,7 +23,7 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.microprofile.bom>25.0.0.Final</version.microprofile.bom>
         <version.server.bootable-jar>25.0.0.Final</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>6.0.0.Final</version.wildfly-jar.maven.plugin>
+        <version.wildfly-jar.maven.plugin>6.1.1.Final</version.wildfly-jar.maven.plugin>
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
         <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>

--- a/microprofile-opentracing/pom.xml
+++ b/microprofile-opentracing/pom.xml
@@ -26,7 +26,7 @@
     <version.microprofile.bom>25.0.0.Final</version.microprofile.bom>
     <version.server.bom>25.0.0.Final</version.server.bom>
     <version.server.bootable-jar>25.0.0.Final</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>6.0.0.Final</version.wildfly-jar.maven.plugin>
+    <version.wildfly-jar.maven.plugin>6.1.1.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>

--- a/microprofile-reactive-messaging-kafka/pom.xml
+++ b/microprofile-reactive-messaging-kafka/pom.xml
@@ -45,7 +45,7 @@
         <version.org.springframework.kafka>2.7.3</version.org.springframework.kafka>
         <!-- Plugin versions -->
         <version.server.bootable-jar>25.0.0.Final</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>6.0.0.Final</version.wildfly-jar.maven.plugin>
+        <version.wildfly-jar.maven.plugin>6.1.1.Final</version.wildfly-jar.maven.plugin>
         <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
         <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
     </properties>

--- a/microprofile-rest-client/pom.xml
+++ b/microprofile-rest-client/pom.xml
@@ -45,7 +45,7 @@
     <version.microprofile.bom>25.0.0.Final</version.microprofile.bom>
     <version.server.bom>25.0.0.Final</version.server.bom>
     <version.server.bootable-jar>25.0.0.Final</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>6.0.0.Final</version.wildfly-jar.maven.plugin>
+    <version.wildfly-jar.maven.plugin>6.1.1.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>

--- a/todo-backend/pom.xml
+++ b/todo-backend/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bootable-jar>25.0.0.Final</version.server.bootable-jar>
-        <version.wildfly-jar.maven.plugin>6.0.0.Final</version.wildfly-jar.maven.plugin>
+        <version.wildfly-jar.maven.plugin>6.1.1.Final</version.wildfly-jar.maven.plugin>
         <version.wildfly-datasources-galleon-pack>2.0.2.Final</version.wildfly-datasources-galleon-pack>
         <version.server.bom>25.0.0.Final</version.server.bom>
     </properties>


### PR DESCRIPTION
@emmartins , this upgrade will be required for 26 Beta1. NB: no Bootable JAR plugin will be released for 26 Beta1, so 6.1.1.Final is the release to use.