### PR TITLE
[WFLY-18814] fixed typo - server.host instead of jbossHome

### DIFF
--- a/shared-doc/run-integration-tests-with-provisioned-server.adoc
+++ b/shared-doc/run-integration-tests-with-provisioned-server.adoc
@@ -57,7 +57,7 @@ For Windows, use the `__{jbossHomeName}__\bin\add-user.bat` script.
 ====
 endif::[]
 
-. Start the {productName} provisioned server, this time using the {productName} Maven Plugin, which is recommended for testing due to simpler automation. The path to the provisioned server should be specified using the `server.host` system property.
+. Start the {productName} provisioned server, this time using the {productName} Maven Plugin, which is recommended for testing due to simpler automation. The path to the provisioned server should be specified using the `jbossHome` system property.
 +
 ifndef::deploymentDir[]
 [source,subs="attributes+",options="nowrap"]


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18814