### PR TITLE
[WFLY-18466] ejb-security-context-propagation Quickstart Common Enhan…

### DIFF
--- a/.github/workflows/quickstart_ci.yml
+++ b/.github/workflows/quickstart_ci.yml
@@ -89,6 +89,10 @@ jobs:
           cd ${{ inputs.QUICKSTART_PATH }}
           echo "Building provisioned server..."
           mvn -U -B -fae clean package -Pprovisioned-server
+          echo "Add quickstartUser..."
+          target/server/bin/add-user.sh -a -u 'quickstartUser' -p 'quickstartPwd1!' -g 'guest,user,JBossAdmin,Users'
+          echo "Add quickstartAdmin..."
+          target/server/bin/add-user.sh -a -u 'quickstartAdmin' -p 'adminPwd1!' -g 'guest,user,admin'
           echo "Starting provisioned server..."
           mvn -U -B -fae wildfly:start -DjbossHome=target/server -Dstartup-timeout=120
           echo "Testing provisioned server..."

--- a/.github/workflows/quickstart_ejb-security-context-propagation_ci.yml
+++ b/.github/workflows/quickstart_ejb-security-context-propagation_ci.yml
@@ -1,0 +1,16 @@
+name: WildFly ejb-security-context-propagation Quickstart CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'ejb-security-context-propagation/**'
+      - '.github/workflows/quickstart_ci.yml'
+
+jobs:
+  call-quickstart_ci:
+    uses: ./.github/workflows/quickstart_ci.yml
+    with:
+      QUICKSTART_PATH: ejb-security-context-propagation
+      TEST_PROVISIONED_SERVER: true
+      TEST_OPENSHIFT: false

--- a/ejb-security-context-propagation/README.adoc
+++ b/ejb-security-context-propagation/README.adoc
@@ -195,20 +195,12 @@ Note that the `http-connector` in the `remoting` subsystem uses this `applicatio
 // Build and Deploy the Quickstart JAR
 include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
-== Run the Client
-
-Before you run the client, make sure you have already successfully deployed the EJBs to the server in the previous step and that your terminal is still in the same folder.
-
-Type this command to execute the client:
-
-[source,options="nowrap"]
-----
-$ mvn exec:exec
-----
+// Server Distribution Testing
+include::../shared-doc/run-integration-tests-with-server-distribution.adoc[leveloffset=+2]
 
 == Investigate the Console Output
 
-When you run the `mvn exec:exec` command, you see the following output. Note there may be other log messages interspersed between these.
+When you run the integration tests, you see the following output. Note there may be other log messages interspersed between these.
 
 [source,options="nowrap"]
 ----
@@ -279,6 +271,8 @@ ERROR [org.jboss.as.ejb3.invocation] (default task-57) WFLYEJB0034: EJB Invocati
     at java.lang.Thread.run(Thread.java:745)
 ----
 
+// Server Distribution Testing
+include::../shared-doc/run-integration-tests-with-server-distribution.adoc[leveloffset=+2]
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Restore the {productName} Standalone Server Configuration
@@ -305,30 +299,10 @@ The batch executed successfully
 
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
-// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
-include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-// Additional Red Hat CodeReady Studio instructions
-This quickstart requires additional configuration and deploys and runs differently in {JBDSProductName} than the other quickstarts.
-
-. Make sure you xref:add_the_application_users[Add the Application Users] as described above.
-. Follow the steps above to xref:configure_the_server[Configure the Server]. Stop the server at the end of that step.
-. To deploy the application to the {productName} server, right-click on the *{artifactId}* project and choose *Run As* -> *Run on Server*.
-. To access the application, right-click on the *{artifactId}* project and choose *Run As* -> *Java Application*.
-. Choose *RemoteClient - org.jboss.as.quickstarts.ejb_security_context_propagation* and click *OK*.
-. Review the output in the console window.
-. To undeploy the project, right-click on the *{artifactId}* project and choose *Run As* -> *Maven build*. Enter `wildfly:undeploy` for the *Goals* and click *Run*.
-. Make sure you xref:restore_the_server_configuration[restore the server configuration] when you have completed testing this quickstart.
-
-// Debug the Application
-include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
-
-//*************************************************
-// Product Release content only
-//*************************************************
-ifdef::ProductRelease[]
+// Build and run sections for other environments/builds
+ifndef::ProductRelease,EAPXPRelease[]
+include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
+endif::[]
 
 // Quickstart not compatible with OpenShift
 include::../shared-doc/openshift-incompatibility.adoc[leveloffset=+1]
-
-endif::[]

--- a/ejb-security-context-propagation/configure-elytron.cli
+++ b/ejb-security-context-propagation/configure-elytron.cli
@@ -24,6 +24,6 @@ batch
 run-batch
 
 # Reload the server configuration
-reload
+#reload
 
 

--- a/ejb-security-context-propagation/configure-system-exception.cli
+++ b/ejb-security-context-propagation/configure-system-exception.cli
@@ -10,6 +10,6 @@ batch
 run-batch
 
 # Reload the server configuration
-reload
+#reload
 
 

--- a/ejb-security-context-propagation/pom.xml
+++ b/ejb-security-context-propagation/pom.xml
@@ -30,7 +30,7 @@
     </parent>
     <artifactId>ejb-security-context-propagation</artifactId>
     <version>31.0.0.Beta1-SNAPSHOT</version>
-    <packaging>ejb</packaging>
+    <packaging>war</packaging>
     <name>Quickstart: ejb-security-context-propagation</name>
     <description>This project demonstrates the security context propagation between remote EJBs</description>
 
@@ -43,10 +43,12 @@
     </licenses>
 
     <properties>
-        <!-- To run this quickstart in Eclipse, we must turn on JDT APT to activate annotation processing-->
-        <m2e.apt.activation>jdt_apt</m2e.apt.activation>
+        <!-- the version for the Server -->
+        <version.server>30.0.0.Final</version.server>
         <!-- The versions for BOMs, Dependencies and Plugins -->
-        <version.server.bom>30.0.0.Final</version.server.bom>
+        <version.bom.ee>${version.server}</version.bom.ee>
+        <version.pack.cloud>5.0.0.Final</version.pack.cloud>
+        <version.plugin.wildfly>4.2.0.Final</version.plugin.wildfly>
     </properties>
 
     <repositories>
@@ -110,7 +112,7 @@
             <dependency>
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-ee-with-tools</artifactId>
-                <version>${version.server.bom}</version>
+                <version>${version.bom.ee}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -144,44 +146,108 @@
             <artifactId>jakarta.ejb-api</artifactId>
         </dependency>
 
+        <!-- Import the Servlet API, we use provided scope as the API is included in JBoss EAP -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        
+        <!-- Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <!-- Set the name of the WAR, used as the context root when the app is deployed -->
         <finalName>${project.artifactId}</finalName>
-        <plugins>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-ejb-plugin</artifactId>
-                <configuration>
-                    <ejbVersion>3.2</ejbVersion>
-                    <generateClient>true</generateClient>
-                </configuration>
-            </plugin>
-            <!-- Add the Maven exec plug-in to allow us to run a Java program via Maven -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <configuration>
-                    <executable>java</executable>
-                    <workingDirectory>${project.build.directory}/exec-working-directory</workingDirectory>
-                    <arguments>
-                        <!-- automatically creates the classpath using all project dependencies,
-                                      also adding the project build directory -->
-                        <argument>-classpath</argument>
-                        <classpath></classpath>
-                        <argument>org.jboss.as.quickstarts.ejb_security_context_propagation.RemoteClient</argument>
-                    </arguments>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-ejb-plugin</artifactId>
+                    <configuration>
+                        <ejbVersion>3.2</ejbVersion>
+                        <generateClient>true</generateClient>
+                    </configuration>
+                </plugin>
+                <plugin>
+                  <groupId>org.wildfly.plugins</groupId>
+                  <artifactId>wildfly-maven-plugin</artifactId>
+                  <version>${version.plugin.wildfly}</version>
+              </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
+    <profiles>
+        <profile>
+            <id>provisioned-server</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <configuration>
+                            <feature-packs>
+                                <feature-pack>                                    
+                                    <location>org.wildfly:wildfly-galleon-pack:${version.server}</location>
+                                </feature-pack>
+                            </feature-packs>
+                            <layers>
+                                <!-- layers may be used to customize the server to provision -->
+                                <layer>cloud-server</layer>
+                                <layer>ejb</layer>
+                            </layers>
+                            <!-- use cli script(s) to configure the server -->
+                            <packaging-scripts>
+                                <packaging-script>
+                                    <scripts>
+                                        <script>${basedir}/configure-elytron.cli</script>
+                                    </scripts>
+                                    <!-- Expressions resolved during server execution -->
+                                    <resolve-expressions>false</resolve-expressions>
+                                </packaging-script>
+                            </packaging-scripts>
+                            <!-- deploys the quickstart on root web context -->
+                            <name>ROOT.war</name>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>integration-testing</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/*IT</include>
+                            </includes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/ejb-security-context-propagation/src/main/java/org/jboss/as/quickstarts/ejb_security_context_propagation/EJBServlet.java
+++ b/ejb-security-context-propagation/src/main/java/org/jboss/as/quickstarts/ejb_security_context_propagation/EJBServlet.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.quickstarts.ejb_security_context_propagation;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+/**
+ * <p>
+ * A simple servlet which indicates successful deployment of the quickstart.
+ * </p>
+ *
+ * <p>
+ * The servlet is registered and mapped to /ejb-security-context-propagation using the {@linkplain WebServlet
+ * @HttpServlet}.
+ * </p>
+ *
+ * @author Prarthona Paul
+ *
+ */
+
+@WebServlet("/ejb-security-context-propagation")
+public class EJBServlet extends HttpServlet {
+
+    static String PAGE_HEADER = "<html><head><title>ejb-security-context-propagation</title></head><body>";
+
+    static String PAGE_FOOTER = "</body></html>";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType("text/html");
+        PrintWriter writer = resp.getWriter();
+        writer.println(PAGE_HEADER);
+        writer.println("ejb-security-context-propagation quickstart deployed successfully. You can find the available operations in the included README file.");
+        writer.println(PAGE_FOOTER);
+        writer.close();
+    }
+}

--- a/ejb-security-context-propagation/src/main/java/org/jboss/as/quickstarts/ejb_security_context_propagation/IntermediateEJB.java
+++ b/ejb-security-context-propagation/src/main/java/org/jboss/as/quickstarts/ejb_security_context_propagation/IntermediateEJB.java
@@ -36,7 +36,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
 @PermitAll
 public class IntermediateEJB implements IntermediateEJBRemote {
 
-    @EJB(lookup="ejb:/ejb-security-context-propagation/SecuredEJB!org.jboss.as.quickstarts.ejb_security_context_propagation.SecuredEJBRemote")
+    @EJB
     private SecuredEJBRemote remote;
 
     @Resource

--- a/ejb-security-context-propagation/src/main/webapp/WEB-INF/beans.xml
+++ b/ejb-security-context-propagation/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+    Copyright 2023 JBoss by Red Hat.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!-- Marker file indicating CDI should be enabled -->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" bean-discovery-mode="all">
+</beans>

--- a/ejb-security-context-propagation/src/main/webapp/index.html
+++ b/ejb-security-context-propagation/src/main/webapp/index.html
@@ -1,0 +1,20 @@
+<!-- 
+    Copyright 2023 JBoss by Red Hat.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Plain HTML page that kicks us into the app -->
+
+<html>
+    <head>
+        <meta http-equiv="Refresh" content="0; URL=ejb-security-context-propagation">
+    </head>
+</html>

--- a/ejb-security-context-propagation/src/test/java/org/jboss/as/quickstarts/ejb_security_context_propagation/BasicRuntimeIT.java
+++ b/ejb-security-context-propagation/src/test/java/org/jboss/as/quickstarts/ejb_security_context_propagation/BasicRuntimeIT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.ejb_security_context_propagation;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The very basic runtime integration testing.
+ * @author Prarthona Paul
+ * @author emartins
+ */
+public class BasicRuntimeIT {
+    private static final String DEFAULT_SERVER_HOST = "http://localhost:8080/ejb-security-context-propagation";
+
+    @Test
+    public void testHTTPEndpointIsAvailable() throws IOException, InterruptedException, URISyntaxException {
+        String serverHost = System.getenv("SERVER_HOST");
+        if (serverHost == null) {
+            serverHost = System.getProperty("server.host");
+        }
+        if (serverHost == null) {
+            serverHost = DEFAULT_SERVER_HOST;
+        }
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(new URI(serverHost+"/"))
+                .GET()
+                .build();
+        final HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.ALWAYS)
+                .connectTimeout(Duration.ofMinutes(1))
+                .build();
+        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+    }
+}

--- a/ejb-security-context-propagation/src/test/java/org/jboss/as/quickstarts/ejb_security_context_propagation/SecurityContextPropagationIT.java
+++ b/ejb-security-context-propagation/src/test/java/org/jboss/as/quickstarts/ejb_security_context_propagation/SecurityContextPropagationIT.java
@@ -1,13 +1,12 @@
 /*
- * JBoss, Home of Professional Open Source
- * Copyright 2017, Red Hat, Inc. and/or its affiliates, and individual
- * contributors by the @authors tag. See the copyright.txt in the
- * distribution for a full listing of individual contributors.
+ * Copyright 2023 JBoss by Red Hat.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,43 +15,47 @@
  */
 package org.jboss.as.quickstarts.ejb_security_context_propagation;
 
-import java.util.Hashtable;
-
-import javax.naming.Context;
-import javax.naming.InitialContext;
-
+import org.junit.Test;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
 import org.wildfly.security.sasl.SaslMechanismSelector;
 
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Hashtable;
+
 /**
- * The remote client responsible for making invoking the intermediate bean to demonstrate security context propagation
- * in EJB to remote EJB calls.
- *
+ * The functional integration testing.
+ * @author emartins
  * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ *
  */
-public class RemoteClient {
+public class SecurityContextPropagationIT {
 
-    public static void main(String[] args) throws Exception {
+    @Test
+    public void testSecurityContextPropagation() throws NamingException {
+        // we assume standard dist, where EJBs are at ejb:/ejb-security-context-propagation/, if no SERVER_HOST or server.host in env/system props
+        final boolean standardDist = System.getenv("SERVER_HOST") == null && System.getProperty("server.host") == null;
+        System.out.println("standardDist: "+standardDist);
         // invoke the intermediate bean using the identity configured in wildfly-config.xml
-        invokeIntermediateBean();
-
+        invokeIntermediateBean(standardDist);
         // now lets programmatically setup an authentication context to switch users before invoking the intermediate bean
         AuthenticationConfiguration superUser = AuthenticationConfiguration.empty().setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism("PLAIN")).
                 useName("quickstartAdmin").usePassword("adminPwd1!");
         final AuthenticationContext authCtx = AuthenticationContext.empty().with(MatchRule.ALL, superUser);
         AuthenticationContext.getContextManager().setThreadDefault(authCtx);
-        invokeIntermediateBean();
+        invokeIntermediateBean(standardDist);
     }
 
-    private static void invokeIntermediateBean() throws Exception {
+    private static void invokeIntermediateBean(boolean standardDist) throws NamingException {
         final Hashtable<String, String> jndiProperties = new Hashtable<>();
         jndiProperties.put(Context.INITIAL_CONTEXT_FACTORY, "org.wildfly.naming.client.WildFlyInitialContextFactory");
         jndiProperties.put(Context.PROVIDER_URL, "remote+http://localhost:8080");
         final Context context = new InitialContext(jndiProperties);
 
-        IntermediateEJBRemote intermediate = (IntermediateEJBRemote) context.lookup("ejb:/ejb-security-context-propagation/IntermediateEJB!"
+        IntermediateEJBRemote intermediate = (IntermediateEJBRemote) context.lookup("ejb:/"+(standardDist?"ejb-security-context-propagation":"ROOT")+"/IntermediateEJB!"
                 + IntermediateEJBRemote.class.getName());
         System.out.println("\n\n* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n");
         System.out.println(intermediate.makeRemoteCalls());

--- a/shared-doc/add-application-and-management-users.adoc
+++ b/shared-doc/add-application-and-management-users.adoc
@@ -27,6 +27,11 @@ ifndef::admin-user-groups[]
 :admin-group-list:
 :admin-group-command:
 endif::admin-user-groups[]
+
+// attr which other sections may check (ifdef) to know if users needs to be added
+:addQuickstartUser: true
+:addQuickstartAdmin: true
+
 This quickstart uses secured management interfaces and requires that you create the following application user to access the running application.
 
 [cols="20%,20%,20%,40%",options="headers"]

--- a/shared-doc/add-application-user.adoc
+++ b/shared-doc/add-application-user.adoc
@@ -17,6 +17,9 @@ ifndef::app-user-groups[]
 :app-group-command:
 endif::app-user-groups[]
 
+// attr which other sections may check (ifdef) to know if users needs to be added
+:addQuickstartUser: true
+
 This quickstart uses secured application interfaces and requires that you create the following application user to access the running application.
 
 [cols="20%,20%,20%,40%",options="headers"]

--- a/shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc
+++ b/shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc
@@ -23,6 +23,30 @@ $ mvn {mavenServerProvisioningCommand} -Pprovisioned-server
 
 The provisioned {productName} server, with the quickstart deployed, can then be found in the `target/server` directory, and its usage is similar to a standard server distribution, with the simplification that there is never the need to specify the server configuration to be started.
 
+ifdef::addQuickstartUser[]
+The quickstart user should be added before running the provisioned server:
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ target/server/bin/add-user.sh -a -u 'quickstartUser' -p 'quickstartPwd1!' {app-group-command}
+----
+[NOTE]
+====
+For Windows, use the `__{jbossHomeName}__\bin\add-user.bat` script.
+====
+endif::[]
+
+ifdef::addQuickstartAdmin[]
+The quickstart admin should be added before running the provisioned server:
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ target/server/bin/add-user.sh -a -u 'quickstartAdmin' -p 'adminPwd1!' {admin-group-command}
+----
+[NOTE]
+====
+For Windows, use the `__{jbossHomeName}__\bin\add-user.bat` script.
+====
+endif::[]
+
 The server provisioning functionality is provided by the WildFly Maven Plugin, and you may find its configuration in the quickstart `pom.xml`:
 
 [source,xml,subs="attributes+"]

--- a/shared-doc/run-integration-tests-with-provisioned-server.adoc
+++ b/shared-doc/run-integration-tests-with-provisioned-server.adoc
@@ -14,7 +14,28 @@ Follow these steps to run the integration tests.
 $ mvn clean package -Pprovisioned-server
 ----
 
-. Start the {productName} provisioned server, this time using the {productName} Maven Plugin, which is recommend for testing due to simpler automation. The path to the provisioned server should be specified using the `server.host` system property.
+ifdef::addQuickstartUser[]
+Add the quickstart user:
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ target/server/bin/add-user.sh -a -u 'quickstartUser' -p 'quickstartPwd1!' {app-group-command}
+----
+endif::[]
+
+ifdef::addQuickstartAdmin[]
+Add the quickstart admin:
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ target/server/bin/add-user.sh -a -u 'quickstartAdmin' -p 'adminPwd1!' {admin-group-command}
+----
+[NOTE]
+====
+For Windows, use the `__{jbossHomeName}__\bin\add-user.bat` script.
+====
+endif::[]
+
+
+. Start the {productName} provisioned server, this time using the {productName} Maven Plugin, which is recommended for testing due to simpler automation. The path to the provisioned server should be specified using the `server.host` system property.
 +
 [source,subs="attributes+",options="nowrap"]
 ----


### PR DESCRIPTION
…cements CY2023Q3
Issue: https://issues.redhat.com/browse/WFLY-18466
Note: This QS is open shift incompatible, requires adding users using `add-user.sh` file and did not have a web endpoint, instead we used mvn exec:exec to check the output. 
A new endpoint has been added to test successful deployment. It does not test any ejb functionalities. Just outputs helloworld if connection is successful. 
