### PR TITLE
[WFLY-19426] microprofile-health Quickstarts should have a root webpage similar to helloworld

### DIFF
--- a/microprofile-health/src/main/java/org/wildfly/quickstarts/microprofile/health/JaxRsApplication.java
+++ b/microprofile-health/src/main/java/org/wildfly/quickstarts/microprofile/health/JaxRsApplication.java
@@ -3,6 +3,6 @@ package org.wildfly.quickstarts.microprofile.health;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
-@ApplicationPath("/")
+@ApplicationPath("/rest")
 public class JaxRsApplication extends Application {
 }

--- a/microprofile-health/src/main/webapp/index.html
+++ b/microprofile-health/src/main/webapp/index.html
@@ -1,0 +1,28 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2024, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!DOCTYPE html>
+<html>
+<title>microprofile-health</title>
+<body>
+<div style="text-align:center">
+
+    <h1>Hello There! Welcome to WildFly!</h1>
+    <h2>The microprofile-health application has been deployed and running successfully.</h2>
+
+</div>
+</body>
+
+</html>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19426

Linked Issue: https://issues.redhat.com/browse/WFLY-19075