### PR TITLE
[WFLY-17535]  Re-enable the logging quickstart

### DIFF
--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -52,7 +52,6 @@
                 <exclude>jsonp/**</exclude>
                 <exclude>jta-crash-rec/**</exclude>
                 <exclude>jts/**</exclude>
-                <exclude>logging/**</exclude>
                 <exclude>messaging-clustering-singleton/**</exclude>
                 <exclude>microprofile-fault-tolerance/**</exclude>
                 <exclude>spring-resteasy/**</exclude>

--- a/logging/configure-logging.cli
+++ b/logging/configure-logging.cli
@@ -4,24 +4,18 @@
 batch
 
 # Add the periodic rotating file handlers corresponding to those added to the logging properties file
-/subsystem=logging/periodic-rotating-file-handler=FILE_QS_TRACE:add(suffix=".yyyy.MM.dd", file={"path"=>"quickstart.trace.log", "relative-to"=>"jboss.server.log.dir"})
-/subsystem=logging/periodic-rotating-file-handler=FILE_QS_DEBUG:add(suffix=".yyyy.MM.dd", file={"path"=>"quickstart.debug.log", "relative-to"=>"jboss.server.log.dir"})
-/subsystem=logging/periodic-rotating-file-handler=FILE_QS_INFO:add(suffix=".yyyy.MM.dd", file={"path"=>"quickstart.info.log", "relative-to"=>"jboss.server.log.dir"})
-/subsystem=logging/periodic-rotating-file-handler=FILE_QS_WARN:add(suffix=".yyyy.MM.dd", file={"path"=>"quickstart.warn.log", "relative-to"=>"jboss.server.log.dir"})
-/subsystem=logging/periodic-rotating-file-handler=FILE_QS_ERROR:add(suffix=".yyyy.MM.dd", file={"path"=>"quickstart.error.log", "relative-to"=>"jboss.server.log.dir"})
-/subsystem=logging/periodic-rotating-file-handler=FILE_QS_FATAL:add(suffix=".yyyy.MM.dd", file={"path"=>"quickstart.fatal.log", "relative-to"=>"jboss.server.log.dir"})
+/subsystem=logging/periodic-rotating-file-handler=FILE_QS_TRACE:add(level=TRACE, suffix=".yyyy.MM.dd", file={"path"=>"quickstart.trace.log", "relative-to"=>"jboss.server.log.dir"})
+/subsystem=logging/periodic-rotating-file-handler=FILE_QS_DEBUG:add(level=DEBUG, suffix=".yyyy.MM.dd", file={"path"=>"quickstart.debug.log", "relative-to"=>"jboss.server.log.dir"})
+/subsystem=logging/periodic-rotating-file-handler=FILE_QS_INFO:add(level=INFO, suffix=".yyyy.MM.dd", file={"path"=>"quickstart.info.log", "relative-to"=>"jboss.server.log.dir"})
+/subsystem=logging/periodic-rotating-file-handler=FILE_QS_WARN:add(level=WARN, suffix=".yyyy.MM.dd", file={"path"=>"quickstart.warn.log", "relative-to"=>"jboss.server.log.dir"})
+/subsystem=logging/periodic-rotating-file-handler=FILE_QS_ERROR:add(level=ERROR, suffix=".yyyy.MM.dd", file={"path"=>"quickstart.error.log", "relative-to"=>"jboss.server.log.dir"})
+/subsystem=logging/periodic-rotating-file-handler=FILE_QS_FATAL:add(level=FATAL, suffix=".yyyy.MM.dd", file={"path"=>"quickstart.fatal.log", "relative-to"=>"jboss.server.log.dir"})
 
 # Configure the logging async handlers
-/subsystem=logging/async-handler=TRACE_QS_ASYNC:add(level=TRACE,queue-length=1024,overflow-action=BLOCK,subhandlers=["FILE_QS_TRACE"]) 
-/subsystem=logging/async-handler=DEBUG_QS_ASYNC:add(level=DEBUG,queue-length=1024,overflow-action=BLOCK,subhandlers=["FILE_QS_DEBUG"]) 
-/subsystem=logging/async-handler=INFO_QS_ASYNC:add(level=INFO,queue-length=1024,overflow-action=BLOCK,subhandlers=["FILE_QS_INFO"]) 
-/subsystem=logging/async-handler=WARN_QS_ASYNC:add(level=WARN,queue-length=1024,overflow-action=BLOCK,subhandlers=["FILE_QS_WARN"]) 
-/subsystem=logging/async-handler=ERROR_QS_ASYNC:add(level=ERROR,queue-length=1024,overflow-action=BLOCK,subhandlers=["FILE_QS_ERROR"]) 
-/subsystem=logging/async-handler=FATAL_QS_ASYNC:add(level=FATAL,queue-length=1024,overflow-action=BLOCK,subhandlers=["FILE_QS_FATAL"]) 
+/subsystem=logging/async-handler=async:add(queue-length=1024, overflow-action=BLOCK, subhandlers=["FILE_QS_TRACE","FILE_QS_DEBUG","FILE_QS_INFO","FILE_QS_WARN","FILE_QS_ERROR","FILE_QS_FATAL"])
 
 # Create the logger for our quickstart class
-### NOTE: To view different logging levels, change the level below from TRACE to DEBUG, INFO, WARN, ERROR, or FATAL, then access the application.
-/subsystem=logging/logger=org.jboss.as.quickstarts.logging:add(level=TRACE,handlers=[TRACE_QS_ASYNC,DEBUG_QS_ASYNC,INFO_QS_ASYNC,WARN_QS_ASYNC,ERROR_QS_ASYNC,FATAL_QS_ASYNC])
+/subsystem=logging/logger=org.jboss.as.quickstarts.logging:add(handlers=[async])
 
 # Run the batch commands
 run-batch

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>2</version>
+        <version>3</version>
         <relativePath/>
     </parent>
     <artifactId>jboss-logging</artifactId>
@@ -44,6 +44,7 @@
 
     <properties>
         <!-- The versions for BOMs, Dependencies and Plugins -->
+        <version.org.wildfly>27.0.1.Final</version.org.wildfly>
         <version.server.bom>27.0.0.Final</version.server.bom>
     </properties>
 
@@ -128,6 +129,22 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <version>${version.org.wildfly}</version>
+                    <fail-on-error>false</fail-on-error>
+                    <scripts>
+                        <script>${project.basedir}${file.separator}configure-logging.cli</script>
+                    </scripts>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
    
 </project>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -104,7 +104,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- importing the jakartaee8-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
+            <!-- importing the wildfly-ee-with-tools BOM adds specs and other useful artifacts as managed dependencies -->
             <dependency>
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-ee-with-tools</artifactId>

--- a/logging/remove-logging.cli
+++ b/logging/remove-logging.cli
@@ -7,12 +7,7 @@ batch
 /subsystem=logging/logger=org.jboss.as.quickstarts.logging:remove
 
 # Remove the log async handler
-/subsystem=logging/async-handler=TRACE_QS_ASYNC:remove
-/subsystem=logging/async-handler=DEBUG_QS_ASYNC:remove
-/subsystem=logging/async-handler=INFO_QS_ASYNC:remove
-/subsystem=logging/async-handler=WARN_QS_ASYNC:remove
-/subsystem=logging/async-handler=ERROR_QS_ASYNC:remove
-/subsystem=logging/async-handler=FATAL_QS_ASYNC:remove
+/subsystem=logging/async-handler=async:remove
 
 # Remove the file handlers
 /subsystem=logging/periodic-rotating-file-handler=FILE_QS_TRACE:remove

--- a/pom.xml
+++ b/pom.xml
@@ -339,9 +339,7 @@
                 <module>jsonp</module>
                 -->                
                 <module>kitchensink</module>
-                <!-- disabled waiting for jakarta migration
                 <module>logging</module>
-                -->
                 <module>mail</module>
                 <!-- disabled waiting for jakarta migration
                 <module>messaging-clustering-singleton</module>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17535

The first commit simply re-enables the quickstart. The second commit does some minor cleanup.