### PR TITLE
[WFLY-16472] update jaxrs-jwt quickstart

### DIFF
--- a/jaxrs-jwt/client/pom.xml
+++ b/jaxrs-jwt/client/pom.xml
@@ -52,8 +52,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
             <scope>compile</scope>
         </dependency>
 

--- a/jaxrs-jwt/configure-elytron.cli
+++ b/jaxrs-jwt/configure-elytron.cli
@@ -15,7 +15,12 @@ batch
 /subsystem=elytron/http-authentication-factory=jwt-http-authentication:add(security-domain=jwt-domain,http-server-mechanism-factory=global,mechanism-configurations=[{mechanism-name="BEARER_TOKEN",mechanism-realm-configurations=[{realm-name="jwt-realm"}]}])
 
 # Configure Undertow to use our http authentication factory for authentication
-/subsystem=undertow/application-security-domain=other:add(http-authentication-factory=jwt-http-authentication)
+/subsystem=undertow/application-security-domain=other:undefine-attribute(name=security-domain)
+
+/subsystem=undertow/application-security-domain=other:write-attribute(name=http-authentication-factory,value=jwt-http-authentication)
+
+# Sync the application-security-domain in the ejb3 subsystem and undertow subsystem.
+/subsystem=ejb3/application-security-domain=other:write-attribute(name=security-domain,value=jwt-domain)
 
 run-batch
 

--- a/jaxrs-jwt/restore-configuration.cli
+++ b/jaxrs-jwt/restore-configuration.cli
@@ -1,7 +1,11 @@
 
 batch
 
-/subsystem=undertow/application-security-domain=other:remove()
+/subsystem=ejb3/application-security-domain=other:write-attribute(name=security-domain,value=ApplicationDomain)
+
+/subsystem=undertow/application-security-domain=other:undefine-attribute(name=http-authentication-factory)
+
+/subsystem=undertow/application-security-domain=other:write-attribute(name=security-domain,value=ApplicationDomain)
 
 /subsystem=elytron/http-authentication-factory=jwt-http-authentication:remove()
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-16472

1. update cli script to work with latest server.
2. remove obsoleted `resteasy-jaxrs` and also add `jakarta.activation` to fix below warning seen on client side:

```
Jun 13, 2022 12:12:09 PM org.jboss.resteasy.plugins.providers.RegisterBuiltin registerProviders
WARN: RESTEASY002145: NoClassDefFoundError: Unable to load builtin provider org.jboss.resteasy.plugins.providers.DataSourceProvider from jar:file:/Users/chaowan/.m2/repository/org/jboss/resteasy/resteasy-core/4.7.4.Final/resteasy-core-4.7.4.Final.jar!/META-INF/services/javax.ws.rs.ext.Providers
java.lang.NoClassDefFoundError: javax/activation/DataSource
	at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3137)
	at java.base/java.lang.Class.getConstructors(Class.java:1943)
	at org.jboss.resteasy.spi.util.PickConstructor.pickSingletonConstructor(PickConstructor.java:30)
	at org.jboss.resteasy.core.providerfactory.Utils.createConstructorInjector(Utils.java:111)
	at org.jboss.resteasy.core.providerfactory.Utils.createProviderInstance(Utils.java:100)
	at org.jboss.resteasy.core.providerfactory.CommonProviders.processProviderContracts(CommonProviders.java:87)
	at org.jboss.resteasy.core.providerfactory.ClientHelper.processProviderContracts(ClientHelper.java:104)
	at org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl.processProviderContracts(ResteasyProviderFactoryImpl.java:841)
	at org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl.registerProvider(ResteasyProviderFactoryImpl.java:829)
	at org.jboss.resteasy.core.providerfactory.ResteasyProviderFactoryImpl.registerProvider(ResteasyProviderFactoryImpl.java:816)
	at org.jboss.resteasy.plugins.providers.RegisterBuiltin.registerProviders(RegisterBuiltin.java:109)
	at org.jboss.resteasy.plugins.providers.RegisterBuiltin.register(RegisterBuiltin.java:74)
	at org.jboss.resteasy.plugins.providers.RegisterBuiltin.getClientInitializedResteasyProviderFactory(RegisterBuiltin.java:54)
	at org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl.getProviderFactory(ResteasyClientBuilderImpl.java:377)
	at org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl.build(ResteasyClientBuilderImpl.java:395)
	at org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl.build(ResteasyClientBuilderImpl.java:47)
	at javax.ws.rs.client.ClientBuilder.newClient(ClientBuilder.java:112)
	at org.jboss.quickstarts.jaxrsjwt.client.JwtRestClient.test(JwtRestClient.java:70)
	at org.jboss.quickstarts.jaxrsjwt.client.JwtRestClient.main(JwtRestClient.java:50)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:282)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ClassNotFoundException: javax.activation.DataSource
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 26 more
```