### PR TITLE
[WFLY-19428] microprofile-rest-client Quickstarts should have a root webpage similar to helloworld

### DIFF
--- a/microprofile-rest-client/README.adoc
+++ b/microprofile-rest-client/README.adoc
@@ -510,9 +510,9 @@ You should see a message in the server log indicating that the archive deployed 
 The application will be running at the following URL: http://localhost:8080/{artifactId}/.
 
 You can verify that the server is responding by accessing
-`http://localhost:8080/{artifactId}/name/France`
+`http://localhost:8080/{artifactId}/rest/name/France`
 endpoint using your browser or
-`curl http://localhost:8080/{artifactId}/name/France`
+`curl http://localhost:8080/{artifactId}/rest/name/France`
 to get some information about `France`.
 
 == The Country REST Client
@@ -533,7 +533,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 
-@Path("/")
+@Path("/rest")
 public interface CountriesServiceClient {
 
     @GET

--- a/microprofile-rest-client/src/main/java/org/wildfly/quickstarts/microprofile/RestApplication.java
+++ b/microprofile-rest-client/src/main/java/org/wildfly/quickstarts/microprofile/RestApplication.java
@@ -22,6 +22,6 @@ package org.wildfly.quickstarts.microprofile;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
-@ApplicationPath("/")
+@ApplicationPath("/rest")
 public class RestApplication extends Application {
 }

--- a/microprofile-rest-client/src/main/webapp/index.html
+++ b/microprofile-rest-client/src/main/webapp/index.html
@@ -1,0 +1,28 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2024, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!DOCTYPE html>
+<html>
+<title>microprofile-rest-client</title>
+<body>
+<div style="text-align:center">
+
+    <h1>Hello There! Welcome to WildFly!</h1>
+    <h2>The microprofile-rest-client application has been deployed and running successfully.</h2>
+
+</div>
+</body>
+
+</html>

--- a/microprofile-rest-client/src/test/java/org/wildfly/quickstarts/microprofile/rest/client/CountriesServiceClient.java
+++ b/microprofile-rest-client/src/test/java/org/wildfly/quickstarts/microprofile/rest/client/CountriesServiceClient.java
@@ -30,7 +30,7 @@ import org.wildfly.quickstarts.microprofile.Country;
 
 import java.util.concurrent.CompletionStage;
 
-@Path("/")
+@Path("/rest")
 @RegisterRestClient
 @RegisterProvider(NotFoundResponseExceptionMapper.class)
 public interface CountriesServiceClient {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19428

Linked Issue: https://issues.redhat.com/browse/WFLY-19075