### PR TITLE
[JBEAP-27122] kafka is not supported on Windows note

### DIFF
--- a/microprofile-reactive-messaging-kafka/README-source.adoc
+++ b/microprofile-reactive-messaging-kafka/README-source.adoc
@@ -887,6 +887,8 @@ $ ./bin/kafka-server-start.sh config/server.properties
 
 NOTE: Zookeeper and Kafka must be left running, so use a new terminal for other commands outlined in this quickstart.
 
+NOTE: Kafka is not supported on Microsoft Windows, but Docker may be used to start a Kafka service on it.
+
 == Build and Deploy the Initial Application
 Let's check that our application works!
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19358
Downstream PR: https://github.com/jbossas/eap-quickstarts/pull/262