### PR TITLE
WFLY-17534 Verify and re-enable spring-resteasy quickstart

### DIFF
--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -56,7 +56,6 @@
                 <exclude>logging/**</exclude>
                 <exclude>messaging-clustering-singleton/**</exclude>
                 <exclude>microprofile-fault-tolerance/**</exclude>
-                <exclude>spring-resteasy/**</exclude>
                 <exclude>tasks-jsf/**</exclude>
                 <exclude>wsat-simple/**</exclude>
                 <exclude>wsba-coordinator-completion-simple/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,6 @@
                 <module>servlet-security</module>
                 <module>shopping-cart</module>
                 <!-- disabled waiting for jakarta migration
-                <module>spring-resteasy</module>
                 <module>tasks-jsf</module>
                 -->
                 <module>temperature-converter</module>

--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -45,7 +45,7 @@
 
     <properties>
         <!-- The versions for BOMs, Dependencies and Plugins -->
-        <version.spring.framework>5.2.4.RELEASE</version.spring.framework>
+        <version.spring.framework>6.0.4</version.spring.framework>
         <version.server.bom>27.0.0.Final</version.server.bom>
     </properties>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17534

Opening as draft as deployment fails with:
```
Failed to execute goal org.wildfly.plugins:wildfly-maven-plugin:2.0.2.Final:deploy (default-cli) on project spring-resteasy: Failed to execute goal deploy: {"WFLYCTL0062: Composite operation failed and was rolled back. Steps that failed:" => {"Operation step-1" => {"WFLYCTL0080: Failed services" => {"jboss.deployment.unit.\"spring-resteasy.war\".undertow-deployment" => "java.lang.RuntimeException: org.jboss.resteasy.spi.LoggableFailure: RESTEASY003880: Unable to find contextual data of type: jakarta.servlet.ServletContext
[ERROR]     Caused by: java.lang.RuntimeException: org.jboss.resteasy.spi.LoggableFailure: RESTEASY003880: Unable to find contextual data of type: jakarta.servlet.ServletContext
[ERROR]     Caused by: org.jboss.resteasy.spi.LoggableFailure: RESTEASY003880: Unable to find contextual data of type: jakarta.servlet.ServletContext"}}}}
[ERROR] -> [Help 1]
```

@emmartins should https://issues.redhat.com/browse/WFLY-17534 have been assigned to @jamezp instead?