### PR TITLE
[WFLY-18476] Additional fixes/enhancements

### DIFF
--- a/helloworld-mutual-ssl/README-source.adoc
+++ b/helloworld-mutual-ssl/README-source.adoc
@@ -27,84 +27,22 @@ include::../shared-doc/system-requirements.adoc[leveloffset=+1]
 // Use of {jbossHomeName}
 include::../shared-doc/use-of-jboss-home-name.adoc[leveloffset=+1]
 
-[[set_up_client_keystore_using_java_keytool]]
-== Set Up the Client Keystore Using Java Keytool
-
-. Open a terminal and navigate to the {productName} server `configuration` directory:
-+
-[source,subs="+quotes,attributes+",options="nowrap"]
-----
-$ cd __{jbossHomeName}__/standalone/configuration/
-----
-
-. Create the client certificate, which is used to authenticate against the server when accessing a resource through TLS.
-+
-[source,options="nowrap"]
-----
-$>keytool -genkey -keystore client.keystore -storepass secret -validity 365 -keyalg RSA -keysize 2048 -storetype pkcs12
-
-What is your first and last name?
-    [Unknown]:  quickstartUser
-What is the name of your organizational unit?
-    [Unknown]:  Sales
-What is the name of your organization?
-    [Unknown]:  My Company
-What is the name of your City or Locality?
-    [Unknown]:  Sao Paulo
-What is the name of your State or Province?
-    [Unknown]:  Sao Paulo
-What is the two-letter country code for this unit?
-    [Unknown]:  BR
-Is CN=quickstartUser, OU=Sales, O=My Company, L=Sao Paulo, ST=Sao Paulo, C=BR correct?
-    [no]:  yes
-----
-
-. Export the client certificate and create a truststore by importing this certificate:
-+
-[source,options="nowrap"]
-----
-$>keytool -exportcert -keystore client.keystore  -storetype pkcs12 -storepass secret -keypass secret -file client.crt
-$>keytool -import -file client.crt -alias quickstartUser -keystore client.truststore -storepass secret
-
-Owner: CN=quickstartUser, OU=Sales, O=My Company, L=Sao Paulo, ST=Sao Paulo, C=BR
-Issuer: CN=quickstartUser, OU=Sales, O=My Company, L=Sao Paulo, ST=Sao Paulo, C=BR
-Serial number: 7fd95ce4
-Valid from: Mon Jul 24 16:14:03 BRT 2017 until: Tue Jul 24 16:14:03 BRT 2018
-Certificate fingerprints:
-     MD5:  87:41:C5:CC:E6:79:91:F0:9D:90:AD:9E:DD:57:81:80
-     SHA1: 55:35:CA:B0:DC:DD:4F:E6:B8:9F:45:4B:4B:98:93:B5:3B:7C:55:84
-     SHA256: 0A:FC:93:B6:25:5A:74:42:B8:A1:C6:5F:69:88:72:7F:27:A9:81:B0:17:0C:F1:AF:3D:DE:B7:E5:F1:69:66:4B
-     Signature algorithm name: SHA256withRSA
-     Version: 3
-
-Extensions:
-
-#1: ObjectId: 2.5.29.14 Criticality=false
-SubjectKeyIdentifier [
-KeyIdentifier [
-0000: 95 84 BE C6 32 BB 2B 13   4C 7F 5D D4 C4 C8 22 12  ....2.+.L.]...".
-0010: CB 09 39 09                                        ..9.
-]
-]
-
-Trust this certificate? [no]:  yes
-Certificate was added to keystore
-----
-
-. Export client certificate to pkcs12 format
-+
-[source,options="nowrap"]
-----
-$>keytool -importkeystore -srckeystore client.keystore -srcstorepass secret -destkeystore clientCert.p12 -srcstoretype PKCS12 -deststoretype PKCS12 -deststorepass secret
-----
-
-. The certificate and keystore are now properly configured.
-
 // Back Up the {productName} Standalone Server Configuration
 include::../shared-doc/back-up-server-standalone-configuration.adoc[leveloffset=+1]
 // Start the {productName} Standalone Server
 include::../shared-doc/start-the-standalone-server.adoc[leveloffset=+1]
 
+[[set_up_client_keystore_using_java_keytool]]
+== Set Up the Client Keystore
+
+. Create the client certificate, which is used to authenticate against the server when accessing a resource through TLS.
++
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=configure-client-cert.cli
+----
+
+. The certificate and keystore are now properly configured.
 
 [[configure_the_server]]
 == Configure the Server
@@ -185,7 +123,7 @@ If it is configured correctly, you should be asked to trust the server certifica
 [[import_the_client_certificate_into_your_browser]]
 == Import the Client Certificate into Your Browser
 
-Before you access the application, you must import the _clientCert.p12_, which holds the client certificate, into your browser.
+Before you access the application, you must import the _client.keystore.P12_, which holds the client certificate, into your browser.
 
 [[import_the_client_certificate_into_google_chrome]]
 === Import the Client Certificate into Google Chrome
@@ -193,7 +131,7 @@ Before you access the application, you must import the _clientCert.p12_, which h
 . Click the Chrome menu icon (3 dots) in the upper right on the browser toolbar and choose *Settings*. This takes you to `link:`chrome://settings/`.
 . Click on *Privacy and security* and then on *Security*.
 . Scroll down to the *Advanced* section and on the *Manage certificates* screen, select the *Your Certificates* tab and click on the *Import* button.
-. Select the *clientCert.p12* file. You will be prompted to enter the password: `secret`.
+. Select the *client.keystore.P12* file. You will be prompted to enter the password: `secret`.
 . The client certificate is now installed in the Google Chrome browser.
 
 [[import_the_client_certificate_into_mozilla_firefox]]
@@ -203,7 +141,7 @@ Before you access the application, you must import the _clientCert.p12_, which h
 . A new window will open. Click on *Privacy & Security* and scroll down to the *Certificates* section.
 . Click the *View Certificates* button.
 . A new window will open. Select the *Your Certificates* tab and click the *Import* button.
-. Select the *clientCert.p12* file. You will be prompted to enter the password: `secret`.
+. Select the *client.keystore.P12* file. You will be prompted to enter the password: `secret`.
 . The certificate is now installed in the Mozilla Firefox browser.
 
 // Build and Deploy the Quickstart
@@ -232,6 +170,9 @@ DHo1uoz5/dzXZz0EjjWCPJk+LVEhEvH0GcWAp3x3irpNU4hRZLd0XomY0Z4NnUt7VMBNYDOxVxgT9qcL
 aEWK4zhPVFynfnMaOxI67FC2QzhfzERyKqHj47WuwN0xWbS/1gBypS2nUwvItyxaEQG2X5uQY8j8QoY9wcMzIIkP2Mk14gJGHUnA8=
 ----
 
+// Server Distribution Testing
+:extraStandardDistTestParams: -Dserver.dir=__{jbossHomeName}__
+include::../shared-doc/run-integration-tests-with-server-distribution.adoc[leveloffset=+2]
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Restore the {productName} Standalone Server Configuration
@@ -253,14 +194,16 @@ include::../shared-doc/restore-standalone-server-configuration-manual.adoc[level
 
 == Remove the keystores and certificates created for this quickstart
 
-. Open a terminal and navigate to the {productName} server `configuration` directory:
+. Run the CLI script for restoring client cert configuration: 
 +
 [source,subs="+quotes,attributes+",options="nowrap"]
 ----
-$ cd __{jbossHomeName}__/standalone/configuration/
+$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=restore-client-cert.cli
 ----
++
+NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat` script.
 
-. Remove the `clientCert.p12`, `client.crt`, `client.keystore`, and `client.truststore` files that
+. Remove the `client.keystore.P12`, `clientCert.crt`, `client.keystore`, and `client.truststore` files that
 were generated for this quickstart.
 
 [[remove_the_client_certificate_from_your_browser]]
@@ -285,30 +228,15 @@ After you are done with this quickstart, remember to remove the certificate that
 . Select the `quickstartUser` certificate and click the `Delete` button.
 . The certificate has now been removed from the Mozilla Firefox browser.
 
-// Run the Quickstart in Red Hat  Studio or Eclipse
-include::../shared-doc/run-the-quickstart-in-jboss-developer-studio.adoc[leveloffset=+1]
-
-// Additional Red Hat CodeReady Studio instructions
-* Make sure you configure the keystore and client certificate as described under xref:set_up_client_keystore_using_java_keytool[Set Up the Client Keystore Using Java Keytool].
-* Depending on the browser you choose, make sure you either xref:import_the_client_certificate_into_google_chrome[import the certificate into Google Chrome] or xref:import_the_client_certificate_into_mozilla_firefox[import the certificate into Mozilla Firefox].
-* Make sure you configure the server by running the JBoss CLI commands as described above under xref:configure_the_server[Configure the Server]. Stop the server at the end of that step.
-* In {JBDSProductName}, choose *Window* –> *Web Browser*, then select the browser you chose to import the certificate.
-* To deploy the application, right-click on the *{artifactId}* project and choose *Run As* –> *Run on Server*.
-* Make sure you xref:restore_the_server_configuration[restore the server configuration] when you have completed testing this quickstart.
-
-== Debug the Application
-
-If you want to debug the source code or look at the Javadocs of any library in the project, run either of the following commands to pull them into your local repository. The IDE should then detect them.
-
-[source,options="nowrap"]
-----
-$ mvn dependency:sources
-$ mvn dependency:resolve -Dclassifier=javadoc
-----
-
 //*************************************************
 // Product Release content only
 //*************************************************
+// Build and run sections for other environments/builds
+ifndef::ProductRelease,EAPXPRelease[]
+:server_provisioning_server_host: https://localhost:8443
+include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
+endif::[]
+
 ifdef::ProductRelease[]
 
 // Quickstart not compatible with OpenShift

--- a/helloworld-mutual-ssl/pom.xml
+++ b/helloworld-mutual-ssl/pom.xml
@@ -32,11 +32,11 @@
 
     <properties>
         <!-- the version for the Server -->
-        <version.server>31.0.0.Beta1</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <version.server>31.0.0.Final</version.server>
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
-        <version.pack.cloud>5.0.0.Beta1</version.pack.cloud>
-        <version.plugin.wildfly>4.2.1.Final</version.plugin.wildfly>
+        <version.pack.cloud>6.0.0.Final</version.pack.cloud>
+        <version.plugin.wildfly>5.0.0.Beta3</version.plugin.wildfly>
     </properties>
 
     <artifactId>helloworld-mutual-ssl</artifactId>
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/helloworld-mutual-ssl/src/test/java/org/jboss/as/quickstarts/helloworld_mutual_ssl/BasicRuntimeIT.java
+++ b/helloworld-mutual-ssl/src/test/java/org/jboss/as/quickstarts/helloworld_mutual_ssl/BasicRuntimeIT.java
@@ -52,6 +52,7 @@ import static org.junit.Assert.assertEquals;
 public class BasicRuntimeIT {
 
     private static final String DEFAULT_SERVER_HOST = "https://localhost:8443/helloworld-mutual-ssl";
+    private static final String DEFAULT_SERVER_DIR = System.getProperty("user.dir") + "/target/server";
 
     @Test
     public void testHTTPEndpointIsAvailable() throws IOException, InterruptedException, URISyntaxException, KeyStoreException {
@@ -62,17 +63,15 @@ public class BasicRuntimeIT {
         if (serverHost == null) {
             serverHost = DEFAULT_SERVER_HOST;
         }
-        String serverDir  = System.getenv("SERVER_HOME");
+        String serverDir  = System.getProperty("server.dir");
         if (serverDir == null) {
-            if (System.getProperty("jboss.server.config.dir").contains("target/server")) {
-                serverDir = System.getProperty("user.dir") + "/" + System.getProperty("jboss.server.config.dir");
-            } else {
-                serverDir = System.getProperty("jboss.server.config.dir");
-            }
+            serverDir = DEFAULT_SERVER_DIR;
         }
+        String serverConfigDir = serverDir + "/standalone/configuration";
+
         HttpGet request = new HttpGet(new URI(serverHost+"/"));
-        KeyStore trustStore = loadKeyPairFromKeyStore(serverDir, "application.keystore", "password", "server", "PKCS12");
-        final HttpClient client = getHttpClientWithSSL(new File(serverDir + "/client.keystore.P12"), "secret", "PKCS12", new File(serverDir + "/client.truststore"), "password", "PKCS12");
+        KeyStore trustStore = loadKeyPairFromKeyStore(serverConfigDir, "application.keystore", "password", "server", "PKCS12");
+        final HttpClient client = getHttpClientWithSSL(new File(serverConfigDir + "/client.keystore.P12"), "secret", "PKCS12", new File(serverConfigDir + "/client.truststore"), "password", "PKCS12");
         HttpResponse response = client.execute(request);
         assertEquals(200, response.getStatusLine().getStatusCode());
     }

--- a/shared-doc/run-integration-tests-with-provisioned-server.adoc
+++ b/shared-doc/run-integration-tests-with-provisioned-server.adoc
@@ -25,6 +25,7 @@ ifndef::server_provisioning_server_host[]
 endif::server_provisioning_server_host[]
 
 ifndef::extraStartParams[:extraStartParams: ]
+ifndef::extraProvisioningTestParams[:extraProvisioningTestParams: ]
 
 The integration tests included with this quickstart, which verify that the quickstart runs correctly, may also be run with a provisioned server.
 
@@ -78,7 +79,7 @@ endif::[]
 +
 [source,subs="attributes+",options="nowrap"]
 ----
-$ mvn verify -Pintegration-testing -Dserver.host={server_provisioning_server_host}
+$ mvn verify -Pintegration-testing -Dserver.host={server_provisioning_server_host} {extraProvisioningTestParams}
 ----
 
 . Shutdown the {productName} provisioned server, this time using the {productName} Maven Plugin too.

--- a/shared-doc/run-integration-tests-with-server-distribution.adoc
+++ b/shared-doc/run-integration-tests-with-server-distribution.adoc
@@ -1,6 +1,7 @@
 [[run_the_integration_tests_with_server_distribution]]
 = Run the Integration Tests
 ifndef::integrationTestsDirectory[:integrationTestsDirectory: src/test/]
+ifndef::extraStandardDistTestParams[:extraStandardDistTestParams: ]
 
 This quickstart includes integration tests, which are located under the `{integrationTestsDirectory}` directory. The integration tests verify that the quickstart runs correctly when deployed on the server.
 
@@ -10,7 +11,7 @@ Follow these steps to run the integration tests.
 . Make sure the quickstart is deployed.
 . Type the following command to run the `verify` goal with the `integration-testing` profile activated.
 +
-[source,options="nowrap"]
+[source,subs="attributes+",options="nowrap"]
 ----
-$ mvn verify -Pintegration-testing
+$ mvn verify -Pintegration-testing {extraStandardDistTestParams}
 ----


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-18476
Changes:
* Moves README.adoc to README-source.adoc
* Moves section set_up_client_keystore_using_java_keytool to after the server is started
* Adds extraStandardDistTestParams and extraProvisioningTestParams extension points to add extra testing params
* Removes include for outdated sections wrt IDEs and debug
* Syncs pom version properties
* Moves http-client dependency to manged version, and test scope
* Simplifies basic test usage of a server.dir property 