### PR TITLE
[WFLY-17194] Verify and enable the the microprofile-metrics quickstart

### DIFF
--- a/microprofile-metrics/src/test/resources/arquillian.xml
+++ b/microprofile-metrics/src/test/resources/arquillian.xml
@@ -23,9 +23,6 @@
   <!-- <property name="deploymentExportPath">target/</property> -->
   <!-- </engine> -->
 
-  <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
-  <defaultProtocol type="Servlet 3.0" />
-
   <!-- Example configuration for a managed ${product.name} instance -->
   <container qualifier="jboss" default="true">
     <!-- By default, Arquillian will use the JBOSS_HOME environment variable to find the ${product.name} installation.

--- a/pom.xml
+++ b/pom.xml
@@ -353,8 +353,8 @@
                 <module>microprofile-health</module>
                 -->
                 <module>microprofile-jwt</module>
-                <!-- disabled waiting for jakarta migration
                 <module>microprofile-metrics</module>
+                <!-- disabled waiting for jakarta migration
                 <module>microprofile-openapi</module>
                 <module>microprofile-opentracing</module>
                 <module>microprofile-reactive-messaging-kafka</module>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17194

Enable microprofile-metrics module
Remove explicit protocol config so the correct default is used