### PR TITLE
Ears need to use install to populate the mvn repo

### DIFF
--- a/.github/workflows/quickstart_ci.yml
+++ b/.github/workflows/quickstart_ci.yml
@@ -47,6 +47,11 @@ on:
         required: false
         default: ''
         type: string
+      MVN_COMMAND:
+        description: 'Maven command to use when building the project. Default is ''package'', ears needs ''install'''
+        required: false
+        default: 'package'
+        type: string
 
 # Only run the latest job
 concurrency:
@@ -98,7 +103,7 @@ jobs:
         run: |
           cd quickstarts
           cd ${{ inputs.QUICKSTART_PATH }}
-          mvn -fae clean install -Drelease
+          mvn -fae clean package -Drelease
         shell: bash
       - name: Build, run & test ${{ inputs.QUICKSTART_PATH }} Quickstart with provisioned-server profile
         if: ${{ inputs.TEST_PROVISIONED_SERVER }}
@@ -106,7 +111,7 @@ jobs:
           cd quickstarts
           cd ${{ inputs.QUICKSTART_PATH }}
           echo "Building provisioned server..."
-          mvn -fae clean package -Pprovisioned-server
+          mvn -fae clean ${{ inputs.MVN_COMMAND }} -Pprovisioned-server
           echo "Add quickstartUser..."
           ${{ inputs.DEPLOYMENT_DIR }}/target/server/bin/add-user.sh -a -u 'quickstartUser' -p 'quickstartPwd1!' -g 'guest,user,JBossAdmin,Users'
           echo "Add quickstartAdmin..."
@@ -124,7 +129,7 @@ jobs:
           cd quickstarts
           cd ${{ inputs.QUICKSTART_PATH }}
           echo "Building bootable jar..."
-          mvn -fae clean package -Pbootable-jar
+          mvn -fae clean ${{ inputs.MVN_COMMAND }} -Pbootable-jar
           echo "Starting bootable jar..."
           mvn -f ${{ inputs.DEPLOYMENT_DIR }}/pom.xml wildfly-jar:start -Djar-file-name=${{ inputs.DEPLOYMENT_DIR }}/target/${{ inputs.QUICKSTART_PATH }}-bootable.jar -Dstartup-timeout=120 ${{ inputs.EXTRA_RUN_ARGS }}
           echo "Testing bootable jar..."
@@ -211,7 +216,7 @@ jobs:
           cd quickstarts
           cd ${{ inputs.QUICKSTART_PATH }}
           echo "Building provisioned server..."
-          mvn -fae clean package -Pprovisioned-server -Dversion.server=${{ needs.wildfly-build.outputs.wildfly-version }}
+          mvn -fae clean ${{ inputs.MVN_COMMAND }} -Pprovisioned-server -Dversion.server=${{ needs.wildfly-build.outputs.wildfly-version }}
           echo "Add quickstartUser..."
           ${{ inputs.DEPLOYMENT_DIR }}/target/server/bin/add-user.sh -a -u 'quickstartUser' -p 'quickstartPwd1!' -g 'guest,user,JBossAdmin,Users'
           echo "Add quickstartAdmin..."
@@ -229,7 +234,7 @@ jobs:
           cd quickstarts
           cd ${{ inputs.QUICKSTART_PATH }}
           echo "Building bootable jar..."
-          mvn -fae clean package -Pbootable-jar -Dversion.server=${{ needs.wildfly-build.outputs.wildfly-version }}
+          mvn -fae clean ${{ inputs.MVN_COMMAND }} -Pbootable-jar -Dversion.server=${{ needs.wildfly-build.outputs.wildfly-version }}
           echo "Starting bootable jar..."
           mvn -f ${{ inputs.DEPLOYMENT_DIR }}/pom.xml wildfly-jar:start -Djar-file-name=${{ inputs.DEPLOYMENT_DIR }}/target/${{ inputs.QUICKSTART_PATH }}-bootable.jar -Dstartup-timeout=120 ${{ inputs.EXTRA_RUN_ARGS }}
           echo "Testing bootable jar..."

--- a/.github/workflows/quickstart_ejb-throws-exception_ci.yml
+++ b/.github/workflows/quickstart_ejb-throws-exception_ci.yml
@@ -15,3 +15,4 @@ jobs:
       DEPLOYMENT_DIR: ear
       TEST_PROVISIONED_SERVER: true
       TEST_OPENSHIFT: false
+      MVN_COMMAND: install


### PR DESCRIPTION
Otherwise mvn wildfly:start fails on resolving dependencies in the ear module