### PR TITLE
[28.x] Bump wildfly-maven-plugin to 4.1.0.Final, cloud FP to 3.0.0.Final, datasources FP to 4.0.0.Final

### DIFF
--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -46,8 +46,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/ee-security/pom.xml
+++ b/ee-security/pom.xml
@@ -47,8 +47,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/helloworld-mdb/pom.xml
+++ b/helloworld-mdb/pom.xml
@@ -47,8 +47,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/helloworld-ws/pom.xml
+++ b/helloworld-ws/pom.xml
@@ -46,8 +46,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -46,8 +46,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -47,8 +47,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -46,8 +46,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/numberguess/pom.xml
+++ b/numberguess/pom.xml
@@ -46,8 +46,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <product.name>WildFly</product.name>
         <!-- A base list of dependency and plug-in version used in the various quick starts. -->
         <version.org.asciidoctor.asciidoctor-maven-plugin>2.1.0</version.org.asciidoctor.asciidoctor-maven-plugin>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.quickstarts.documentation.plugin>2.3.0.Final</version.org.wildfly.quickstarts.documentation.plugin>
         <!-- other plug-in versions -->

--- a/remote-helloworld-mdb/pom.xml
+++ b/remote-helloworld-mdb/pom.xml
@@ -47,8 +47,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>27.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -47,9 +47,9 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
-        <version.wildfly-datasources-galleon-pack>3.0.0.Final</version.wildfly-datasources-galleon-pack>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
+        <version.wildfly-datasources-galleon-pack>4.0.0.Final</version.wildfly-datasources-galleon-pack>
     </properties>
 
     <repositories>

--- a/temperature-converter/pom.xml
+++ b/temperature-converter/pom.xml
@@ -46,8 +46,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/thread-racing/pom.xml
+++ b/thread-racing/pom.xml
@@ -46,8 +46,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/todo-backend/pom.xml
+++ b/todo-backend/pom.xml
@@ -47,11 +47,11 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bootable-jar>28.0.0.Final</version.server.bootable-jar>
         <version.wildfly-jar.maven.plugin>9.0.0.Final</version.wildfly-jar.maven.plugin>
-        <version.wildfly-datasources-galleon-pack>3.0.0.Final</version.wildfly-datasources-galleon-pack>
+        <version.wildfly-datasources-galleon-pack>4.0.0.Final</version.wildfly-datasources-galleon-pack>
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>

--- a/websocket-hello/pom.xml
+++ b/websocket-hello/pom.xml
@@ -47,8 +47,8 @@
         <!-- The versions for BOMs, Dependencies and Plugins -->
         <version.server.bom>28.0.0.Final</version.server.bom>
         <version.server>28.0.0.Final</version.server>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
-        <version.cloud.fp>2.0.0.Final</version.cloud.fp>
+        <version.wildfly.maven.plugin>4.1.0.Final</version.wildfly.maven.plugin>
+        <version.cloud.fp>3.0.0.Final</version.cloud.fp>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Draft PR, require WildFly Maven Plugin 4.1.0.Final to be released.