### PR TITLE
WFLY-17530, WFLY-17531, WFLY-17532 re-enable xts quickstarts

### DIFF
--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -47,9 +47,6 @@
                 <exclude>jaxws-retail/**</exclude>
                 <exclude>messaging-clustering-singleton/**</exclude>
                 <exclude>tasks-jsf/**</exclude>
-                <exclude>wsat-simple/**</exclude>
-                <exclude>wsba-coordinator-completion-simple/**</exclude>
-                <exclude>wsba-participant-completion-simple/**</exclude>
             </excludes>
         </fileSet>
     </fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -428,11 +428,9 @@
                 </property>
             </activation>
             <modules>
-                <!-- disabled waiting for jakarta migration
                 <module>wsat-simple</module>
                 <module>wsba-coordinator-completion-simple</module>
                 <module>wsba-participant-completion-simple</module>
-                -->
             </modules>
         </profile>
         <profile>

--- a/wsat-simple/README.adoc
+++ b/wsat-simple/README.adoc
@@ -10,6 +10,7 @@ The `wsat-simple` quickstart demonstrates a WS-AT (WS-AtomicTransaction) enabled
 
 :standalone-server-type: custom
 :archiveType: war
+:restoreScriptName: restore-configuration.cli
 
 == What is it?
 
@@ -53,7 +54,7 @@ include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 You must start {productName} with the XTS subsystem enabled.
 
-. Edit the log level to reduce the amount of log output. This should make it easier to read the logs produced by this example. To do this add the following logger block to the `__{jbossHomeName}__/docs/examples/configs/standalone-xts.xml` of your JBoss distribution. You should add it just below one of the other logger blocks.
+. Edit the log level to reduce the amount of log output. This should make it easier to read the logs produced by this example. To do this add the following logger block to the `__{jbossHomeName}__/standalone/configuration/standalone.xml` of your JBoss distribution. You should add it just below one of the other logger blocks.
 +
 [source,xml,options="nowrap"]
 ----
@@ -62,19 +63,79 @@ You must start {productName} with the XTS subsystem enabled.
 </logger>
 ----
 
+[[configure_the_server]]
+=== Configure the Server
+
+You can configure the server by running JBoss CLI commands. For your convenience, this quickstart batches the commands into a `configure-server.cli` script provided in the root directory of this quickstart.
++
+NOTE: Remember you will need to run the restore-configuration.cli script to restore the server original configuration.
+
+
+. Before you begin, make sure you do the following:
+
+* xref:back_up_standalone_server_configuration[Back up the {productName} standalone server configuration] as described above.
+* Start the {productName} server with the standalone profile : 
++
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/standalone.sh
+----
+
+. Review the `configure-server.cli` file in the root of this quickstart directory. This script adds xts domain
+. Open a new terminal, navigate to the root directory of this quickstart, and run the following command, replacing `__{jbossHomeName}__` with the path to your server:
++
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=configure-server.cli
+----
++
+NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat` script.
+
++
+You should see the following result when you run the script:
++
+[source,options="nowrap"]
+----
+The batch executed successfully
+----
+
+. Stop the {productName} server.
+
+=== Review the Modified Server Configuration
+
+After stopping the server, open the `__{jbossHomeName}__/standalone/configuration/standalone.xml` file and review the changes.
+
+. The following subsystem was added.
++
+[source,xml,options="nowrap"]
+----
+<subsystem xmlns="urn:jboss:domain:xts:3.0">
+            <host name="default-host"/>
+            <xts-environment url="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService"/>
+            <default-context-propagation enabled="true"/>
+</subsystem>
+----
+
+. The following `extension` was added.
++
+[source,xml,options="nowrap"]
+----
+        <extension module="org.jboss.as.xts"/>
+----
++
+
 . Open a terminal and navigate to the root of the {productName} directory.
 . Start the {productName} server with XTS subsystem enabled by typing the following command.
 +
 [source,subs="+quotes,attributes+",options="nowrap"]
 ----
-$ __{jbossHomeName}__/bin/standalone.sh --server-config=../../docs/examples/configs/standalone-xts.xml
+$ __{jbossHomeName}__/bin/standalone.sh
 ----
 +
 NOTE: For Windows, use the `__{jbossHomeName}__\bin\standalone.bat` script.
 
 // Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
 
 [[investigate_the_console_output]]
 == Investigate the Console Output
@@ -94,12 +155,10 @@ You see the following warning when you run the Arquillian tests in remote mode.
 
 [source,options="nowrap"]
 ----
-WARNING: Configuration contain properties not supported by the backing object org.jboss.as.arquillian.container.remote.RemoteContainerConfiguration
-Unused property entries: {serverConfig=../../docs/examples/configs/standalone-xts.xml}
-Supported property names: [managementAddress, password, managementPort, managementProtocol, username]
+WARN  [org.jboss.as.dependency.deprecated] (MSC service thread 1-4) WFLYSRV0221: Deployment "deployment.wsat-simple.war" is using a deprecated module ("org.jboss.xts") which may be removed in future versions without notice.
 ----
 
-This is because, in remote mode, you are responsible for starting the server with the XTS subsystem enabled. When you run the Arquillian tests in managed mode, the container uses the `serverConfig` property defined in the `arquillian.xml` file to start the server with the XTS subsystem enabled.
+This is because, in remote mode, you are responsible for starting the server with the XTS subsystem enabled. When you run the Arquillian tests in managed mode, the container uses the `serverConfig` property defined in the `arquillian.xml` file to start the server with the XTS subsystem enabled (default is standalone.xml).
 ====
 
 [[investigate_the_server_log]]
@@ -145,13 +204,14 @@ INFO  [stdout] (TaskWorker-2) [SERVICE] all participants voted 'prepared', so co
 INFO  [stdout] (TaskWorker-2) [SERVICE] commit called on backend resource.
 ----
 
-NOTE: You can ignore the warning message `ARJUNA043219: Could not save recovery state for non-serializable durable WS-AT participant restaurantServiceAT` that is printed in the server console. This quickstart does not implement the required recovery hooks in the interest of making it easy to follow. In a real world production application, you should provide the required recovery code. For more information, see http://narayana.io/docs/product.
+//  Restore the {productName} Standalone Server Configuration
+include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+2]
 
 // Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional Red Hat CodeReady Studio instructions
-This quickstart is more complex than the others. It requires that you configure the {productName} server to use the _standalone-xts.xml_ configuration file, which is located in an external configuration directory.
+This quickstart is more complex than the others. It requires that you configure the {productName} server using the configure-server.cli file.
 
 . Import the quickstart into {JBDSProductName}.
 +
@@ -178,7 +238,7 @@ This is a known Eclipse issue. For more information, see Eclipse Bugzilla - http
 *Home Directory*: __Browse to the __{jbossHomeName}__ directory and select it.__
 *Runtime JRE*: __Choose an alternate JRE if not correct.__
 *Server base directory*: __This should already point to your standalone server configuration directory,__
-*Configuration file*: `../../docs/examples/configs/standalone-xts.xml`
+*Configuration file*: `standalone.xml`
 ----
 
 . Start the new *{productName} XTS Configuration* server.

--- a/wsat-simple/configure-server.cli
+++ b/wsat-simple/configure-server.cli
@@ -1,0 +1,17 @@
+
+# Batch script to configure XTS subsystem
+
+
+/extension=org.jboss.as.xts:add
+
+batch
+
+# Creating the xts subsystem
+/subsystem=xts/:add(host=default-host, url="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService", default-context-propagation=true )
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+#reload
+

--- a/wsat-simple/configure-server.cli
+++ b/wsat-simple/configure-server.cli
@@ -13,5 +13,5 @@ batch
 run-batch
 
 # Reload the server configuration
-#reload
+reload
 

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -139,7 +139,7 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- The XTS api needed to use WS-AT -->

--- a/wsat-simple/restore-configuration.cli
+++ b/wsat-simple/restore-configuration.cli
@@ -1,0 +1,16 @@
+# Batch script to remove the XTS subsystem and extension
+
+# Start batching commands
+
+batch
+
+# Remove xts's application security domain
+/subsystem=xts/:remove()
+
+/extension=org.jboss.as.xts:remove
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+reload

--- a/wsat-simple/src/main/java/org/jboss/as/quickstarts/wsat/simple/MockRestaurantManager.java
+++ b/wsat-simple/src/main/java/org/jboss/as/quickstarts/wsat/simple/MockRestaurantManager.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.as.quickstarts.wsat.simple;
 
+import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -25,7 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author paul.robinson@redhat.com, 2012-01-04
  */
-public class MockRestaurantManager {
+public class MockRestaurantManager implements Serializable{
 
     // The singleton instance of this class.
     private static MockRestaurantManager singletonInstance;

--- a/wsat-simple/src/main/webapp/WEB-INF/beans.xml
+++ b/wsat-simple/src/main/webapp/WEB-INF/beans.xml
@@ -16,9 +16,8 @@
     limitations under the License.
 -->
 <!-- Marker file indicating CDI should be enabled -->
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-    bean-discovery-mode="all">
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+       https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="all">
 </beans>

--- a/wsat-simple/src/main/webapp/WEB-INF/classes/context-handlers.xml
+++ b/wsat-simple/src/main/webapp/WEB-INF/classes/context-handlers.xml
@@ -15,9 +15,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<handler-chains xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-    http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/javaee_web_services_metadata_handler_2_0.xsd">
+<handler-chains xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee">
     <handler-chain>
         <handler>
             <handler-name>ContextHandler</handler-name>

--- a/wsat-simple/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/wsat-simple/src/main/webapp/WEB-INF/jboss-web.xml
@@ -16,10 +16,10 @@
     limitations under the License.
 -->
 <!DOCTYPE jboss-web>
-<jboss-web xmlns="http://www.jboss.com/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.jboss.org/schema/jbossas
-    http://www.jboss.org/schema/jbossas/jboss-web_7_2.xsd">
+<jboss-web xmlns="urn:jboss:jakartaee:1.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="urn:jboss:jakartaee:1.0 https://www.jboss.org/schema/jbossas/jboss-web_15_0.xsd"
+   version="15.0">
     <context-root>/</context-root>
 </jboss-web>
 

--- a/wsat-simple/src/test/java/org/jboss/as/quickstarts/wsat/simple/ClientIT.java
+++ b/wsat-simple/src/test/java/org/jboss/as/quickstarts/wsat/simple/ClientIT.java
@@ -22,9 +22,7 @@ import com.arjuna.mw.wst11.UserTransactionFactory;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.quickstarts.wsat.simple.jaxws.RestaurantServiceAT;
-import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -58,7 +56,7 @@ public class ClientIT {
 
         return ShrinkWrap.create(WebArchive.class, "wsat-simple.war")
             .addPackages(true, RestaurantServiceATImpl.class.getPackage()).addAsResource("context-handlers.xml")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
+            .addAsWebInfResource(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "beans.xml")
             .setManifest(new StringAsset(ManifestMF));
     }
 

--- a/wsat-simple/src/test/resources/arquillian.xml
+++ b/wsat-simple/src/test/resources/arquillian.xml
@@ -27,7 +27,7 @@
              following `jbossHome` property and replace EAP_HOME with the path to your JBoss EAP installation. -->
         <configuration>
             <!-- <property name="jbossHome">EAP_HOME</property> -->
-            <property name="serverConfig">../../docs/examples/configs/standalone-xts.xml</property>
+<!--             <property name="serverConfig">standalone.xml</property> -->
         </configuration>
     </container>
 </arquillian>

--- a/wsat-simple/src/test/resources/context-handlers.xml
+++ b/wsat-simple/src/test/resources/context-handlers.xml
@@ -15,9 +15,11 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<handler-chains xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-    http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/javaee_web_services_metadata_handler_2_0.xsd">
+
+<handler-chains xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee">
     <handler-chain>
         <handler>
             <handler-name>ContextHandler</handler-name>

--- a/wsba-coordinator-completion-simple/README.adoc
+++ b/wsba-coordinator-completion-simple/README.adoc
@@ -10,6 +10,7 @@ The `wsba-coordinator-completion-simple` quickstart deploys a WS-BA (WS Business
 
 :standalone-server-type: custom
 :archiveType: war
+:restoreScriptName: restore-configuration.cli
 
 == What is it?
 
@@ -55,17 +56,82 @@ include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 You must start {productName} with the XTS subsystem enabled.
 
+. Edit the log level to reduce the amount of log output. This should make it easier to read the logs produced by this example. To do this add the following logger block to the `__{jbossHomeName}__/standalone/configuration/standalone.xml` of your JBoss distribution. You should add it just below one of the other logger blocks.
++
+[source,xml,options="nowrap"]
+----
+<logger category="org.apache.cxf.service.factory.ReflectionServiceFactoryBean">
+    <level name="WARN"/>
+</logger>
+----
+
+[[configure_the_server]]
+=== Configure the Server
+
+You can configure the server by running JBoss CLI commands. For your convenience, this quickstart batches the commands into a `configure-server.cli` script provided in the root directory of this quickstart.
+
+. Before you begin, make sure you do the following:
+
+* xref:back_up_standalone_server_configuration[Back up the {productName} standalone server configuration] as described above.
+* Start the {productName} server with the standalone default profile : 
++
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/standalone.sh
+----
+
+. Review the `configure-server.cli` file in the root of this quickstart directory. This script adds xts domain
+. Open a new terminal, navigate to the root directory of this quickstart, and run the following command, replacing `__{jbossHomeName}__` with the path to your server:
++
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=configure-server.cli
+----
++
+NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat` script.
+
++
+You should see the following result when you run the script:
++
+[source,options="nowrap"]
+----
+The batch executed successfully
+----
+
+. Stop the {productName} server.
+
+=== Review the Modified Server Configuration
+
+After stopping the server, open the `__{jbossHomeName}__/standalone/configuration/standalone.xml` file and review the changes.
+
+. The following subsystem was added.
++
+[source,xml,options="nowrap"]
+----
+<subsystem xmlns="urn:jboss:domain:xts:3.0">
+            <host name="default-host"/>
+            <xts-environment url="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService"/>
+            <default-context-propagation enabled="true"/>
+</subsystem>
+----
+
+. The following `extension` was added.
++
+[source,xml,options="nowrap"]
+----
+        <extension module="org.jboss.as.xts"/>
+----
++
+
 . Open a terminal and navigate to the root of the {productName} directory.
 . Start the {productName} server with XTS subsystem enabled by typing the following command.
 +
 [source,subs="+quotes,attributes+",options="nowrap"]
 ----
-$ __{jbossHomeName}__/bin/standalone.sh --server-config=../../docs/examples/configs/standalone-xts.xml | egrep "started|stdout"
+$ __{jbossHomeName}__/bin/standalone.sh
 ----
 +
 NOTE: For Windows, use the `__{jbossHomeName}__\bin\standalone.bat` script.
-
-The pipe to egrep, `| egrep "started|stdout"`, is useful to show when the server has started and the output from these tests. For normal operation, this pipe can be removed.
 
 // Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
@@ -88,12 +154,10 @@ You see the following warning when you run the Arquillian tests in remote mode.
 
 [source,options="nowrap"]
 ----
-WARNING: Configuration contain properties not supported by the backing object org.jboss.as.arquillian.container.remote.RemoteContainerConfiguration
-Unused property entries: {serverConfig=../../docs/examples/configs/standalone-xts.xml}
-Supported property names: [managementAddress, password, managementPort, managementProtocol, username]
+WARN  [org.jboss.as.dependency.deprecated] (MSC service thread 1-4) WFLYSRV0221: Deployment "deployment.wsat-simple.war" is using a deprecated module ("org.jboss.xts") which may be removed in future versions without notice.
 ----
 
-This is because, in remote mode, you are responsible for starting the server with the XTS subsystem enabled. When you run the Arquillian tests in managed mode, the container uses the `serverConfig` property defined in the `arquillian.xml` file to start the server with the XTS subsystem enabled.
+This is because, in remote mode, you are responsible for starting the server with the XTS subsystem enabled. When you run the Arquillian tests in managed mode, the container uses the `serverConfig` property defined in the `arquillian.xml` file to start the server with the XTS subsystem enabled (default is standalone.xml).
 ====
 
 == Investigate the Server Log
@@ -144,11 +208,14 @@ INFO  [stdout] (TaskWorker-3) [SERVICE] Compensate the backend resource by remov
 INFO  [stdout] (TaskWorker-3) [SERVICE] Compensate the backend resource by removing '2' from the set (e.g. undo any changes to databases that were previously made visible to others)
 ----
 
+//  Restore the {productName} Standalone Server Configuration
+include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+2]
+
 // Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional Red Hat CodeReady Studio instructions
-This quickstart is more complex than the others. It requires that you configure the {productName} server to use the _standalone-xts.xml_ configuration file, which is located in an external configuration directory.
+This quickstart is more complex than the others. It requires that you configure the {productName} server using the configure-server.cli file.
 
 . Make sure you import the quickstart into {JBDSProductName}.
 . If you have not already done so, you must configure a new {productName} server to use the XTS configuration.
@@ -165,7 +232,7 @@ This quickstart is more complex than the others. It requires that you configure 
 *Home Directory*: __Browse to the _{jbossHomeName}__ directory and select it.__
 *Runtime JRE*: __Choose an alternate JRE if not correct.__
 *Server base directory*: __This should already point to your standalone server configuration directory,__
-*Configuration file*: `../../docs/examples/configs/standalone-xts.xml`
+*Configuration file*: `standalone.xml`
 ----
 
 . Start the new *{productName} XTS Configuration* server.

--- a/wsba-coordinator-completion-simple/configure-server.cli
+++ b/wsba-coordinator-completion-simple/configure-server.cli
@@ -1,0 +1,17 @@
+
+# Batch script to configure XTS subsystem
+
+
+/extension=org.jboss.as.xts:add
+
+batch
+
+# Creating the xts subsystem
+/subsystem=xts/:add(host=default-host, url="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService", default-context-propagation=true )
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+#reload
+

--- a/wsba-coordinator-completion-simple/configure-server.cli
+++ b/wsba-coordinator-completion-simple/configure-server.cli
@@ -13,5 +13,5 @@ batch
 run-batch
 
 # Reload the server configuration
-#reload
+reload
 

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -140,7 +140,7 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- The XTS api needed to use WS-BA -->

--- a/wsba-coordinator-completion-simple/restore-configuration.cli
+++ b/wsba-coordinator-completion-simple/restore-configuration.cli
@@ -1,0 +1,16 @@
+# Batch script to remove the XTS subsystem and extension
+
+# Start batching commands
+
+batch
+
+# Remove xts's application security domain
+/subsystem=xts/:remove()
+
+/extension=org.jboss.as.xts:remove
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+reload

--- a/wsba-coordinator-completion-simple/src/test/java/org/jboss/as/quickstarts/wsba/coordinatorcompletion/simple/ClientIT.java
+++ b/wsba-coordinator-completion-simple/src/test/java/org/jboss/as/quickstarts/wsba/coordinatorcompletion/simple/ClientIT.java
@@ -22,9 +22,7 @@ import org.junit.Assert;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.quickstarts.wsba.coordinatorcompletion.simple.jaxws.SetServiceBA;
-import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
@@ -46,7 +44,7 @@ public class ClientIT {
         return ShrinkWrap.create(WebArchive.class, "test.war")
             .addPackages(true, SetServiceBAImpl.class.getPackage().getName())
             .addAsResource("context-handlers.xml")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
+            .addAsWebInfResource(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "beans.xml")
             .setManifest(new StringAsset(ManifestMF));
     }
 

--- a/wsba-coordinator-completion-simple/src/test/resources/arquillian.xml
+++ b/wsba-coordinator-completion-simple/src/test/resources/arquillian.xml
@@ -27,7 +27,7 @@
              following `jbossHome` property and replace EAP_HOME with the path to your JBoss EAP installation. -->
         <configuration>
             <!-- <property name="jbossHome">EAP_HOME</property> -->
-            <property name="serverConfig">../../docs/examples/configs/standalone-xts.xml</property>
+<!--             <property name="serverConfig">standalone.xml</property> -->
         </configuration>
     </container>
 </arquillian>

--- a/wsba-participant-completion-simple/README.adoc
+++ b/wsba-participant-completion-simple/README.adoc
@@ -10,6 +10,7 @@ The `wsba-participant-completion-simple` quickstart deploys a WS-BA (WS Business
 
 :standalone-server-type: custom
 :archiveType: war
+:restoreScriptName: restore-configuration.cli
 
 == What is it?
 
@@ -60,21 +61,85 @@ include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
 You must start {productName} with the XTS subsystem enabled.
 
+. Edit the log level to reduce the amount of log output. This should make it easier to read the logs produced by this example. To do this add the following logger block to the `__{jbossHomeName}__/standalone/configuration/standalone.xml` of your JBoss distribution. You should add it just below one of the other logger blocks.
++
+[source,xml,options="nowrap"]
+----
+<logger category="org.apache.cxf.service.factory.ReflectionServiceFactoryBean">
+    <level name="WARN"/>
+</logger>
+----
+
+[[configure_the_server]]
+=== Configure the Server
+
+You can configure the server by running JBoss CLI commands. For your convenience, this quickstart batches the commands into a `configure-server.cli` script provided in the root directory of this quickstart.
+
+. Before you begin, make sure you do the following:
+
+* xref:back_up_standalone_server_configuration[Back up the {productName} standalone server configuration] as described above.
+* Start the {productName} server with the standalone default profile : 
++
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/standalone.sh
+----
+
+. Review the `configure-server.cli` file in the root of this quickstart directory. This script adds xts domain
+. Open a new terminal, navigate to the root directory of this quickstart, and run the following command, replacing `__{jbossHomeName}__` with the path to your server:
++
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=configure-server.cli
+----
++
+NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat` script.
+
++
+You should see the following result when you run the script:
++
+[source,options="nowrap"]
+----
+The batch executed successfully
+----
+
+. Stop the {productName} server.
+
+=== Review the Modified Server Configuration
+
+After stopping the server, open the `__{jbossHomeName}__/standalone/configuration/standalone.xml` file and review the changes.
+
+. The following subsystem was added.
++
+[source,xml,options="nowrap"]
+----
+<subsystem xmlns="urn:jboss:domain:xts:3.0">
+            <host name="default-host"/>
+            <xts-environment url="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService"/>
+            <default-context-propagation enabled="true"/>
+</subsystem>
+----
+
+. The following `extension` was added.
++
+[source,xml,options="nowrap"]
+----
+        <extension module="org.jboss.as.xts"/>
+----
++
+
 . Open a terminal and navigate to the root of the {productName} directory.
 . Start the {productName} server with XTS subsystem enabled by typing the following command.
 +
 [source,subs="+quotes,attributes+",options="nowrap"]
 ----
-$ __{jbossHomeName}__/bin/standalone.sh --server-config=../../docs/examples/configs/standalone-xts.xml | egrep "started|stdout"
+$ __{jbossHomeName}__/bin/standalone.sh
 ----
 +
 NOTE: For Windows, use the `__{jbossHomeName}__\bin\standalone.bat` script.
 
-The pipe to egrep, `| egrep "started|stdout"`, is useful to show when the server has started and the output from these tests. For normal operation, this pipe can be removed.
-
 // Run the Arquillian Tests
 include::../shared-doc/run-arquillian-tests.adoc[leveloffset=+1]
-
 
 [[investigate_the_console_output]]
 == Investigate the Console Output
@@ -94,12 +159,10 @@ You see the following warning when you run the Arquillian tests in remote mode.
 
 [source,options="nowrap"]
 ----
-WARNING: Configuration contain properties not supported by the backing object org.jboss.as.arquillian.container.remote.RemoteContainerConfiguration
-Unused property entries: {serverConfig=../../docs/examples/configs/standalone-xts.xml}
-Supported property names: [managementAddress, password, managementPort, managementProtocol, username]
+WARN  [org.jboss.as.dependency.deprecated] (MSC service thread 1-4) WFLYSRV0221: Deployment "deployment.wsat-simple.war" is using a deprecated module ("org.jboss.xts") which may be removed in future versions without notice.
 ----
 
-This is because, in remote mode, you are responsible for starting the server with the XTS subsystem enabled. When you run the Arquillian tests in managed mode, the container uses the `serverConfig` property defined in the `arquillian.xml` file to start the server with the XTS subsystem enabled.
+This is because, in remote mode, you are responsible for starting the server with the XTS subsystem enabled. When you run the Arquillian tests in managed mode, the container uses the `serverConfig` property defined in the `arquillian.xml` file to start the server with the XTS subsystem enabled (default is standalone.xml).
 ====
 
 == Investigate the Server Log
@@ -141,11 +204,14 @@ INFO  [stdout] (http-localhost-127.0.0.1-8080-1) [SERVICE] Prepare successful, n
 INFO  [stdout] (http-localhost-127.0.0.1-8080-1) [SERVICE] Participant.confirmCompleted('true') (This tells the participant that compensation information has been logged and that it is safe to commit any changes.)
 ----
 
+//  Restore the {productName} Standalone Server Configuration
+include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+2]
+
 // Run the Quickstart in Red Hat CodeReady Studio or Eclipse
 include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
 
 // Additional Red Hat CodeReady Studio instructions
-This quickstart is more complex than the others. It requires that you configure the {productName} server to use the _standalone-xts.xml_ configuration file, which is located in an external configuration directory.
+This quickstart is more complex than the others. It requires that you configure the {productName} server using the configure-server.cli file.
 
 . Import the quickstart into {JBDSProductName}.
 . If you have not already done so, you must configure a new {productName} server to use the XTS configuration.
@@ -161,7 +227,7 @@ This quickstart is more complex than the others. It requires that you configure 
 *Home Directory*: __Browse to the __{jbossHomeName}__ directory and select it.__
 *Runtime JRE*: __Choose an alternate JRE if not correct.__
 *Server base directory*: __This should already point to your standalone server configuration directory,__
-*Configuration file*: `../../docs/examples/configs/standalone-xts.xml`
+*Configuration file*: `standalone.xml`
 ----
 
 . Start the new *{productName} XTS Configuration* server.

--- a/wsba-participant-completion-simple/configure-server.cli
+++ b/wsba-participant-completion-simple/configure-server.cli
@@ -1,0 +1,17 @@
+
+# Batch script to configure XTS subsystem
+
+
+/extension=org.jboss.as.xts:add
+
+batch
+
+# Creating the xts subsystem
+/subsystem=xts/:add(host=default-host, url="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService", default-context-propagation=true )
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+#reload
+

--- a/wsba-participant-completion-simple/configure-server.cli
+++ b/wsba-participant-completion-simple/configure-server.cli
@@ -13,5 +13,5 @@ batch
 run-batch
 
 # Reload the server configuration
-#reload
+reload
 

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -140,7 +140,7 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- The XTS api needed to use WS-BA -->

--- a/wsba-participant-completion-simple/restore-configuration.cli
+++ b/wsba-participant-completion-simple/restore-configuration.cli
@@ -1,0 +1,16 @@
+# Batch script to remove the XTS subsystem and extension
+
+# Start batching commands
+
+batch
+
+# Remove xts's application security domain
+/subsystem=xts/:remove()
+
+/extension=org.jboss.as.xts:remove
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+#reload

--- a/wsba-participant-completion-simple/restore-configuration.cli
+++ b/wsba-participant-completion-simple/restore-configuration.cli
@@ -13,4 +13,4 @@ batch
 run-batch
 
 # Reload the server configuration
-#reload
+reload

--- a/wsba-participant-completion-simple/src/main/java/META-INF/beans.xml
+++ b/wsba-participant-completion-simple/src/main/java/META-INF/beans.xml
@@ -16,9 +16,8 @@
     limitations under the License.
 -->
 <!-- Marker file indicating CDI should be enabled -->
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="
-      http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-    bean-discovery-mode="all">
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+       https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="all">
 </beans>

--- a/wsba-participant-completion-simple/src/test/java/org/jboss/as/quickstarts/wsba/participantcompletion/simple/ClientIT.java
+++ b/wsba-participant-completion-simple/src/test/java/org/jboss/as/quickstarts/wsba/participantcompletion/simple/ClientIT.java
@@ -19,12 +19,13 @@ package org.jboss.as.quickstarts.wsba.participantcompletion.simple;
 import com.arjuna.mw.wst11.UserBusinessActivity;
 import com.arjuna.mw.wst11.UserBusinessActivityFactory;
 import org.junit.Assert;
+
+import java.io.File;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.quickstarts.wsba.participantcompletion.simple.jaxws.SetServiceBA;
-import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
@@ -46,7 +47,7 @@ public class ClientIT {
         return ShrinkWrap.create(WebArchive.class, "test.war")
             .addPackages(true, SetServiceBAImpl.class.getPackage().getName())
             .addAsResource("context-handlers.xml")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
+            .addAsWebInfResource(new File("src/main/java/META-INF/beans.xml"))
             .setManifest(new StringAsset(ManifestMF));
     }
 

--- a/wsba-participant-completion-simple/src/test/resources/arquillian.xml
+++ b/wsba-participant-completion-simple/src/test/resources/arquillian.xml
@@ -27,7 +27,7 @@
              following `jbossHome` property and replace EAP_HOME with the path to your JBoss EAP installation. -->
         <configuration>
             <!--    <property name="jbossHome">EAP_HOME</property> -->
-            <property name="serverConfig">../../docs/examples/configs/standalone-xts.xml</property>
+<!--             <property name="serverConfig">standalone.xml</property> -->
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17530
https://issues.redhat.com/browse/WFLY-17531
https://issues.redhat.com/browse/WFLY-17532

updated READMEs
JBOSS configuration must be in standalone/configuration folder 
updated dependencies
set bean-discovery to all