### PR TITLE
[WFLY-19359] bootable jar with kafka can produce a warning message

### DIFF
--- a/microprofile-reactive-messaging-kafka/README-source.adoc
+++ b/microprofile-reactive-messaging-kafka/README-source.adoc
@@ -971,6 +971,18 @@ data: three
 // Bootable JAR
 include::../shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc[leveloffset=+1]
 
+[NOTE]
+====
+The following warning message may be seen when starting the {productName} bootable jar, due to the topic missing in Kafka:
+```
+WARN  [org.apache.kafka.clients.NetworkClient] (smallrye-kafka-consumer-thread-0) [Consumer clientId=kafka-consumer-from-kafka, groupId="microprofile-reactive-messaging-kafka-group-id"] Error while fetching metadata with correlation id 2 : {testing=LEADER_NOT_AVAILABLE}
+```
+You may ignore this warning, yet to avoid it the topic may be manually created in advance, with the following command:
+```
+bin/kafka-topics.sh --create --topic testing --bootstrap-server localhost:9092
+```
+====
+
 // OpenShift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19359
Downstream PR: https://github.com/jbossas/eap-quickstarts/pull/263