### PR TITLE
WFLY-16072 Fix readme in the microprofile-reactive-messaging-kafka quickstart

### DIFF
--- a/microprofile-reactive-messaging-kafka/README.adoc
+++ b/microprofile-reactive-messaging-kafka/README.adoc
@@ -8,7 +8,7 @@ include::../shared-doc/attributes.adoc[]
 [abstract]
 The `microprofile-reactive-messaging-kafka` quickstart demonstrates the use of the MicroProfile Reactive Messaging specification backed by Apache Kafka in {productName}.
 
-:standalone-server-type: default
+:standalone-server-type: microprofile
 :archiveType: war
 :archiveName: {artifactId}
 :reactive-messaging:


### PR DESCRIPTION
to use correct configuration xml file name.

https://issues.redhat.com/browse/WFLY-16072