### PR TITLE
[WFLY-17399] Verify and re-enable ejb-txn-remote-call quickstart

### DIFF
--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -45,7 +45,6 @@
                 <!-- disabled waiting for jakarta migration -->
                 <exclude>bmt/**</exclude>
                 <exclude>contacts-jquerymobile/**</exclude>
-                <exclude>ejb-txn-remote-call/**</exclude>
                 <exclude>helloworld-jms/**</exclude>
                 <exclude>hibernate/**</exclude>
                 <exclude>jaxws-ejb/**</exclude>

--- a/ejb-txn-remote-call/README.adoc
+++ b/ejb-txn-remote-call/README.adoc
@@ -143,8 +143,7 @@ NOTE: For Windows, use the `bin\jboss-cli.bat` script.
   can be reached at `server2`.
 * It configures a https://docs.wildfly.org/22/wildscribe/subsystem/remoting/remote-outbound-connection/index.html[`remote outbound connection`]. It is referenced in the war deployment with `jboss-ejb-client.xml` descriptor
 (see `${PATH_TO_QUICKSTART_DIR}/ejb-txn-remote-call/client/src/main/webapp/WEB-INF/jboss-ejb-client.xml`).
-* It defines the security realm, using the credentials of the user created at <<add_application_user, Add the Authorized Application User>>.
-* It defines the security realm, using the credentials of the user created at <<add_application_user, Add the Authorized Application User>>.
+* It defines an authentication context `auth_context` which is used by the new created remoting connection `remote-ejb-connection`. The authentication context uses the same username and password created for `server2` and `server3`.
 
 === Configure datasources
 
@@ -366,7 +365,7 @@ due to transaction affinity.
 |The two returned hostnames must be the same.
 
 |__http://localhost:8080/client/remote-outbound-notx-stateless__
-|Seven remote invocations to stateless EJB without a transaction context.
+|Several remote invocations to stateless EJB without a transaction context.
 The EJB remote call is configured from the `remote-outbound-connection`.
 The EJB client is expected to load balance the calls on various servers.
 |The list of the returned hostnames should contain occurrences of both
@@ -385,7 +384,7 @@ The remote invocation is run, unlike the other calls of this quickstarts, via ht
 |The returned hostnames must be the same.
 
 |__http://localhost:8080/client/remote-outbound-notx-stateful__
-|Two invocations under the transaction context stared on `server1` (`client` application).
+|Two invocations under the transaction context started on `server1` (`client` application).
 The EJB remote call is configured from the `remote-outbound-connection`.
 Both calls are directed to the same stateful bean on the remote server because
 the stateful bean invocations are sticky ensuring affinity to the same server instance.
@@ -569,7 +568,7 @@ For building the application the {productName} s2i functionality
 (provided out-of-boxy by OpenShift) needs to be used.
 
 The {productName} provides `ImageStream` definition of builder images and runtime images.
-The builder image makes the application to be build, configure the application server
+The builder image makes the application to be built, configure the application server
 with s2i scripts. The resulted image may be used for running,
 but it's big as it contains many dependencies needed only for the build.
 The chain build defines the next step which is to get the runtime image
@@ -716,7 +715,7 @@ endif::[]
 [#_running_on_openshift_run_the_quickstart_with_productname_operator]
 ==== Running on OpenShift: Run the Quickstart with {productName} Operator
 
-After you install the {productName} Operator, you can deploy the`CustomResource` that uses it.
+After you install the {productName} Operator, you can deploy the `CustomResource` that uses it.
 The `CustomResource.yaml` definition contains information the {productName} Operator uses
 to start the application pods for the client application and for the server application.
 

--- a/ejb-txn-remote-call/client/extensions/postgresql-module.xml
+++ b/ejb-txn-remote-call/client/extensions/postgresql-module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module name="org.postgresql.jdbc" xmlns="urn:jboss:module:1.8">
     <resources>
-        <artifact name="org.postgresql:postgresql:42.2.8"/>
+        <artifact name="org.postgresql:postgresql:42.2.27"/>
     </resources>
     <dependencies>
         <module name="javax.api"/>

--- a/ejb-txn-remote-call/client/pom.xml
+++ b/ejb-txn-remote-call/client/pom.xml
@@ -97,7 +97,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <!-- importing the wildfly-ee-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
             <dependency>
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-ee-with-tools</artifactId>

--- a/ejb-txn-remote-call/client/src/main/resources/META-INF/persistence.xml
+++ b/ejb-txn-remote-call/client/src/main/resources/META-INF/persistence.xml
@@ -15,9 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<persistence version="2.1"
-    xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="
+               https://jakarta.ee/xml/ns/persistence
+               https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
     <persistence-unit name="primary">
         <!-- If you are running in a production environment, add a managed
             data source, this example data source is just for development and testing! -->

--- a/ejb-txn-remote-call/client/src/main/webapp/WEB-INF/web.xml
+++ b/ejb-txn-remote-call/client/src/main/webapp/WEB-INF/web.xml
@@ -14,9 +14,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+         xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
   <!-- One of the way of activating REST Services is adding these lines, the server is responsible for adding the corresponding servlet automatically. -->
   <servlet-mapping>

--- a/ejb-txn-remote-call/server/extensions/postgresql-module.xml
+++ b/ejb-txn-remote-call/server/extensions/postgresql-module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module name="org.postgresql.jdbc" xmlns="urn:jboss:module:1.8">
     <resources>
-        <artifact name="org.postgresql:postgresql:42.2.8"/>
+        <artifact name="org.postgresql:postgresql:42.2.27"/>
     </resources>
     <dependencies>
         <module name="javax.api"/>

--- a/ejb-txn-remote-call/server/pom.xml
+++ b/ejb-txn-remote-call/server/pom.xml
@@ -98,7 +98,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <!-- importing the wildfly-ee-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
             <dependency>
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-ee-with-tools</artifactId>

--- a/ejb-txn-remote-call/server/src/main/resources/META-INF/persistence.xml
+++ b/ejb-txn-remote-call/server/src/main/resources/META-INF/persistence.xml
@@ -15,9 +15,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<persistence version="2.1"
-    xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="
+               https://jakarta.ee/xml/ns/persistence
+               https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
     <persistence-unit name="primary">
         <!-- If you are running in a production environment, add a managed
             data source, this example data source is just for development and testing! -->

--- a/ejb-txn-remote-call/server/src/main/webapp/WEB-INF/web.xml
+++ b/ejb-txn-remote-call/server/src/main/webapp/WEB-INF/web.xml
@@ -14,9 +14,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+         xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
   <!-- Activating REST Services, the server is responsible for adding the corresponding servlet automatically. -->
   <servlet-mapping>

--- a/pom.xml
+++ b/pom.xml
@@ -314,9 +314,7 @@
                 <module>ejb-security-programmatic-auth</module>
                 <module>ejb-throws-exception</module>
                 <module>ejb-timer</module>
-                <!-- disabled waiting for jakarta migration
                 <module>ejb-txn-remote-call</module>
-                -->
                 <module>ha-singleton-deployment</module>
                 <module>ha-singleton-service</module>
                 <module>helloworld</module>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-17399

Verified on bare metal setup, I would like to enable the quickstart, and leave the verification on OpenShift as a new issue.

However, I did not find way yet to verify the steps running on Openshift platform, which has been migrated to use helm chart I believe.

Please reject it if the verification on OpenShift platform should be done before enabling it. thanks :)