### PR TITLE
fix asciidoctor syntax error leading to page break

### DIFF
--- a/guide/GettingStarted.asciidoc
+++ b/guide/GettingStarted.asciidoc
@@ -133,7 +133,7 @@ covers more on configuring logging.
 
 
 Starting the JBoss server from CodeReady Studio or Eclipse with JBoss Tools
----------------------------------------------------
+---------------------------------------------------------------------------
 [[GettingStarted-with_jboss_tools]]
 
 You may choose to use CodeReady Studio, or Eclipse with JBoss Tools, rather than the command line to run JBoss WildFly, and to deploy the quickstarts. If you don't wish to use Eclipse, you should skip this section.


### PR DESCRIPTION
I was reading doc [https://docs.wildfly.org/28/Getting_Started_Developing_Applications_Guide.html] and found page break, version 27 and 28 influenced. By the way, I compare 26 doc and found some sections also missing, like [CDI + Servlet: Helloworld quickstart]

