### PR TITLE
Don't run OpenShift CI if there is no charts/ dir for the QS

### DIFF
--- a/.ci/openshift-ci/build-root/scripts/openshift-test-runner.sh
+++ b/.ci/openshift-ci/build-root/scripts/openshift-test-runner.sh
@@ -153,6 +153,11 @@ filterDirectories() {
         continue
       fi
 
+      if [ ! -d "${basedir}/${fileName}/charts" ]; then
+        continue
+      fi
+
+
       tmp+=(${fileName})
   done
   test_directories=(${tmp[@]})


### PR DESCRIPTION
If it works, this is better than https://github.com/wildfly/quickstart/pull/822