### PR TITLE
[WFLY-19390] temperature-converter Quickstarts should have a root webpage similar to helloworld

### DIFF
--- a/temperature-converter/src/main/webapp/index.html
+++ b/temperature-converter/src/main/webapp/index.html
@@ -1,6 +1,6 @@
 <!--
     JBoss, Home of Professional Open Source
-    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    Copyright 2024, Red Hat, Inc. and/or its affiliates, and individual
     contributors by the @authors tag. See the copyright.txt in the
     distribution for a full listing of individual contributors.
 
@@ -14,10 +14,21 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
+<!DOCTYPE html>
 <!-- Plain HTML page that kicks us into the app -->
 
-<html>
+<html lang="en">
 <head>
-<meta http-equiv="Refresh" content="0; URL=temperatureconvert.jsf">
+    <meta charset="UTF-8">
+    <title>temperature converter</title>
 </head>
+<body>
+<div style="text-align:center">
+
+    <h1>Hello There! Welcome to WildFly!</h1>
+    <h2>The temperature-converter quickstart application has been deployed and running successfully.</h2>
+    <a href="temperatureconvert.jsf" title="Go to the application">Access the temperature-converter application here</a>
+
+</div>
+</body>
 </html>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19390

Linked Issue: https://issues.redhat.com/browse/WFLY-19075