### PR TITLE
[WFLY-18464] ejb-multi-server Quickstart Common Enhancements CY2023Q3

### DIFF
--- a/.github/workflows/quickstart_ejb-multi-server_ci.yml
+++ b/.github/workflows/quickstart_ejb-multi-server_ci.yml
@@ -1,0 +1,15 @@
+name: WildFly ejb-multi-server Quickstart CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'ejb-multi-server/**'
+      - '.github/workflows/quickstart_ci.yml'
+jobs:
+  call-quickstart_ci:
+    uses: ./.github/workflows/quickstart_ci.yml
+    with:
+      QUICKSTART_PATH: ejb-multi-server
+      TEST_PROVISIONED_SERVER: false
+      TEST_OPENSHIFT: false

--- a/ejb-multi-server/README-source.adoc
+++ b/ejb-multi-server/README-source.adoc
@@ -78,8 +78,6 @@ $ __{jbossHomeName}__/bin/add-user.sh -a -u quickuser2 -p quick+123
 
 NOTE: For Windows, use the `__{jbossHomeName}__\bin\add-user.bat` script.
 
-If you prefer, you can use the `add-user` utility interactively. For an example of how to use the add-user utility, see the instructions located here: link:{addApplicationUserDocUrl}[Add an Application User].
-
 // Back Up the {productName} Managed Domain Configuration
 include::../shared-doc/back-up-managed-domain-configuration.adoc[leveloffset=+1]
 // Start the {productName} Managed Domain
@@ -116,57 +114,8 @@ IMPORTANT: Depending on your machine configuration, you might see "Exception in 
 
 There are too many additions to the configuration files to list here. Feel free to compare the `domain.xml` and `host.xml` to the backup copies to see the changes made to configure the server to run this quickstart.
 
-
-
-
-[[build_and_deploy_the_quickstart]]
-== Build and Deploy the Quickstart
-
-. Make sure you have xref:install_the_quickstart_parent_artifact_in_maven[installed the quickstart parent artifact] in your Maven repository.
-. Make sure you have started and configured the {productName} server successfully as described above.
-. Open a terminal and navigate to the root directory of this quickstart.
-. Type this command to build the artifacts.
-+
-[source,options="nowrap"]
-----
-$ mvn clean install
-----
-+
-You should see `BUILD SUCCESS` at the end of the build `SUCCESS` messages for each component.
-
-. In the same terminal, deploy the applications using the provided CLI batch script by typing the following command.
-+
-[source,subs="+quotes,attributes+",options="nowrap"]
-----
-$ __{jbossHomeName}__/bin/jboss-cli.sh -c --file=deploy-domain.cli
-----
-+
-NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat` script.
-
-+
-This deploys the `app-*.ear` files to different server groups of the running domain. You should see the following result when you run the script.
-+
-[source,options="nowrap"]
-----
-The batch executed successfully
-process-state: reload-required
-----
-
-. You might see the following warnings in the server log. You can ignore these warnings.
-+
-[source,options="nowrap"]
-----
-[Server:app-oneB] 13:00:13,346 WARN  [org.jboss.as.clustering.jgroups.protocol.UDP] (ServerService Thread Pool -- 13) JGRP000015: the send buffer of socket MulticastSocket was set to 1MB, but the OS only allocated 212.99KB. This might lead to performance problems. Please set your max send buffer in the OS correctly (e.g. net.core.wmem_max on Linux)
-[Server:app-oneB] 13:00:13,346 WARN  [org.jboss.as.clustering.jgroups.protocol.UDP] (ServerService Thread Pool -- 13) JGRP000015: the receive buffer of socket MulticastSocket was set to 20MB, but the OS only allocated 212.99KB. This might lead to performance problems. Please set your max receive buffer in the OS correctly (e.g. net.core.rmem_max on Linux)
-[Server:app-oneB] 13:00:13,347 WARN  [org.jboss.as.clustering.jgroups.protocol.UDP] (ServerService Thread Pool -- 13) JGRP000015: the send buffer of socket MulticastSocket was set to 1MB, but the OS only allocated 212.99KB. This might lead to performance problems. Please set your max send buffer in the OS correctly (e.g. net.core.wmem_max on Linux)
-[Server:app-oneB] 13:00:13,347 WARN  [org.jboss.as.clustering.jgroups.protocol.UDP] (ServerService Thread Pool -- 13) JGRP000015: the receive buffer of socket MulticastSocket was set to 25MB, but the OS only allocated 212.99KB. This might lead to performance problems. Please set your max receive buffer in the OS correctly (e.g. net.core.rmem_max on Linux)
-[Server:app-oneA] 13:00:13,407 WARN  [org.jboss.as.clustering.jgroups.protocol.UDP] (ServerService Thread Pool -- 11) JGRP000015: the send buffer of socket MulticastSocket was set to 1MB, but the OS only allocated 212.99KB. This might lead to performance problems. Please set your max send buffer in the OS correctly (e.g. net.core.wmem_max on Linux)
-[Server:app-oneA] 13:00:13,408 WARN  [org.jboss.as.clustering.jgroups.protocol.UDP] (ServerService Thread Pool -- 11) JGRP000015: the receive buffer of socket MulticastSocket was set to 20MB, but the OS only allocated 212.99KB. This might lead to performance problems. Please set your max receive buffer in the OS correctly (e.g. net.core.rmem_max on Linux)
-[Server:app-oneA] 13:00:13,408 WARN  [org.jboss.as.clustering.jgroups.protocol.UDP] (ServerService Thread Pool -- 11) JGRP000015: the send buffer of socket MulticastSocket was set to 1MB, but the OS only allocated 212.99KB. This might lead to performance problems. Please set your max send buffer in the OS correctly (e.g. net.core.wmem_max on Linux)
-[Server:app-oneA] 13:00:13,408 WARN  [org.jboss.as.clustering.jgroups.protocol.UDP] (ServerService Thread Pool -- 11) JGRP000015: the receive buffer of socket MulticastSocket was set to 25MB, but the OS only allocated 212.99KB. This might lead to performance problems. Please set your max receive buffer in the OS correctly (e.g. net.core.rmem_max on Linux)
-----
-
-IMPORTANT: If errors appear in the `server.log` when installing or deploying the quickstart, stop the domain and restart it. This should ensure further steps run correctly.
+// Build and Deploy the Quickstart
+include::../shared-doc/build-and-deploy-the-quickstart.adoc[leveloffset=+1]
 
 [[access_the_remote_client_application]]
 == Access the Remote Client Application
@@ -225,38 +174,15 @@ An example how to access EJBs from a separate instance which only contains a web
 . Use a browser to access the Servlet at the following URL: http://localhost:8380/ejb-multi-server-app-web/
 . The Servlet will invoke the remote EJBs directly and show the results, compare that the invocation is successful
 
-[[undeploy_the_quickstart]]
-== Undeploy the Quickstart
+// Server Distribution Testing
+:integrationTestsDirectory: app-web/src/test/
+include::../shared-doc/run-integration-tests-with-server-distribution.adoc[leveloffset=+1]
 
-. xref:start_eap_managed_domain[Start the {productName} managed domain] as described above.
-. Open a terminal and navigate to the root directory of this quickstart.
-. When you are finished testing, type this command to undeploy the archive:
-+
-[source,subs="+quotes,attributes+",options="nowrap"]
-----
-$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=undeploy-domain.cli
-----
-+
-NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat`.
-
+// Undeploy the Quickstart
+include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
 // Restore the {productName} Managed Domain Configuration Manually
 include::../shared-doc/restore-managed-domain-configuration-manual.adoc[leveloffset=+1]
-// Run the Quickstart in Red Hat CodeReady Studio or Eclipse
-include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-// Additional Red Hat CodeReady Studio instructions
-EJB Client (ejb-client) currently has limited support in the Eclipse Web Tools Platform (WTP).
-
-// Debug the Application
-include::../shared-doc/debug-the-application.adoc[leveloffset=+1]
-
-//*************************************************
-// Product Release content only
-//*************************************************
-ifdef::ProductRelease[]
 
 // Quickstart not compatible with OpenShift
 include::../shared-doc/openshift-incompatibility.adoc[leveloffset=+1]
-
-endif::[]

--- a/ejb-multi-server/README.adoc
+++ b/ejb-multi-server/README.adoc
@@ -393,11 +393,6 @@ You configure the domain server by running JBoss CLI commands. For your convenie
 
 . Before you begin, make sure you do the following:
 
-* xref:start_with_a_clean_server_install[Start with clean {productName} installation].
-* xref:back_up_managed_domain_configuration[Back up the {productName} managed domain configuration].
-* xref:add_the_application_users[Add the application users].
-* xref:start_eap_managed_domain[Start the {productName} managed domain].
-
 . Review the `install-domain.cli` file in the root of this quickstart directory. This script configures and starts multiple servers needed to run this quickstart.
 . Open a new terminal, navigate to the root directory of this quickstart, and run the following command, replacing __{jbossHomeName}__ with the path to your server:
 +
@@ -418,12 +413,9 @@ IMPORTANT: Depending on your machine configuration, you might see "Exception in 
 There are too many additions to the configuration files to list here. Feel free to compare the `domain.xml` and `host.xml` to the backup copies to see the changes made to configure the server to run this quickstart.
 
 
-
-
 [[build_and_deploy_the_quickstart]]
 == Build and Deploy the Quickstart
 
-. Make sure you have xref:install_the_quickstart_parent_artifact_in_maven[installed the quickstart parent artifact] in your Maven repository.
 . Make sure you have started and configured the {productName} server successfully as described above.
 . Open a terminal and navigate to the root directory of this quickstart.
 . Type this command to build the artifacts.
@@ -437,12 +429,11 @@ You should see `BUILD SUCCESS` at the end of the build `SUCCESS` messages for ea
 
 . In the same terminal, deploy the applications using the provided CLI batch script by typing the following command.
 +
-[source,subs="+quotes,attributes+",options="nowrap"]
+[source,options="nowrap"]
 ----
-$ __{jbossHomeName}__/bin/jboss-cli.sh -c --file=deploy-domain.cli
+$ mvn wildfly:deploy
 ----
-+
-NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat` script.
+
 
 +
 This deploys the `app-*.ear` files to different server groups of the running domain. You should see the following result when you run the script.
@@ -529,16 +520,13 @@ An example how to access EJBs from a separate instance which only contains a web
 [[undeploy_the_quickstart]]
 == Undeploy the Quickstart
 
-. xref:start_eap_managed_domain[Start the {productName} managed domain] as described above.
 . Open a terminal and navigate to the root directory of this quickstart.
 . When you are finished testing, type this command to undeploy the archive:
 +
-[source,subs="+quotes,attributes+",options="nowrap"]
+[source,options="nowrap"]
 ----
-$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=undeploy-domain.cli
+$ mvn wildfly:undeploy
 ----
-+
-NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat`.
 
 
 // Restore the {productName} Managed Domain Configuration Manually

--- a/ejb-multi-server/app-main/ear/pom.xml
+++ b/ejb-multi-server/app-main/ear/pom.xml
@@ -107,6 +107,16 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                    <server-groups>
+                        <server-group>quickstart-ejb-multi-main-server</server-group>
+                    </server-groups>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/ejb-multi-server/app-one/ear/pom.xml
+++ b/ejb-multi-server/app-one/ear/pom.xml
@@ -70,6 +70,17 @@
                     </archive>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                    <server-groups>
+                        <server-group>quickstart-ejb-multi-appOne-server</server-group>
+                    </server-groups>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/ejb-multi-server/app-two/ear/pom.xml
+++ b/ejb-multi-server/app-two/ear/pom.xml
@@ -71,6 +71,16 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                    <server-groups>
+                        <server-group>quickstart-ejb-multi-appTwo-server</server-group>
+                    </server-groups>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/ejb-multi-server/app-web/pom.xml
+++ b/ejb-multi-server/app-web/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -79,6 +83,16 @@
                     <archive>
                         <addMavenDescriptor>false</addMavenDescriptor>
                     </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                    <server-groups>
+                        <server-group>quickstart-ejb-multi-appWeb-server</server-group>
+                    </server-groups>
                 </configuration>
             </plugin>
         </plugins>

--- a/ejb-multi-server/app-web/src/test/java/org/jboss/as/quickstarts/ejb/multi/server/BasicRuntimeIT.java
+++ b/ejb-multi-server/app-web/src/test/java/org/jboss/as/quickstarts/ejb/multi/server/BasicRuntimeIT.java
@@ -1,0 +1,37 @@
+package org.jboss.as.quickstarts.ejb.multi.server;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+public class BasicRuntimeIT {
+    private static final String DEFAULT_SERVER_HOST = "http://localhost:8080/ejb-multi-server-app-main-web/";
+
+    @Test
+    public void testHTTPEndpointIsAvailable() throws IOException, InterruptedException, URISyntaxException {
+        String serverHost = System.getProperty("server.host");
+        if (serverHost == null) {
+            serverHost = DEFAULT_SERVER_HOST;
+        }
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(new URI(serverHost+"/"))
+                .GET()
+                .build();
+        final HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.ALWAYS)
+                .connectTimeout(Duration.ofMinutes(1))
+                .build();
+        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+        final String[] bodyLines = response.body().toString().split(System.lineSeparator());
+        assertEquals("<meta http-equiv=\"Refresh\" content=\"0; URL=ejbinvoke.jsf\">", bodyLines[bodyLines.length-3].strip());
+    }
+}

--- a/ejb-multi-server/deploy-domain.cli
+++ b/ejb-multi-server/deploy-domain.cli
@@ -1,6 +1,0 @@
-batch
-deploy app-one/ear/target/ejb-multi-server-app-one.ear --server-groups=quickstart-ejb-multi-appOne-server
-deploy app-two/ear/target/ejb-multi-server-app-two.ear --server-groups=quickstart-ejb-multi-appTwo-server
-deploy app-main/ear/target/ejb-multi-server-app-main.ear --server-groups=quickstart-ejb-multi-main-server
-deploy app-web/target/ejb-multi-server-app-web.war --server-groups=quickstart-ejb-multi-appWeb-server
-run-batch

--- a/ejb-multi-server/install-domain.cli
+++ b/ejb-multi-server/install-domain.cli
@@ -79,7 +79,7 @@ batch
 
 /profile=default-web:add()
 /profile=default-web/subsystem="logging":add()
-/profile=default-web/subsystem="logging"/periodic-rotating-file-handler="FILE":add(append="true",autoflush="true",file={"relative-to" => "jboss.server.log.dir","path" => "server.log"},name="FILE",named-formatter="PATTERN",suffix=".yyyy-MM-dd")
+/profile=default-web/subsystem="logging"/periodic-rotating-file-handler="FILE":add(append="true",autoflush="true",file={"relative-to" => "jboss.server.log.dir","path" => "server.log"},named-formatter="PATTERN",suffix=".yyyy-MM-dd")
 /profile=default-web/subsystem="logging"/pattern-formatter="PATTERN":add(pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n")
 /profile=default-web/subsystem="logging"/logger="com.arjuna":add(category="com.arjuna",level="WARN")
 /profile=default-web/subsystem="logging"/logger="sun.rmi":add(category="sun.rmi",level="WARN")
@@ -158,7 +158,6 @@ batch
 #/profile=default-web/subsystem="pojo":add()
 
 /profile=default-web/subsystem="remoting":add()
-/profile=default-web/subsystem="remoting"/configuration="endpoint":add(worker="default")
 /profile=default-web/subsystem="remoting"/http-connector="http-remoting-connector":add(connector-ref="default")
 
 /profile=default-web/subsystem="transactions":add(process-id-uuid="true",socket-binding="txn-recovery-environment",status-socket-binding="txn-status-manager")

--- a/ejb-multi-server/pom.xml
+++ b/ejb-multi-server/pom.xml
@@ -46,8 +46,11 @@
     </licenses>
 
     <properties>
+        <!-- the version for the Server -->
+        <version.server>31.0.0.Final</version.server>
         <!-- The versions for BOMs, Dependencies and Plugins -->
-        <version.server.bom>31.0.0.Final</version.server.bom>
+        <version.bom.ee>${version.server}</version.bom.ee>
+        <version.plugin.wildfly>4.2.1.Final</version.plugin.wildfly>
     </properties>
 
     <repositories>
@@ -111,7 +114,7 @@
             <dependency>
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-ee-with-tools</artifactId>
-                <version>${version.server.bom}</version>
+                <version>${version.bom.ee}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -127,14 +130,44 @@
     </modules>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                    <version>${version.plugin.wildfly}</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>integration-testing</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/BasicRuntimeIT</include>
+                            </includes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/ejb-multi-server/undeploy-domain.cli
+++ b/ejb-multi-server/undeploy-domain.cli
@@ -1,5 +1,0 @@
-# remove all deployments from the domain
-undeploy --server-groups=quickstart-ejb-multi-appWeb-server ejb-multi-server-app-web.war
-undeploy --server-groups=quickstart-ejb-multi-main-server ejb-multi-server-app-main.ear
-undeploy --server-groups=quickstart-ejb-multi-appOne-server ejb-multi-server-app-one.ear
-undeploy --server-groups=quickstart-ejb-multi-appTwo-server ejb-multi-server-app-two.ear

--- a/shared-doc/build-and-deploy-the-quickstart.adoc
+++ b/shared-doc/build-and-deploy-the-quickstart.adoc
@@ -67,7 +67,7 @@ endif::[]
 
 endif::mavenCommand[]
 
-. Make sure you xref:start_the_eap_standalone_server[start the {productName} server] as described above.
+. Make sure you start the {productName} server as described above.
 . Open a terminal and navigate to the root directory of this quickstart.
 ifdef::reactive-messaging[]
 . Run this command to enable the MicroProfile Reactive Messaging functionality on the server

--- a/shared-doc/openshift-incompatibility.adoc
+++ b/shared-doc/openshift-incompatibility.adoc
@@ -1,4 +1,4 @@
 [[openshift_incompatibility]]
 = {xpaasproduct-shortname} Incompatibility
 
-This quickstart is not compatible with {xpaasproduct-shortname} or {xpaasproductOpenShiftOnline-shortname} templates.
+This quickstart is not compatible with {xpaasproduct-shortname}.

--- a/shared-doc/run-integration-tests-with-server-distribution.adoc
+++ b/shared-doc/run-integration-tests-with-server-distribution.adoc
@@ -1,6 +1,8 @@
 [[run_the_integration_tests_with_server_distribution]]
 = Run the Integration Tests
-This quickstart includes integration tests, which are located under the  `src/test/` directory. The integration tests verify that the quickstart runs correctly when deployed on the server.
+ifndef::integrationTestsDirectory[:integrationTestsDirectory: src/test/]
+
+This quickstart includes integration tests, which are located under the `{integrationTestsDirectory}` directory. The integration tests verify that the quickstart runs correctly when deployed on the server.
 
 Follow these steps to run the integration tests.
 
@@ -14,8 +16,3 @@ Follow these steps to run the integration tests.
 ----
 $ mvn verify -Pintegration-testing
 ----
-
-[NOTE]
-====
-You may also use the environment variable `SERVER_HOST` or the system property `server.host` to define the target URL of the tests.
-====


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18464
 
Changes on top of  #842:
* Renamed workflow to correct filename: quickstart_ejb-multi-server_ci.yml
* Moved workflow to correct directory: /.github/workflows (not ejb-multi-server/.github/workflows) 
* Fixed content in the workflow
* Replaced custom sections in README with includes for related ones in shared-docs, wrt deploy and undeploy (and removed ref to standalone start in that deploy section)
* Added include of integration tests section from shared-docs (and added customization of test sources dir in it)
* Removed unused cli scripts to deploy and undeploy domain
* Fixed plugin management for wildfly maven plugin
* Updated server.version value
