### PR TITLE
[WFLY-18334] remote-helloworld-mdb QS: use values in Maven repos URL definitions inste…

### DIFF
--- a/remote-helloworld-mdb/pom.xml
+++ b/remote-helloworld-mdb/pom.xml
@@ -55,8 +55,7 @@
         <repository>
             <id>jboss-public-maven-repository</id>
             <name>JBoss Public Maven Repository</name>
-            <url>${maven.jboss.public.repository.url}</url>
-            <layout>default</layout>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
@@ -65,12 +64,12 @@
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
             </snapshots>
+            <layout>default</layout>
         </repository>
         <repository>
             <id>redhat-ga-maven-repository</id>
             <name>Red Hat GA Maven Repository</name>
-            <url>${maven.redhat.ga.repository.url}</url>
-            <layout>default</layout>
+            <url>https://maven.repository.redhat.com/ga/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
@@ -79,13 +78,14 @@
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
             </snapshots>
+            <layout>default</layout>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>jboss-public-maven-repository</id>
             <name>JBoss Public Maven Repository</name>
-            <url>${maven.jboss.public.repository.url}</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -96,7 +96,7 @@
         <pluginRepository>
             <id>redhat-ga-maven-repository</id>
             <name>Red Hat GA Maven Repository</name>
-            <url>${maven.redhat.ga.repository.url}</url>
+            <url>https://maven.repository.redhat.com/ga/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
…ad of parent properties.

Currently this QS is the one that uses QS parent Maven repo URL properties instead of direct values. Let's keep using values instead of properties in order to align with the rest of QS.

[Jira issue](https://issues.redhat.com/browse/WFLY-18334)