### PR TITLE
remove unnecessary resteasy spring feature pack configuration

### DIFF
--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -57,7 +57,6 @@
 
         <!-- The versions for other Dependencies and Plugins -->
         <version.spring.framework>6.0.4</version.spring.framework>
-        <version.resteasy.spring>3.0.4.Final</version.resteasy.spring>
     </properties>
 
     <repositories>
@@ -217,11 +216,6 @@
                                 <feature-pack>
                                     <location>org.wildfly:wildfly-galleon-pack:${version.server}</location>
                                 </feature-pack>
-                                <feature-pack>
-                                    <groupId>org.jboss.resteasy.spring</groupId>
-                                    <artifactId>galleon-feature-pack</artifactId>
-                                    <version>${version.resteasy.spring}</version>
-                                </feature-pack>
                             </feature-packs>
                             <!-- deploys the quickstart on root web context -->
                             <name>ROOT.war</name>
@@ -252,11 +246,6 @@
                                 <feature-pack>
                                     <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.pack.cloud}
                                     </location>
-                                </feature-pack>
-                                <feature-pack>
-                                    <groupId>org.jboss.resteasy.spring</groupId>
-                                    <artifactId>galleon-feature-pack</artifactId>
-                                    <version>${version.resteasy.spring}</version>
                                 </feature-pack>
                             </feature-packs>
                             <filename>ROOT.war</filename>


### PR DESCRIPTION
The `feature pack` configuration is unnecessary because it's already included in WildFly.