### PR TITLE
[WFLY-17189] Re-enable the the microprofile-health quickstart

### DIFF
--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -26,7 +26,7 @@
     <version.microprofile.bom>27.0.0.Beta1</version.microprofile.bom>
     <version.server.bom>27.0.0.Beta1</version.server.bom>
     <version.server.bootable-jar>27.0.0.Beta1</version.server.bootable-jar>
-    <version.wildfly-jar.maven.plugin>7.0.0.Final</version.wildfly-jar.maven.plugin>
+    <version.wildfly-jar.maven.plugin>8.0.1.Final</version.wildfly-jar.maven.plugin>
     <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
     <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -352,8 +352,8 @@
                 <module>microprofile-config</module>
                 <!--
                 <module>microprofile-fault-tolerance</module>
-                <module>microprofile-health</module>
                 -->
+                <module>microprofile-health</module>
                 <module>microprofile-jwt</module>
                 <module>microprofile-metrics</module>
                 <module>microprofile-openapi</module>


### PR DESCRIPTION
Upsate wildlfy-jar-maven-plugin to 8.0.1.Final to be able to build the Bootable Jar version of the quickstart

JIRA: https://issues.redhat.com/browse/WFLY-17189

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>