### PR TITLE
[WFLY-18769] Infrastructure for publishing quickstart html content on…

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,0 +1,67 @@
+name: Deploy Quickstart html to Pages
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish'
+        required: true
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out tag to publish
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+          cache: 'maven'
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with Maven
+        run: mvn -U -B -ntp clean package -DskipTests -Pdocs -Dpublish
+      - name: Rename README.html to index.html
+        shell: bash
+        run: mv dist/target/site/README.html dist/target/site/index.html
+#        # For source browsing we need to generate indexes for directories
+#      - name: Generate a directory listing index.html for any directory without an pre-existing index.html
+#        uses: jayanta525/github-pages-directory-listing@v3.0.0
+#        with:
+#          FOLDER: dist/target/site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: './dist/target/site'
+
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -40,6 +40,13 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
     </licenses>
+
+    <properties>
+        <quickstart-assembly-name>wildfly-${project.version}-quickstarts</quickstart-assembly-name>
+        <quickstart-assembly-format>zip</quickstart-assembly-format>
+        <quickstart-assembly-attach>true</quickstart-assembly-attach>
+    </properties>
+
     <build>
         <finalName>wildfly-${project.version}</finalName>
         <plugins>
@@ -58,11 +65,55 @@
                             <descriptors>
                                 <descriptor>src/main/assembly/assembly.xml</descriptor>
                             </descriptors>
+                            <attach>${quickstart-assembly-attach}</attach>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>publish</id>
+            <activation>
+                <property>
+                    <name>publish</name>
+                </property>
+            </activation>
+
+            <properties>
+                <quickstart-assembly-name>site</quickstart-assembly-name>
+                <quickstart-assembly-format>dir</quickstart-assembly-format>
+                <quickstart-assembly-attach>false</quickstart-assembly-attach>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-site</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/site</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${basedir}/target/wildfly-${project.version}-quickstarts/site/</directory>
+                                        </resource>
+                                    </resources>
+                                    <overwrite>true</overwrite>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
    
 </project>

--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -19,9 +19,9 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
     <id>quickstarts</id>
-    <baseDirectory>wildfly-${project.version}-quickstarts</baseDirectory>
+    <baseDirectory>${quickstart-assembly-name}</baseDirectory>
     <formats>
-        <format>zip</format>
+        <format>${quickstart-assembly-format}</format>
     </formats>
 
     <fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -514,5 +514,16 @@
                 <module>dist</module>
             </modules>
         </profile>
+        <profile>
+            <id>publish</id>
+            <activation>
+                <property>
+                    <name>publish</name>
+                </property>
+            </activation>
+            <modules>
+                <module>dist</module>
+            </modules>
+        </profile>
     </profiles>
 </project>

--- a/shared-doc/view-the-source.adoc
+++ b/shared-doc/view-the-source.adoc
@@ -1,0 +1,3 @@
+ifndef::ProductRelease,EAPXPRelease[]
+link:https://github.com/wildfly/quickstart/tree/{artifactVersion}/{artifactId}[Browse the source]
+endif::[]


### PR DESCRIPTION
… GitHub pages

PART OF https://issues.redhat.com/browse/WFLY-18769

@emmartins This is the second from last commit from my https://github.com/bstansberry/quickstart/commits/WFLY-18769 branch; i.e. the one that doesn't touch any of the poms or README.adoc files in the actual QS modules.