### PR TITLE
Fix formatting of HelloworldQuickstart

### DIFF
--- a/guide/HelloworldQuickstart.asciidoc
+++ b/guide/HelloworldQuickstart.asciidoc
@@ -1,5 +1,4 @@
-CDI + Servlet: Helloworld quickstart
-====================================
+= CDI + Servlet: Helloworld quickstart
 :Author: Pete Muir
 
 [[HelloworldQuickstart-]]
@@ -38,8 +37,7 @@ some changes, it's pretty easy:
 
 It's time to pull the covers back and dive into the internals of the quickstart.
 
-Deploying the Helloworld quickstart using CodeReady Studio, or Eclipse with JBoss Tools
----------------------------------------------------------------------------------------------
+== Deploying the Helloworld quickstart using CodeReady Studio, or Eclipse with JBoss Tools
 
 You may choose to deploy the quickstart using CodeReady Studio, or Eclipse with JBoss Tools. You'll need to have JBoss WildFly started in the IDE (as described  in <<GettingStarted-with_jboss_tools, Starting the JBoss server from JBDS or Eclipse with JBoss Tools>>) and to have imported the quickstarts into Eclipse (as described in <<GettingStarted-importing_quickstarts_into_eclipse,Importing the quickstarts into Eclipse>>).
 
@@ -56,8 +54,7 @@ You should see the server start up (unless you already started it in <<GettingSt
 image:gfx/Eclipse_Helloworld_Deploy_3.jpg[]
 
 
-The helloworld quickstart in depth
-----------------------------------
+== The helloworld quickstart in depth
 
 The quickstart is very simple - all it does is print "Hello World" onto a web page.
 
@@ -125,4 +122,3 @@ public class HelloService {
 ------------------------------------------------------------------------
 
 The service is very simple - no registration (XML or annotation) is required!
-


### PR DESCRIPTION
The incorrect formatting of this documents breaks formatting of WildFly documentation at https://docs.wildfly.org/29/Getting_Started_Developing_Applications_Guide.html