### PR TITLE
[WFLY-18381] Update versions of WFLY Maven plugin and used Helm chart…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <product.name>WildFly</product.name>
         <!-- A base list of dependency and plug-in version used in the various quick starts. -->
         <version.org.asciidoctor.asciidoctor-maven-plugin>2.1.0</version.org.asciidoctor.asciidoctor-maven-plugin>
-        <version.wildfly.maven.plugin>4.1.1.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>4.2.0.Final</version.wildfly.maven.plugin>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.quickstarts.documentation.plugin>2.3.0.Final</version.org.wildfly.quickstarts.documentation.plugin>
         <!-- other plug-in versions -->

--- a/todo-backend/todo-backend-chart/Chart.yaml
+++ b/todo-backend/todo-backend-chart/Chart.yaml
@@ -25,7 +25,7 @@ appVersion: "0.0.2"
 dependencies:
     - name: postgresql
       repository: https://charts.bitnami.com/bitnami
-      version: 12.3.1
+      version: 12.9.0
     - name: wildfly
       repository: http://docs.wildfly.org/wildfly-charts/
-      version: 2.3.1
+      version: 2.3.2


### PR DESCRIPTION
… dependencies

The issue: [WFLY-18381](https://issues.redhat.com/browse/WFLY-18381)

todo-backend QS has been tested and verified, newer versions work as expected.