### PR TITLE
[WFLY-17740] Add missing @fallback test in Microprofile Fault Tolerance quickstart

### DIFF
--- a/microprofile-fault-tolerance/src/main/java/org/wildfly/quickstarts/microprofile/faulttolerance/Coffee.java
+++ b/microprofile-fault-tolerance/src/main/java/org/wildfly/quickstarts/microprofile/faulttolerance/Coffee.java
@@ -37,4 +37,9 @@ public class Coffee {
         this.countryOfOrigin = countryOfOrigin;
         this.price = price;
     }
+
+    public int getId() {
+        return id;
+    }
+
 }

--- a/microprofile-fault-tolerance/src/main/java/org/wildfly/quickstarts/microprofile/faulttolerance/CoffeeRepositoryService.java
+++ b/microprofile-fault-tolerance/src/main/java/org/wildfly/quickstarts/microprofile/faulttolerance/CoffeeRepositoryService.java
@@ -65,6 +65,7 @@ public class CoffeeRepositoryService {
         if (id == null) {
             return Collections.emptyList();
         }
+
         return coffeeList.values().stream()
                 .filter(coffee -> !id.equals(coffee.id))
                 .limit(2)

--- a/microprofile-fault-tolerance/src/main/java/org/wildfly/quickstarts/microprofile/faulttolerance/CoffeeResource.java
+++ b/microprofile-fault-tolerance/src/main/java/org/wildfly/quickstarts/microprofile/faulttolerance/CoffeeResource.java
@@ -55,6 +55,10 @@ public class CoffeeResource {
 
     private Float failRatio = 0.5f;
 
+    private int minDelay = 0;
+
+    private int maxDelay = 500;
+
     /**
      * Provides list of all our coffees.
      * <p>
@@ -139,6 +143,7 @@ public class CoffeeResource {
 
         try {
             randomDelay();
+
             LOGGER.infof("CoffeeResource#recommendations() invocation #%d returning successfully", invocationNumber);
             return coffeeRepository.getRecommendations(id);
         } catch (InterruptedException e) {
@@ -157,7 +162,6 @@ public class CoffeeResource {
         return Collections.singletonList(coffeeRepository.getCoffeeById(1));
     }
 
-
     private void maybeFail(String failureLogMessage) {
         // introduce some artificial failures
         if (new Random().nextFloat() < failRatio) {
@@ -168,7 +172,7 @@ public class CoffeeResource {
 
     private void randomDelay() throws InterruptedException {
         // introduce some artificial delay
-        Thread.sleep(new Random().nextInt(500));
+        Thread.sleep(new Random().nextInt(maxDelay - minDelay) + minDelay);
     }
 
     // The following methods are only used for automated integration testing
@@ -177,6 +181,18 @@ public class CoffeeResource {
     @Path("/setFailRatio/{failRatio}")
     public void setFailRatio(@PathParam("failRatio") Float failRatio) {
         this.failRatio = failRatio;
+    }
+
+    @GET
+    @Path("/setMaxDelay/{maxDelay}")
+    public void setMaxDelay(@PathParam("maxDelay") int maxDelay) {
+        this.maxDelay = maxDelay;
+    }
+
+    @GET
+    @Path("/setMinDelay/{minDelay}")
+    public void setMinDelay(@PathParam("minDelay") int minDelay) {
+        this.minDelay = minDelay;
     }
 
     @GET


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17740
In this issue were added two Test methods, both testing a method with @Fallback annotation . The first one tests the successful execution of the method, which also has specific time frame (with the help of @Timeout). The second one secures that every time the execution time of the method exceeds the time limit, the Fallback method executed successfully.