### PR TITLE
[WFLY-16720/16721] Remove undefine for legacy security realm in helloworld-mutual-ssl[-secured] quickstart

### DIFF
--- a/helloworld-mutual-ssl-secured/configure-ssl.cli
+++ b/helloworld-mutual-ssl-secured/configure-ssl.cli
@@ -26,7 +26,6 @@ batch
 /subsystem=elytron/http-authentication-factory=quickstart-http-authentication:add(security-domain=QuickstartDomain,http-server-mechanism-factory=global,mechanism-configurations=[{mechanism-name=CLIENT_CERT}])
 
 # Change the undertow subsystem configuration to use the ssl context configured above for https
-/subsystem=undertow/server=default-server/https-listener=https:undefine-attribute(name=security-realm)
 /subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=ssl-context,value=qsSSLContext)
 
 # Add an application-security-domain in the undertow subsystem to map the client_cert_domain from the quickstart app to the http-authentication-factory

--- a/helloworld-mutual-ssl-secured/restore-configuration.cli
+++ b/helloworld-mutual-ssl-secured/restore-configuration.cli
@@ -4,8 +4,7 @@
 batch
 
 # Revert the changes in the undertow subsystem
-/subsystem=undertow/server=default-server/https-listener=https:undefine-attribute(name=ssl-context)
-/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=security-realm,value=ApplicationRealm)
+/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=ssl-context,value=applicationSSC)
 
 # Remove the application-security-domain mapping that was added for the quickstart
 /subsystem=undertow/application-security-domain=client_cert_domain:remove

--- a/helloworld-mutual-ssl/configure-ssl.cli
+++ b/helloworld-mutual-ssl/configure-ssl.cli
@@ -11,7 +11,6 @@ batch
 /subsystem=elytron/server-ssl-context=qsSSLContext:add(key-manager=qsKeyManager,trust-manager=qsTrustManager,protocols=[TLSv1.2],need-client-auth=true)
 
 # Change the undertow subsystem configuration to use the ssl context defined in the previous step for https
-/subsystem=undertow/server=default-server/https-listener=https:undefine-attribute(name=security-realm)
 /subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=ssl-context,value=qsSSLContext)
 
 # Run the batch commands

--- a/helloworld-mutual-ssl/restore-configuration.cli
+++ b/helloworld-mutual-ssl/restore-configuration.cli
@@ -4,8 +4,7 @@
 batch
 
 # Revert the changes in the undertow subsystem
-/subsystem=undertow/server=default-server/https-listener=https:undefine-attribute(name=ssl-context)
-/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=security-realm,value=ApplicationRealm)
+/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=ssl-context,value=applicationSSC)
 
 # Remove the ssl context, key manager, trust manager and keystores configuration from the elytron subsystem
 /subsystem=elytron/server-ssl-context=qsSSLContext:remove


### PR DESCRIPTION
- https://issues.redhat.com/browse/WFLY-16720
- https://issues.redhat.com/browse/WFLY-16721

Depends on [migration to Jakarta EE 10](https://issues.redhat.com/browse/WFLY-16730), or usage on pre-Big Bang server.