### PR TITLE
[WFLY-17526] Verify and re-enable helloworld-jms quickstart.

### DIFF
--- a/helloworld-jms/README.adoc
+++ b/helloworld-jms/README.adoc
@@ -93,16 +93,6 @@ $ cd PATH_TO_QUICKSTARTS/helloworld-jms
 $ mvn clean compile exec:java
 ----
 
-[NOTE]
-====
-If you execute this command multiple times, you may see the following warning and exception, followed by a stacktrace. This is caused by a bug in Artemis that has been fixed, but not yet released. For details, see https://issues.apache.org/jira/browse/ARTEMIS-158. You can ignore this warning._
-
-[source,options="nowrap"]
-----
-WARN: AMQ212007: connector.create or connectorFactory.createConnector should never throw an exception, implementation is badly behaved, but we will deal with it anyway.
-java.lang.IllegalArgumentException: port out of range:-1
-----
-====
 
 == Investigate the Console Output
 

--- a/pom.xml
+++ b/pom.xml
@@ -314,9 +314,7 @@
                 <module>ha-singleton-deployment</module>
                 <module>ha-singleton-service</module>
                 <module>helloworld</module>
-                <!-- disabled waiting for jakarta migration
                 <module>helloworld-jms</module>
-                -->
                 <module>helloworld-mdb</module>
 
                 <module>helloworld-mutual-ssl</module>


### PR DESCRIPTION
* Re-enabling helloworld-jms quickstart.

Jira: https://issues.redhat.com/browse/WFLY-17526
Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>