### PR TITLE
[WFLY-19435] microprofile-reactive-messaging-kafka Quickstarts should have a root webpage similar to helloworld

### DIFF
--- a/microprofile-reactive-messaging-kafka/README.adoc
+++ b/microprofile-reactive-messaging-kafka/README.adoc
@@ -1290,7 +1290,7 @@ package org.wildfly.quickstarts.microprofile.reactive.messaging;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
-@ApplicationPath("/")
+@ApplicationPath("/rest")
 public class JaxRsApplication extends Application {
 }
 
@@ -1525,7 +1525,7 @@ Then we get another section where it is using the randomised order
 
 In both parts of the log we see that all messages reach the `logAllMessages()` method, while only `Hello` and `Kafka` reach the `receiveFromKafka()` method which saves them to the RDBMS.
 
-To inspect what was stored in the database, go to http://localhost:8080/microprofile-reactive-messaging-kafka/db in  your browser and you should see something like:
+To inspect what was stored in the database, go to http://localhost:8080/microprofile-reactive-messaging-kafka/rest/db in  your browser and you should see something like:
 
 [source, options="nowrap"]
 ----
@@ -1539,15 +1539,15 @@ The timestamps of the entries in the browser match the ones we saw in the server
 === Interaction with User Initiated Code
 With the application still running, open two terminal windows. Enter the following `curl` command in both of them
 ```
-$curl -N http://localhost:8080/microprofile-reactive-messaging-kafka/user
+$curl -N http://localhost:8080/microprofile-reactive-messaging-kafka/rest/user
 ```
 The `-N` option keeps the connection open, so we receive data as it becomes available on the publisher.
 
 In a third terminal window enter the commands:
 ```
-$curl -X POST http://localhost:8080/microprofile-reactive-messaging-kafka/user/one
-$curl -X POST http://localhost:8080/microprofile-reactive-messaging-kafka/user/two
-$curl -X POST http://localhost:8080/microprofile-reactive-messaging-kafka/user/three
+$curl -X POST http://localhost:8080/microprofile-reactive-messaging-kafka/rest/user/one
+$curl -X POST http://localhost:8080/microprofile-reactive-messaging-kafka/rest/user/two
+$curl -X POST http://localhost:8080/microprofile-reactive-messaging-kafka/rest/user/three
 ```
 In the first two terminal windows you should see these entries appear as they are posted:
 ```

--- a/microprofile-reactive-messaging-kafka/src/main/java/org/wildfly/quickstarts/microprofile/reactive/messaging/JaxRsApplication.java
+++ b/microprofile-reactive-messaging-kafka/src/main/java/org/wildfly/quickstarts/microprofile/reactive/messaging/JaxRsApplication.java
@@ -19,6 +19,6 @@ package org.wildfly.quickstarts.microprofile.reactive.messaging;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
-@ApplicationPath("/")
+@ApplicationPath("/rest")
 public class JaxRsApplication extends Application {
 }

--- a/microprofile-reactive-messaging-kafka/src/main/webapp/index.html
+++ b/microprofile-reactive-messaging-kafka/src/main/webapp/index.html
@@ -1,0 +1,27 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2024, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!DOCTYPE html>
+<html>
+<title>microprofile-reactive-messaging-kafka</title>
+<body>
+<div style="text-align:center">
+
+    <h1>Hello There! Welcome to WildFly!</h1>
+    <h2>The microprofile-reactive-messaging-kafka quickstart application has been deployed and running successfully.</h2>
+
+</div>
+</body>
+</html>

--- a/microprofile-reactive-messaging-kafka/src/test/java/org/wildfly/quickstarts/microprofile/reactive/messaging/test/TestUtils.java
+++ b/microprofile-reactive-messaging-kafka/src/test/java/org/wildfly/quickstarts/microprofile/reactive/messaging/test/TestUtils.java
@@ -2,6 +2,7 @@ package org.wildfly.quickstarts.microprofile.reactive.messaging.test;
 
 public class TestUtils {
     static final String DEFAULT_SERVER_HOST = "http://localhost:8080/microprofile-reactive-messaging-kafka";
+    static final String API_PATH = "/rest";
 
     static String getServerHost() {
         String serverHost = System.getenv("SERVER_HOST");
@@ -11,6 +12,6 @@ public class TestUtils {
         if (serverHost == null) {
             serverHost = DEFAULT_SERVER_HOST;
         }
-        return serverHost;
+        return serverHost + API_PATH;
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19435

Linked Issue: https://issues.redhat.com/browse/WFLY-19075