### PR TITLE
Adjust todo-backend bootable jar database service name since the remo…

### DIFF
--- a/todo-backend/README.adoc
+++ b/todo-backend/README.adoc
@@ -439,12 +439,12 @@ endif::[]
 [source,options="nowrap"]
 ----
 $ oc new-app postgresql-ephemeral \
-   -p DATABASE_SERVICE_NAME=todos-db \
+   -p DATABASE_SERVICE_NAME=todo-backend-db \
    -p POSTGRESQL_DATABASE=todos
 ----
 
-This will create a PostgreSQL database named `todos` on OpenShift that can be accessed on the port `5432` on the service `todos-db`.
-We don't need to copy the credentials to connect to the database as we will retrieve them later using the `todos-db` secret that was created
+This will create a PostgreSQL database named `todos` on OpenShift that can be accessed on the port `5432` on the service `todo-backend-db`.
+We don't need to copy the credentials to connect to the database as we will retrieve them later using the `todo-backend-db` secret that was created
 when the database is deployed.
 
 ifndef::ProductRelease,EAPXPRelease[]


### PR DESCRIPTION
…te Helm chart got an update.

The remote Helm chart example [has been updated](https://github.com/wildfly/wildfly-charts/commit/2864e90d7fac7061bfb916262c946a2b069745f2) recently, that's why we need to reflect these changes in todo-backend Readme instructions (`Build and Deploy the Backend on OpenShift with Bootable Jar using the Helm Chart` section).