### PR TITLE
Verify and re-enable tasks-jsf quickstart

### DIFF
--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -46,7 +46,8 @@
                 <exclude>jaxws-ejb/**</exclude>
                 <exclude>jaxws-retail/**</exclude>
                 <exclude>messaging-clustering-singleton/**</exclude>
-                <exclude>tasks-jsf/**</exclude>
+                <exclude>microprofile-fault-tolerance/**</exclude>
+                <exclude>spring-resteasy/**</exclude>
                 <exclude>wsat-simple/**</exclude>
                 <exclude>wsba-coordinator-completion-simple/**</exclude>
                 <exclude>wsba-participant-completion-simple/**</exclude>

--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -46,8 +46,6 @@
                 <exclude>jaxws-ejb/**</exclude>
                 <exclude>jaxws-retail/**</exclude>
                 <exclude>messaging-clustering-singleton/**</exclude>
-                <exclude>microprofile-fault-tolerance/**</exclude>
-                <exclude>spring-resteasy/**</exclude>
                 <exclude>wsat-simple/**</exclude>
                 <exclude>wsba-coordinator-completion-simple/**</exclude>
                 <exclude>wsba-participant-completion-simple/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -351,9 +351,7 @@
                 <module>servlet-filterlistener</module>
                 <module>servlet-security</module>
                 <module>shopping-cart</module>
-                <!-- disabled waiting for jakarta migration
                 <module>tasks-jsf</module>
-                -->
                 <module>temperature-converter</module>
                 <module>todo-backend</module>
                 <module>thread-racing</module>

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/AuthController.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/AuthController.java
@@ -38,7 +38,7 @@ public class AuthController {
     private Authentication authentication;
 
     @Inject
-    private UserDao userDao;
+    private PersonDao userDao;
 
     @Inject
     private FacesContext facesContext;
@@ -74,7 +74,7 @@ public class AuthController {
     @Produces
     @Named
     @CurrentUser
-    public User getCurrentUser() {
+    public Person getCurrentUser() {
         return authentication.getCurrentUser();
     }
 
@@ -93,7 +93,7 @@ public class AuthController {
             throw new IllegalStateException("User is logged and tries to authenticate again");
         }
 
-        User user = userDao.getForUsername(userName);
+        Person user = userDao.getForUsername(userName);
         if (user == null) {
             user = createUser(userName);
         }
@@ -118,9 +118,9 @@ public class AuthController {
         return authentication.getCurrentUser() != null;
     }
 
-    private User createUser(String username) {
+    private Person createUser(String username) {
         try {
-            User user = new User(username);
+            Person user = new Person(username);
             userDao.createUser(user);
             facesContext.addMessage(null, new FacesMessage("User successfully created"));
             return user;

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/Authentication.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/Authentication.java
@@ -30,13 +30,13 @@ import jakarta.enterprise.context.ConversationScoped;
 @ConversationScoped
 public class Authentication implements Serializable {
 
-    private User currentUser;
+    private Person currentUser;
 
-    public User getCurrentUser() {
+    public Person getCurrentUser() {
         return currentUser;
     }
 
-    public void setCurrentUser(User user) {
+    public void setCurrentUser(Person user) {
         currentUser = user;
     }
 }

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/FacesConfiguration.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/FacesConfiguration.java
@@ -24,7 +24,7 @@ import jakarta.faces.annotation.FacesConfig;
  *
  * @author Rene Fischer
  */
-@FacesConfig(version = FacesConfig.Version.JSF_2_3)
+@FacesConfig
 @ApplicationScoped
 public class FacesConfiguration {
 }

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/Person.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/Person.java
@@ -30,13 +30,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 
 /**
- * User entity
+ * Person entity
  *
  * @author Oliver Kiss
  */
 @SuppressWarnings("serial")
 @Entity
-public class User implements Serializable {
+public class Person implements Serializable {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -49,10 +49,10 @@ public class User implements Serializable {
     @Column(updatable = false)
     private List<Task> tasks = new ArrayList<>();
 
-    public User() {
+    public Person() {
     }
 
-    public User(String username) {
+    public Person(String username) {
         this.username = username;
     }
 
@@ -96,7 +96,7 @@ public class User implements Serializable {
             return false;
         if (getClass() != obj.getClass())
             return false;
-        User other = (User) obj;
+        Person other = (Person) obj;
         if (username == null) {
             if (other.username != null)
                 return false;

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/PersonDao.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/PersonDao.java
@@ -25,9 +25,9 @@ import jakarta.ejb.Local;
  *
  */
 @Local
-public interface UserDao {
+public interface PersonDao {
 
-    User getForUsername(String username);
+    Person getForUsername(String username);
 
-    void createUser(User user);
+    void createUser(Person user);
 }

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/PersonDaoImpl.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/PersonDaoImpl.java
@@ -30,13 +30,13 @@ import jakarta.persistence.EntityManager;
  *
  */
 @Stateful
-public class UserDaoImpl implements UserDao {
+public class PersonDaoImpl implements PersonDao {
 
     @Inject
     private EntityManager em;
 
-    public User getForUsername(String username) {
-        List<User> result = em.createQuery("select u from User u where u.username = ?1", User.class).setParameter(1, username)
+    public Person getForUsername(String username) {
+        List<Person> result = em.createQuery("select u from Person u where u.username = ?1", Person.class).setParameter(1, username)
             .getResultList();
 
         if (result.isEmpty()) {
@@ -45,7 +45,7 @@ public class UserDaoImpl implements UserDao {
         return result.get(0);
     }
 
-    public void createUser(User user) {
+    public void createUser(Person user) {
         em.persist(user);
     }
 }

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/Task.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/Task.java
@@ -39,7 +39,7 @@ public class Task implements Serializable {
     private Long id;
 
     @ManyToOne
-    private User owner;
+    private Person owner;
 
     private String title;
 
@@ -59,11 +59,11 @@ public class Task implements Serializable {
         this.id = id;
     }
 
-    public User getOwner() {
+    public Person getOwner() {
         return owner;
     }
 
-    public void setOwner(User owner) {
+    public void setOwner(Person owner) {
         this.owner = owner;
     }
 

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/TaskController.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/TaskController.java
@@ -44,7 +44,7 @@ public class TaskController {
      */
     @Inject
     @CurrentUser
-    private Instance<User> currentUser;
+    private Instance<Person> currentUser;
 
     /**
      * Injects current user stored in the conversation scope

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/TaskDao.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/TaskDao.java
@@ -29,13 +29,13 @@ import jakarta.ejb.Local;
 @Local
 public interface TaskDao {
 
-    void createTask(User user, Task task);
+    void createTask(Person user, Task task);
 
-    List<Task> getAll(User user);
+    List<Task> getAll(Person user);
 
-    List<Task> getRange(User user, int offset, int count);
+    List<Task> getRange(Person user, int offset, int count);
 
-    List<Task> getForTitle(User user, String title);
+    List<Task> getForTitle(Person user, String title);
 
     void deleteTask(Task task);
 }

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/TaskDaoImpl.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/TaskDaoImpl.java
@@ -37,7 +37,7 @@ public class TaskDaoImpl implements TaskDao {
     private EntityManager em;
 
     @Override
-    public void createTask(User user, Task task) {
+    public void createTask(Person user, Task task) {
         if (!em.contains(user)) {
             user = em.merge(user);
         }
@@ -47,13 +47,13 @@ public class TaskDaoImpl implements TaskDao {
     }
 
     @Override
-    public List<Task> getAll(User user) {
+    public List<Task> getAll(Person user) {
         TypedQuery<Task> query = querySelectAllTasksFromUser(user);
         return query.getResultList();
     }
 
     @Override
-    public List<Task> getRange(User user, int offset, int count) {
+    public List<Task> getRange(Person user, int offset, int count) {
         TypedQuery<Task> query = querySelectAllTasksFromUser(user);
         query.setMaxResults(count);
         query.setFirstResult(offset);
@@ -61,7 +61,7 @@ public class TaskDaoImpl implements TaskDao {
     }
 
     @Override
-    public List<Task> getForTitle(User user, String title) {
+    public List<Task> getForTitle(Person user, String title) {
         String lowerCaseTitle = "%" + title.toLowerCase() + "%";
         return em.createQuery("SELECT t FROM Task t WHERE t.owner = ?1 AND LOWER(t.title) LIKE ?2", Task.class)
             .setParameter(1, user).setParameter(2, lowerCaseTitle).getResultList();
@@ -75,7 +75,7 @@ public class TaskDaoImpl implements TaskDao {
         em.remove(task);
     }
 
-    private TypedQuery<Task> querySelectAllTasksFromUser(User user) {
+    private TypedQuery<Task> querySelectAllTasksFromUser(Person user) {
         return em.createQuery("SELECT t FROM Task t WHERE t.owner = ?1", Task.class).setParameter(1, user);
     }
 }

--- a/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/TaskListBean.java
+++ b/tasks-jsf/src/main/java/org/jboss/as/quickstarts/tasksJsf/TaskListBean.java
@@ -54,7 +54,7 @@ public class TaskListBean implements TaskList {
 
     @Inject
     @CurrentUser
-    private User currentUser;
+    private Person currentUser;
 
     @Override
     public List<Task> getAll() {

--- a/tasks-jsf/src/main/webapp/WEB-INF/faces-config.xml
+++ b/tasks-jsf/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2023, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 
@@ -15,19 +15,19 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<faces-config xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="
-                  https://jakarta.ee/xml/ns/jakartaee
-                  https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
-              version="4.0">
+<faces-config 
+              xmlns="https://jakarta.ee/xml/ns/jakartaee"
+	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+	      https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
+	      version="4.0">
     <navigation-rule>
         <from-view-id>/index.xhtml</from-view-id>
         <navigation-case>
-            <from-action>#{authController.authenticate(username)}</from-action>
+            <from-action>#{authController.authenticate}</from-action>
             <if>#{authController.logged}</if>
             <to-view-id>/tasks.xhtml</to-view-id>
-            <redirect />
+            <redirect/>
         </navigation-case>
     </navigation-rule>
 
@@ -37,7 +37,7 @@
             <from-action>#{authController.logout}</from-action>
             <if>#{!authController.logged}</if>
             <to-view-id>/index.xhtml</to-view-id>
-            <redirect />
+            <redirect/>
         </navigation-case>
     </navigation-rule>
 

--- a/tasks-jsf/src/main/webapp/WEB-INF/tasks-jsf-ds.xml
+++ b/tasks-jsf/src/main/webapp/WEB-INF/tasks-jsf-ds.xml
@@ -28,7 +28,7 @@
       pool-name="tasks-jsf-quickstart" enabled="true"
       use-java-context="true">
       <!-- Ignore H2 reserved keyword `USER` as workaround for syntax error as per https://github.com/h2database/h2database/issues/3363#issuecomment-1010631797 -->
-      <connection-url>jdbc:h2:mem:tasks-jsf-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;NON_KEYWORDS=USER</connection-url>
+      <connection-url>jdbc:h2:mem:tasks-jsf-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>

--- a/tasks-jsf/src/main/webapp/WEB-INF/tasks-jsf-ds.xml
+++ b/tasks-jsf/src/main/webapp/WEB-INF/tasks-jsf-ds.xml
@@ -27,7 +27,8 @@
    <datasource jndi-name="java:jboss/datasources/TasksJsfQuickstartDS"
       pool-name="tasks-jsf-quickstart" enabled="true"
       use-java-context="true">
-      <connection-url>jdbc:h2:mem:tasks-jsf-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1</connection-url>
+      <!-- Ignore H2 reserved keyword `USER` as workaround for syntax error as per https://github.com/h2database/h2database/issues/3363#issuecomment-1010631797 -->
+      <connection-url>jdbc:h2:mem:tasks-jsf-quickstart;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;NON_KEYWORDS=USER</connection-url>
       <driver>h2</driver>
       <security>
          <user-name>sa</user-name>

--- a/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskDaoIT.java
+++ b/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskDaoIT.java
@@ -42,7 +42,7 @@ public class TaskDaoIT {
     @Deployment
     public static WebArchive deployment() throws IllegalArgumentException, FileNotFoundException {
         return new DefaultDeployment().withPersistence().withImportedData().getArchive()
-                .addClasses(Resources.class, User.class, UserDao.class, Task.class, TaskDao.class, TaskDaoImpl.class);
+                .addClasses(Resources.class, Person.class, PersonDao.class, Task.class, TaskDao.class, TaskDaoImpl.class);
     }
 
     @Inject
@@ -51,11 +51,11 @@ public class TaskDaoIT {
     @Inject
     private TaskDao taskDao;
 
-    private User detachedUser;
+    private Person detachedUser;
 
     @Before
     public void setUp() throws Exception {
-        detachedUser = new User("jdoe");
+        detachedUser = new Person("jdoe");
         detachedUser.setId(1L);
     }
 
@@ -63,7 +63,7 @@ public class TaskDaoIT {
     @InSequence(1)
     public void user_should_be_created_with_one_task_attached() throws Exception {
         // given
-        User user = new User("New user");
+        Person user = new Person("New user");
         Task task = new Task("New task");
 
         // when

--- a/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskDaoStub.java
+++ b/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskDaoStub.java
@@ -25,22 +25,22 @@ public class TaskDaoStub implements TaskDao {
     private int getAllCallsCount = 0;
 
     @Override
-    public void createTask(User user, Task task) {
+    public void createTask(Person user, Task task) {
     }
 
     @Override
-    public List<Task> getAll(User user) {
+    public List<Task> getAll(Person user) {
         getAllCallsCount += 1;
         return Arrays.asList(new Task[] {});
     }
 
     @Override
-    public List<Task> getRange(User user, int offset, int count) {
+    public List<Task> getRange(Person user, int offset, int count) {
         return null;
     }
 
     @Override
-    public List<Task> getForTitle(User user, String title) {
+    public List<Task> getForTitle(Person user, String title) {
         return null;
     }
 

--- a/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskListBeanIT.java
+++ b/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/TaskListBeanIT.java
@@ -38,7 +38,7 @@ public class TaskListBeanIT {
     @Deployment
     public static WebArchive deployment() throws IllegalArgumentException, FileNotFoundException {
         return new DefaultDeployment(true).withPersistence().withImportedData().getArchive()
-                .addClasses(User.class, Task.class, TaskList.class, TaskListBean.class, TaskDao.class, TaskDaoStub.class, Testing.class);
+                .addClasses(Person.class, Task.class, TaskList.class, TaskListBean.class, TaskDao.class, TaskDaoStub.class, Testing.class);
     }
 
     @Inject

--- a/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/UserDaoIT.java
+++ b/tasks-jsf/src/test/java/org/jboss/as/quickstarts/tasksJsf/UserDaoIT.java
@@ -40,11 +40,11 @@ public class UserDaoIT {
     @Deployment
     public static WebArchive deployment() throws IllegalArgumentException, FileNotFoundException {
         return new DefaultDeployment().withPersistence().withImportedData().getArchive()
-                .addClasses(Resources.class, User.class, UserDao.class, Task.class, TaskDao.class, UserDaoImpl.class);
+                .addClasses(Resources.class, Person.class, PersonDao.class, Task.class, TaskDao.class, PersonDaoImpl.class);
     }
 
     @Inject
-    private UserDao userDao;
+    private PersonDao userDao;
 
     @Inject
     private EntityManager em;
@@ -52,11 +52,11 @@ public class UserDaoIT {
     @Test
     public void userDao_should_create_user_so_it_could_be_retrieved_from_userDao_by_username() {
         // given
-        User created = new User("username1");
+        Person created = new Person("username1");
 
         // when
         userDao.createUser(created);
-        User retrieved = userDao.getForUsername("username1");
+        Person retrieved = userDao.getForUsername("username1");
 
         // then
         assertTrue(em.contains(created));
@@ -70,7 +70,7 @@ public class UserDaoIT {
         String username = "jdoe";
 
         // when
-        User retrieved = userDao.getForUsername(username);
+        Person retrieved = userDao.getForUsername(username);
 
         // then
         Assert.assertEquals(username, retrieved.getUsername());
@@ -82,7 +82,7 @@ public class UserDaoIT {
         String nonExistent = "nonExistent";
 
         // when
-        User retrieved = userDao.getForUsername(nonExistent);
+        Person retrieved = userDao.getForUsername(nonExistent);
 
         // then
         assertNull(retrieved);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17533

- Updated datasource URL to instruct H2 to ignore `USER` keyword in SQL statements.
- Enabled tasks-jsf quickstart

I suspect that further application changes may be needed as we can create users but no further UI is displayed other than:
1.  Open http://localhost:8080/tasks-jsf/index.jsf and enter "scott" for user name, press login button.
2. Browser only shows `Tasks - Authentication`. 
3. Server console shows `14:42:30,946 INFO  [jakarta.enterprise.resource.webcontainer.faces.renderkit] (default task-1) WARNING: FacesMessage(s) have been enqueued, but may not have been displayed.
sourceId=null[severity=(INFO 0), summary=(User successfully created), detail=(User successfully created)]`

@emmartins @jasondlee is there a known fix for why the tasks-jsf quickstart doesn't show anything interesting in the browser after a user is created?  I assume there should be a menu or something shown but the browser doesn't show anything that can be clicked on.