### PR TITLE
[WFLY-16212] QS jaxws-retail is using broken version of jaxws-tools-maven-plugin

### DIFF
--- a/jaxws-retail/pom.xml
+++ b/jaxws-retail/pom.xml
@@ -44,7 +44,7 @@
 
     <properties>
         <!-- The versions for BOMs, Dependencies and Plugins -->
-        <version.jaxws-tools-maven-plugin>1.2.3.Final</version.jaxws-tools-maven-plugin>
+        <version.jaxws-tools-maven-plugin>1.3.0.Final</version.jaxws-tools-maven-plugin>
         <version.server.bom>27.0.0.Alpha4</version.server.bom>
     </properties>
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-16212