### PR TITLE
[WFLY-18769] Add 'Browse the source' links to all the QS READMEs that…

### DIFF
--- a/batch-processing/README.adoc
+++ b/batch-processing/README.adoc
@@ -30,6 +30,8 @@ The job contains two tasks:
 
 The database schema defines that the column for name is unique. For that reason, any attempt to persist a duplicate value will throw an exception. On the second attempt to run the job, the `ChunkCheckpoint` provides information to skip the contacts that were already persisted.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
 // System Requirements

--- a/batch-processing/pom.xml
+++ b/batch-processing/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/bean-validation-custom-constraint/README.adoc
+++ b/bean-validation-custom-constraint/README.adoc
@@ -19,6 +19,8 @@ The `bean-validation-custom-constraint` quickstart demonstrates how to use CDI, 
 
 This quickstart does not contain a user interface layer. The purpose of this project is to show you how to test bean validation using custom constraints with Arquillian. In this quickstart, the personAddress field of entity Person is validated using a set of custom constraints defined in the class AddressValidator. If you want to see an example of how to test bean validation with a user interface, look at the link:../kitchensink/README{outfilesuffix}[kitchensink] example.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
 // System Requirements

--- a/bean-validation-custom-constraint/pom.xml
+++ b/bean-validation-custom-constraint/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/bmt/README.adoc
+++ b/bmt/README.adoc
@@ -30,6 +30,8 @@ This example shows how to transactionally insert key value pairs into the databa
 
 ifndef::EAPCDRelease[]
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
 // System Requirements

--- a/bmt/pom.xml
+++ b/bmt/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/cmt/README.adoc
+++ b/cmt/README.adoc
@@ -23,6 +23,9 @@ Aspects touched upon in the code:
 * XA access to the standard default datasource using the JPA API
 * XA access to a JMS queue
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
+
 === What are Container Managed Transactions?
 
 Prior to EJB, getting the right incantation to ensure sound transactional operation of the business logic was a highly specialized skill. Although this still holds true to a great extent, EJB has provided a series of improvements to allow simplified transaction demarcation notation that is therefore easier to read and test.

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>cmt</artifactId>

--- a/contacts-jquerymobile/README.adoc
+++ b/contacts-jquerymobile/README.adoc
@@ -30,6 +30,9 @@ This application focuses on *CRUD* in a strictly mobile app using only *jQuery M
 
 Validation is an important part of an application. Typically in an HTML5 app you can let the built-in HTML5 form validation do the work for you. However, mobile browsers do not support this feature at this time. In order to validate the forms, the `jquery.validate` plugin was added, which provides both client-side and server-side validation. Over AJAX, if there is an error, the error is returned and displayed in the form. You can see an example of this in the *Edit* form if you enter an email that is already in use. The application will attempt to insert the error message into a field if that field exists. If the field does not exist then it display it at the top. In addition, there are xref:run_the_qunit_tests[QUnit Tests] for every form of validation.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
+
 //*************************************************
 // Product Release content only
 //*************************************************

--- a/contacts-jquerymobile/functional-tests/pom.xml
+++ b/contacts-jquerymobile/functional-tests/pom.xml
@@ -24,7 +24,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>contacts-jquerymobile-test-webdriver</artifactId>

--- a/contacts-jquerymobile/pom.xml
+++ b/contacts-jquerymobile/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>contacts-jquerymobile</artifactId>

--- a/ee-security/README.adoc
+++ b/ee-security/README.adoc
@@ -21,6 +21,8 @@ The deployment in this quickstart contains a simple HTTP servlet, which is secur
 
 This quickstart is hard coded to work with a user `quickstartUser` with password `quickstartPwd1!`.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/ee-security/pom.xml
+++ b/ee-security/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/ejb-multi-server/README.adoc
+++ b/ejb-multi-server/README.adoc
@@ -41,6 +41,8 @@ The root `pom.xml` builds each of the subprojects in an appropriate order.
 
 The server configuration is done using CLI batch scripts located in the root of the quickstart folder.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/ejb-multi-server/pom.xml
+++ b/ejb-multi-server/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>ejb-multi-server</artifactId>

--- a/ejb-remote/README.adoc
+++ b/ejb-remote/README.adoc
@@ -26,6 +26,8 @@ The server component is comprised of a stateful EJB and a stateless EJB. It prov
 +
 The remote client application depends on the remote business interfaces from the server component. This application looks up the stateless and stateful beans via JNDI and invokes a number of methods on them.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/ejb-remote/pom.xml
+++ b/ejb-remote/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>ejb-remote</artifactId>

--- a/ejb-security-context-propagation/README.adoc
+++ b/ejb-security-context-propagation/README.adoc
@@ -59,6 +59,8 @@ Finally there is the `RemoteClient` stand-alone client. The client makes calls u
 In the real world, remote calls between servers in the servers-to-server scenario would truly be remote and separate.
 For the purpose of this quickstart, we make use of a loopback connection to the same server so we do not need two servers just to run the test.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/ejb-security-context-propagation/pom.xml
+++ b/ejb-security-context-propagation/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>ejb-security-context-propagation</artifactId>

--- a/ejb-security-programmatic-auth/README.adoc
+++ b/ejb-security-programmatic-auth/README.adoc
@@ -18,6 +18,8 @@ The `ejb-security-programmatic-auth` quickstart demonstrates how to programmatic
 
 The `ejb-security-programmatic-auth` quickstart demonstrates how to invoke a remote secured EJB using the `Elytron` client API to establish different identities. The quickstart client application accomplishes that by looking up and invoking the secured EJB under different `AuthenticationContext`s. Each context is setup to use a different identities and credentials.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/ejb-security-programmatic-auth/pom.xml
+++ b/ejb-security-programmatic-auth/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>ejb-security-programmatic-auth</artifactId>

--- a/ejb-throws-exception/README.adoc
+++ b/ejb-throws-exception/README.adoc
@@ -59,6 +59,8 @@ The example follows the common "Hello World" pattern, using the following workfl
 . The managed bean is annotated as `@RequestScoped`, so the same managed bean instance is used only for the request/response.
 
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/ejb-throws-exception/pom.xml
+++ b/ejb-throws-exception/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>ejb-throws-exception</artifactId>

--- a/ejb-timer/README.adoc
+++ b/ejb-timer/README.adoc
@@ -21,6 +21,8 @@ The following Jakarta Enterprise Bean Timer services are demonstrated:
 * `@Schedule`: Uses this annotation to mark a method to be executed according to the calendar schedule specified in the attributes of the annotation. This example schedules a message to be printed to the server console every 6 seconds.
 * `@Timeout`: Uses this annotation to mark a method to execute when a programmatic timer goes off. This example sets the timer to go off every 3 seconds, at which point the method prints a message to the server console.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/ejb-timer/pom.xml
+++ b/ejb-timer/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>ejb-timer</artifactId>

--- a/ejb-txn-remote-call/README.adoc
+++ b/ejb-txn-remote-call/README.adoc
@@ -54,6 +54,9 @@ The propagated transaction enlists two participants
 (the database, and a mock XAResource used for quickstart demonstration purposes).
 |===
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
+
 == Running the Quickstart
 
 The quickstart elaborates on running the example in <<_running_in_a_bare_metal_environment, a bare metal environment>> and on OpenShift.

--- a/ejb-txn-remote-call/client/pom.xml
+++ b/ejb-txn-remote-call/client/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/ejb-txn-remote-call/pom.xml
+++ b/ejb-txn-remote-call/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/ejb-txn-remote-call/server/pom.xml
+++ b/ejb-txn-remote-call/server/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/ha-singleton-deployment/README.adoc
+++ b/ha-singleton-deployment/README.adoc
@@ -21,6 +21,8 @@ The example is built and packaged as a single EJB archive.
 
 For more information about singleton deployments, see _HA Singleton Deployments_ in the {LinkDevelopmentGuide}[__{DevelopmentBookName}__] for {DocInfoProductName} located on the Red Hat Customer Portal.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}_1 and {jbossHomeName}_2

--- a/ha-singleton-deployment/pom.xml
+++ b/ha-singleton-deployment/pom.xml
@@ -31,7 +31,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/ha-singleton-service/README.adoc
+++ b/ha-singleton-service/README.adoc
@@ -23,6 +23,8 @@ This example is built and packaged as JAR archive.
 
 For more information about clustered singleton services, see _HA Singleton Service_ in the {LinkDevelopmentGuide}[__{DevelopmentBookName}__] for {DocInfoProductName} located on the Red Hat Customer Portal.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}_1 and {jbossHomeName}_2

--- a/ha-singleton-service/pom.xml
+++ b/ha-singleton-service/pom.xml
@@ -26,7 +26,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/helloworld-jms/README.adoc
+++ b/helloworld-jms/README.adoc
@@ -23,6 +23,8 @@ It contains the following:
 
 . A message consumer that receives message from a JMS destination deployed to a {productName} server.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>helloworld-jms</artifactId>

--- a/helloworld-mdb/README.adoc
+++ b/helloworld-mdb/README.adoc
@@ -26,6 +26,8 @@ This project creates two JMS resources:
 //*************************************************
 
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/helloworld-mdb/pom.xml
+++ b/helloworld-mdb/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/helloworld-mutual-ssl-secured/README.adoc
+++ b/helloworld-mutual-ssl-secured/README.adoc
@@ -21,6 +21,8 @@ Mutual TLS provides the same security as TLS, with the addition of authenticatio
 
 The out of the box configuration for {productName} has one-way TLS enabled by default. This quickstart shows how to configure {productName} with mutual (two-way) TLS authentication in order to secure a WAR application with restricted access.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/helloworld-mutual-ssl-secured/pom.xml
+++ b/helloworld-mutual-ssl-secured/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/helloworld-mutual-ssl/README.adoc
+++ b/helloworld-mutual-ssl/README.adoc
@@ -20,6 +20,8 @@ The out of the box configuration for {productName} has one-way TLS enabled by de
 
 Before you run this example, you must create the client certificate and configure the server to use two-way TLS.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/helloworld-mutual-ssl/pom.xml
+++ b/helloworld-mutual-ssl/pom.xml
@@ -26,7 +26,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>helloworld-mutual-ssl</artifactId>

--- a/helloworld-singleton/README.adoc
+++ b/helloworld-singleton/README.adoc
@@ -16,6 +16,8 @@ The `helloworld-singleton` quickstart demonstrates an EJB Singleton Bean that is
 
 The `helloworld-singleton` quickstart demonstrates the use of an EJB Singleton Bean in {productNameFull}. It is instantiated once and maintains its state for the life of the session.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/helloworld-ws/README.adoc
+++ b/helloworld-ws/README.adoc
@@ -16,6 +16,8 @@ The `helloworld-ws` quickstart demonstrates a simple Hello World application, bu
 
 The `helloworld-ws` quickstart demonstrates the use of JAX-WS in {productNameFull} as a simple Hello World application.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/helloworld-ws/pom.xml
+++ b/helloworld-ws/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>helloworld-ws</artifactId>

--- a/helloworld/README.adoc
+++ b/helloworld/README.adoc
@@ -16,6 +16,8 @@ The `helloworld` quickstart demonstrates the use of Servlet 6 and is a good star
 
 The `helloworld` quickstart demonstrates the use of _Servlet 6_ in {productNameFull} {productVersion}.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>helloworld</artifactId>

--- a/hibernate/README.adoc
+++ b/hibernate/README.adoc
@@ -20,7 +20,9 @@ The `hibernate` quickstart is based upon the link:../kitchensink/README{outfiles
 
 This project is setup to allow you to create a compliant {javaVersion} application using Faces, Contexts and Dependency Injection, Enterprise Beans, Persistence, Hibernate ORM and Bean Validation. It includes a persistence unit, Persistence use to help you with database access.
 
-//  Considerations for Use in a Production Environment
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
+// Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]

--- a/hibernate/pom.xml
+++ b/hibernate/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/http-custom-mechanism/README.adoc
+++ b/http-custom-mechanism/README.adoc
@@ -44,6 +44,8 @@ a| This project contains the source for a custom HTTP authentication module that
 * `org.wildfly.security.examples.CustomMechanismFactory`: This resource file contains a single line of text that names the custom mechanism factory class, which in this case is `org.jboss.as.quickstart.http_custom_mechanism.CustomMechanismFactory`.
 |===
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/http-custom-mechanism/pom.xml
+++ b/http-custom-mechanism/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/jaxrs-client/README.adoc
+++ b/jaxrs-client/README.adoc
@@ -19,6 +19,8 @@ The `jaxrs-client` quickstart demonstrates the Jakarta REST Client API which int
 This client tests "call" many `POST`, `GET`, and `DELETE` operations using different ways: synchronized, asynchronous,
 delayed and filtered invocations.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 //  System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -26,7 +26,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>jaxrs-client</artifactId>

--- a/jaxrs-jwt/README.adoc
+++ b/jaxrs-jwt/README.adoc
@@ -25,6 +25,8 @@ There are 4 resource endpoints, plus another one for generating JWTs.
 
 NOTE: This quickstart asserts only few JWT claims for demonstration purposes. In your application, you should use all claims required by the specification you are using.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/jaxrs-jwt/pom.xml
+++ b/jaxrs-jwt/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>jaxrs-jwt</artifactId>

--- a/jaxws-ejb/README.adoc
+++ b/jaxws-ejb/README.adoc
@@ -19,6 +19,8 @@ The `jaxws-ejb` quickstart is a working example of the web service endpoint crea
 
 The `jaxws-ejb` quickstart demonstrates the use of _JAX-WS_ in {productNameFull} as a simple EJB web service application.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/jaxws-ejb/pom.xml
+++ b/jaxws-ejb/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>jaxws-ejb</artifactId>

--- a/jaxws-retail/README.adoc
+++ b/jaxws-retail/README.adoc
@@ -19,6 +19,8 @@ The `jaxws-retail` quickstart is a working example of a simple web service endpo
 
 The `jaxws-retail` quickstart demonstrates the use of _JAX-WS_ in {productNameFull} as a simple profile management application. It also demonstrates usage of wsconsume to generate classes from WSDL file.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/jaxws-retail/pom.xml
+++ b/jaxws-retail/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>jaxws-retail</artifactId>

--- a/jsonp/README.adoc
+++ b/jsonp/README.adoc
@@ -18,6 +18,9 @@ The `jsonp` quickstart creates a JSON string through object-based JSON generatio
 
 It shows how to use the JSON-P API to generate, parse, and consume JSON files.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
+
 // build and run with standard server distribution
 [[build_and_run_the_quickstart_with_server_dist]]
 == Building and running the quickstart application with a {productName} server distribution

--- a/jsonp/pom.xml
+++ b/jsonp/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>jsonp</artifactId>

--- a/jta-crash-rec/README.adoc
+++ b/jta-crash-rec/README.adoc
@@ -30,6 +30,8 @@ In this example, you halt the {productName} server in the middle of an XA transa
 
 {productName} ships with H2, an in-memory database written in Java. In this example, we use H2 for the database. Although H2 XA support is not recommended for production systems, the example does illustrate the general steps you need to perform for any datasource vendor. This example provides its own H2 XA datasource configuration. It is defined in the `jta-crash-rec-ds.xml` file in the WEB-INF folder of the WAR archive.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
 // System Requirements

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>jta-crash-rec</artifactId>

--- a/jts/README.adoc
+++ b/jts/README.adoc
@@ -42,6 +42,8 @@ A simple MDB has been provided that prints out the messages sent but this is not
 
 Also, while the `cmt` quickstart uses the Jakarta EE container default datasource, which is not distributed, this quickstart instead uses an external PostgreSQL database.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
 // System Requirements

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <!-- TODO fix artifact name to match components -->

--- a/kitchensink/README.adoc
+++ b/kitchensink/README.adoc
@@ -22,6 +22,9 @@ It demonstrates how to create a _localized_ {javaVersion} compliant application 
 
 This quickstart has been enhanced to provide localization of labels and messages. A user sets the preferred language choice in the browser and, if the application supports that language, the application web page is rendered in that language. For demonstration purposes, this quickstart has been tranlated into French(fr) and Spanish (es) using http://translate.google.com, so the translations may not be ideal.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
+
 === Localization Code Changes
 
 The following changes were made to the quickstart to enable it to use the browser preferred locale setting when displaying the web page:

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>kitchensink</artifactId>

--- a/logging/README.adoc
+++ b/logging/README.adoc
@@ -23,6 +23,8 @@ messages.
 
 To better visualize how the logging configuration works, you first deploy and access the application before configuring the logs and view the resulting log files. Then you configure the logs, redeploy and access the application, and look at the log files again to see the differences.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>jboss-logging</artifactId>

--- a/mail/README.adoc
+++ b/mail/README.adoc
@@ -22,6 +22,8 @@ You can use the default mail provider that comes out of the box with {productNam
 
 This example is a web application that takes `To`, `From`, `Subject`, and `Message Body` input and sends mail using SMTP. These emails can be later read by using IMAP or POP3. The front end is a JSF page with a simple POJO backing, leveraging CDI for resource injection.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/messaging-clustering-singleton/README.adoc
+++ b/messaging-clustering-singleton/README.adoc
@@ -48,6 +48,8 @@ Here, you can see that only one of the MDBs, `HelloWorldTopicMDB`, is associated
 
 If a delivery group is used in conjunction with singleton, as is the case of this quickstart, the MDB will be active in the singleton provider node only if that node has `delivery-group` enabled. If not, the MDB will be inactive in that node and all remainder nodes of the cluster.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/messaging-clustering-singleton/pom.xml
+++ b/messaging-clustering-singleton/pom.xml
@@ -24,7 +24,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/microprofile-config/README.adoc
+++ b/microprofile-config/README.adoc
@@ -26,6 +26,8 @@ In this quickstart, we have a collection of CDI beans that expose functionalitie
 the MicroProfile Config specification. The individual externally configured values
 are provided to the users through a set of REST endpoints.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 

--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -8,7 +8,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/microprofile-fault-tolerance/README.adoc
+++ b/microprofile-fault-tolerance/README.adoc
@@ -41,6 +41,8 @@ We recommend that you follow the instructions that
 <<project-from-scratch, create the application from scratch>>. However, you can
 also <<working_with_the_completed_quickstart, deploy the completed example>> which is available in this directory.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -26,7 +26,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>microprofile-fault-tolerance</artifactId>

--- a/microprofile-health/README.adoc
+++ b/microprofile-health/README.adoc
@@ -29,6 +29,8 @@ or restarted.
 In this quickstart, we have a simple REST application that exposes MicroProfile Health
 functionalities at the `/health/live`, `/health/ready`, and `/health/started` endpoints according to the specification.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -8,7 +8,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/microprofile-jwt/README.adoc
+++ b/microprofile-jwt/README.adoc
@@ -26,6 +26,9 @@ specification in {productName}.  Within the quickstart the following topics will
  * Enabling authorization based on claims contained within the JWT token.
  * Injection of claims from the JWT token.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
+
 [[considerations_for_use_in_a_production_environment]]
 == Considerations for Use in a Production Environment
 

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -24,7 +24,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/microprofile-lra/README.adoc
+++ b/microprofile-lra/README.adoc
@@ -54,6 +54,8 @@ endpoints:
 - `PUT /participant1/complete` - complete action of Participant 1
 - `PUT /participant2/complete` - complete action of Participant 2
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]

--- a/microprofile-lra/pom.xml
+++ b/microprofile-lra/pom.xml
@@ -8,7 +8,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/microprofile-openapi/README.adoc
+++ b/microprofile-openapi/README.adoc
@@ -8,6 +8,9 @@ include::../shared-doc/attributes.adoc[]
 [abstract]
 This guide demonstrate how to use the MicroProfile OpenAPI functionality in {productName} to expose an OpenAPI document for a simple REST application.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
+
 :standalone-server-type: microprofile
 :archiveType: war
 :archiveName: {artifactId}
@@ -19,6 +22,8 @@ To complete this guide, you will need:
 * less than 15 minutes
 * JDK 11+ installed with `JAVA_HOME` configured appropriately
 * Apache Maven 3.5.3+
+
+
 
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 

--- a/microprofile-openapi/pom.xml
+++ b/microprofile-openapi/pom.xml
@@ -9,7 +9,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/microprofile-reactive-messaging-kafka/README.adoc
+++ b/microprofile-reactive-messaging-kafka/README.adoc
@@ -26,6 +26,8 @@ The implementation of MicroProfile Reactive Messaging is built on top of link:ht
 
 In this quickstart, we have a CDI bean that demonstrates the functionality of the MicroProfile Reactive Messaging specification. Currently, we support Reactive Messaging 1.0. Connections to external messaging systems such as Apache Kafka are configured via MicroProfile Config. We will also use Reactive Streams Operators to modify the data relayed in these streams in the methods handling the Reactive Messaging streams.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 

--- a/microprofile-reactive-messaging-kafka/pom.xml
+++ b/microprofile-reactive-messaging-kafka/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>microprofile-reactive-messaging-kafka</artifactId>

--- a/microprofile-rest-client/README.adoc
+++ b/microprofile-rest-client/README.adoc
@@ -24,6 +24,8 @@ In this quickstart we have a country server and a country client used in the tes
 interface providing information about some countries. The test creates a client that consumes this API through the
 MicroProfile REST Client specification.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 

--- a/microprofile-rest-client/pom.xml
+++ b/microprofile-rest-client/pom.xml
@@ -24,7 +24,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>microprofile-rest-client</artifactId>

--- a/numberguess/README.adoc
+++ b/numberguess/README.adoc
@@ -16,6 +16,8 @@ The `numberguess` quickstart demonstrates the use of CDI  (Contexts and Dependen
 
 The `numberguess` quickstart demonstrates the use of CDI (Contexts and Dependency Injection) and JSF (JavaServer Faces) in {productNameFull}.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/numberguess/pom.xml
+++ b/numberguess/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
     <artifactId>numberguess</artifactId>

--- a/remote-helloworld-mdb/README.adoc
+++ b/remote-helloworld-mdb/README.adoc
@@ -34,6 +34,8 @@ This project uses two JMS resources on a remote broker:
 // Product Release content only
 //*************************************************
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/remote-helloworld-mdb/pom.xml
+++ b/remote-helloworld-mdb/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/security-domain-to-domain/README.adoc
+++ b/security-domain-to-domain/README.adoc
@@ -50,6 +50,8 @@ Password: quickstartPwd1!
 +
 When used with the `entry-domain`, this user will have the role `Users`. When used with the `business-domain`, this user will have the role `Manager`.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 //  Use of {jbossHomeName}

--- a/security-domain-to-domain/pom.xml
+++ b/security-domain-to-domain/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/servlet-async/README.adoc
+++ b/servlet-async/README.adoc
@@ -20,6 +20,8 @@ It shows how to detach the execution of a long-running task from the request pro
 
 A long-running task in this context does not refer to a computation intensive task executed on the same machine but could for example be contacting a third-party service that has limited resources or only allows for a limited number of concurrent connections. Moving the calls to this service into a separate and smaller sized thread pool ensures that less threads will be busy interacting with the long-running service and that more requests can be served that do not depend on this service.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/servlet-async/pom.xml
+++ b/servlet-async/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/servlet-filterlistener/README.adoc
+++ b/servlet-filterlistener/README.adoc
@@ -22,6 +22,8 @@ This example contains the following classes:
 * `VowelRemoverFilter`: A servlet filter that removes the vowels from the text entered in the form.
 * `ParameterDumpingRequestListener`: A simple servlet request listener that creates a map of the original HTTP request parameter values before the filter is applied.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/servlet-filterlistener/pom.xml
+++ b/servlet-filterlistener/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/servlet-security/README.adoc
+++ b/servlet-security/README.adoc
@@ -48,6 +48,8 @@ Password: guestPwd1!
 Role: notauthorized
 ----
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 //  Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
 // System Requirements

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/shared-doc/view-the-source.adoc
+++ b/shared-doc/view-the-source.adoc
@@ -1,3 +1,3 @@
 ifndef::ProductRelease,EAPXPRelease[]
-link:https://github.com/wildfly/quickstart/tree/{artifactVersion}/{artifactId}[Browse the source]
+link:https://github.com/wildfly/quickstart/tree/{WildFlyQuickStartRepoTag}/{artifactId}[Browse the source]
 endif::[]

--- a/spring-resteasy/README.adoc
+++ b/spring-resteasy/README.adoc
@@ -24,6 +24,8 @@ The `spring-resteasy` quickstart demonstrates how to package and deploy a web ap
 // Product Release content only
 //*************************************************
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/tasks-jsf/README.adoc
+++ b/tasks-jsf/README.adoc
@@ -34,6 +34,8 @@ JSF is used to present the user two views.
 
 ifndef::EAPCDRelease[]
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
 // System Requirements

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/temperature-converter/README.adoc
+++ b/temperature-converter/README.adoc
@@ -24,6 +24,8 @@ The application does the following:
 . The response from TemperatureConvertEJB is stored in the `temperature` field of the managed bean.
 . The managed bean is annotated as @SessionScoped, so the same managed bean instance is used for the entire session.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/temperature-converter/pom.xml
+++ b/temperature-converter/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/thread-racing/README.adoc
+++ b/thread-racing/README.adoc
@@ -39,6 +39,8 @@ JPA 3.1 is also present in the application code. Specifically it is used to stor
 
 ifndef::EAPCDRelease[]
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // Considerations for Use in a Production Environment
 include::../shared-doc/development-shortcuts.adoc[leveloffset=+1]
 // System Requirements

--- a/thread-racing/pom.xml
+++ b/thread-racing/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/todo-backend/README.adoc
+++ b/todo-backend/README.adoc
@@ -43,6 +43,8 @@ ifdef::ProductRelease[]
 * It is deployed on OpenShift using the https://jbossas.github.io/eap-charts//[Helm Chart for {productName}].
 endif::[]
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 

--- a/todo-backend/pom.xml
+++ b/todo-backend/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/websocket-endpoint/README.adoc
+++ b/websocket-endpoint/README.adoc
@@ -20,6 +20,8 @@ The `BidWebSocketEndpoint` provides the WebSocket endpoint that receives `Messag
 
 Every update made on the `Bidding` are immediately propagated to all opened WebSocket sessions without any browser submission or AJAX polling mechanism.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/websocket-endpoint/pom.xml
+++ b/websocket-endpoint/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/websocket-hello/README.adoc
+++ b/websocket-hello/README.adoc
@@ -24,6 +24,8 @@ WebSockets are a requirement of the {javaVersion} specification and are implemen
 
 NOTE: This quickstart demonstrates only a few of the basic functions. A fully functional application should provide better error handling and intercept and handle additional events.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/websocket-hello/pom.xml
+++ b/websocket-hello/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/wsat-simple/README.adoc
+++ b/wsat-simple/README.adoc
@@ -44,6 +44,8 @@ When running the `org.jboss.as.quickstarts.wsat.simple.ClientTest#testCommit()` 
 
 There is another test that shows what happens if the client decides to rollback the AT.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/wsat-simple/pom.xml
+++ b/wsat-simple/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/wsba-coordinator-completion-simple/README.adoc
+++ b/wsba-coordinator-completion-simple/README.adoc
@@ -46,6 +46,8 @@ When running the `org.jboss.as.quickstarts.wsba.coordinatorcompletion.simple.Cli
 
 There is another test that shows how the client can cancel a BA.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/wsba-coordinator-completion-simple/pom.xml
+++ b/wsba-coordinator-completion-simple/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 

--- a/wsba-participant-completion-simple/README.adoc
+++ b/wsba-participant-completion-simple/README.adoc
@@ -51,6 +51,8 @@ There are additional tests that show:
 * What happens when an application exception is thrown by the service.
 * How the client can cancel a BA.
 
+// Link to the quickstart source
+include::../shared-doc/view-the-source.adoc[leveloffset=+1]
 // System Requirements
 include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}

--- a/wsba-participant-completion-simple/pom.xml
+++ b/wsba-participant-completion-simple/pom.xml
@@ -25,7 +25,7 @@
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
-        <version>5</version>
+        <version>6</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
… target the GitHub quickstart repo
Issue: https://issues.redhat.com/browse/WFLY-18769
3rd and final part of this new functionality, moves all QSes to parent v6 and adds the "view the source" link on every README.adoc