### PR TITLE
add support for 'mvn wildfly:execute-commands -Pconfigure-server' ins…

### DIFF
--- a/security-domain-to-domain/ear/pom.xml
+++ b/security-domain-to-domain/ear/pom.xml
@@ -83,14 +83,6 @@
                     <outputFileNameMapping>@{artifactId}@@{dashClassifier?}@.@{extension}@</outputFileNameMapping>
                 </configuration>
             </plugin>
-            <!-- WildFly plug-in to deploy EAR -->
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <configuration>
-                    <skip>false</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -145,6 +137,21 @@
                                     <contextRoot>/</contextRoot>
                                 </webModule>
                             </modules>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>configure-server</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <configuration>
+                            <!-- disables wildfly maven plugin for this module, for this profile -->
+                            <skip>true</skip>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/security-domain-to-domain/ejb/pom.xml
+++ b/security-domain-to-domain/ejb/pom.xml
@@ -74,4 +74,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <!-- disables wildfly maven plugin for this module -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/security-domain-to-domain/pom.xml
+++ b/security-domain-to-domain/pom.xml
@@ -146,19 +146,33 @@
     </dependencyManagement>
 
     <build>
-        <plugins>
-            <!-- The WildFly plug-in deploys your ear to a local JBoss EAP container. 
-                Due to Maven's lack of intelligence with EARs we need to configure
-                the WildFly Maven plug-in to skip deployment for all modules. We then enable
-                it specifically in the ear module. -->
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <version>${version.plugin.wildfly}</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                    <version>${version.plugin.wildfly}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
+
+    <profiles>
+        <!-- a profile which should be used with wildfly:execute-commands to execute 'configure-server.cli' script -->
+        <profile>
+            <id>configure-server</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <configuration>
+                            <scripts>configure-server.cli</scripts>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/security-domain-to-domain/test/pom.xml
+++ b/security-domain-to-domain/test/pom.xml
@@ -66,4 +66,17 @@
             </build>
         </profile>
     </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <!-- disables wildfly maven plugin for this module -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/security-domain-to-domain/web/pom.xml
+++ b/security-domain-to-domain/web/pom.xml
@@ -90,4 +90,17 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <!-- disables wildfly maven plugin for this module -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
…tead of jboss-cli usage

PoC to replace usage of $WILDFLY_HOME/bin/jboss-cli.sh (as noted at https://github.com/wildfly/quickstart/tree/main/security-domain-to-domain#configure-the-wildfly-server )
with command:

mvn wildfly:execute-commands -Pconfigure-server

Please note that this solution is exclusive to multimodule maven projects, in the case of single module projects we would just use the command:

mvn wildfly:execute-commands -Dwildlfy.scripts=configure-server.cli