### PR TITLE
[WFLY-19389] websocket-endpoint Quickstarts should have a root webpage similar to helloworld

### DIFF
--- a/websocket-endpoint/src/main/webapp/index.html
+++ b/websocket-endpoint/src/main/webapp/index.html
@@ -1,6 +1,6 @@
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2024, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 
@@ -14,10 +14,21 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
+<!DOCTYPE html>
 <!-- Plain HTML page that kicks us into the app -->
 
-<html>
+<html lang="en">
 <head>
-<meta http-equiv="Refresh" content="0; URL=bid.html">
+    <meta charset="UTF-8">
+    <title>websocket-endpoint</title>
 </head>
+<body>
+<div style="text-align:center">
+
+    <h1>Hello There! Welcome to WildFly!</h1>
+    <h2>The websocket-endpoint application has been deployed and running successfully.</h2>
+    <a href="bid.html" title="Go to the application">Access the websocket-endpoint application here</a>
+
+</div>
+</body>
 </html>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19389

Linked Issue: https://issues.redhat.com/browse/WFLY-19075