### PR TITLE
[WFLY-19449] opentelemetry-tracing Quickstarts should have a root webpage similar to helloworld

### DIFF
--- a/opentelemetry-tracing/src/main/java/org/wildfly/quickstarts/opentelemetry/JakartaRestApplication.java
+++ b/opentelemetry-tracing/src/main/java/org/wildfly/quickstarts/opentelemetry/JakartaRestApplication.java
@@ -5,6 +5,6 @@ import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
 @ApplicationScoped
-@ApplicationPath("/")
+@ApplicationPath("/rest")
 public class JakartaRestApplication extends Application {
 }

--- a/opentelemetry-tracing/src/main/webapp/index.html
+++ b/opentelemetry-tracing/src/main/webapp/index.html
@@ -1,0 +1,28 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2024, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!DOCTYPE html>
+<html>
+<title>opentelemetry-tracing</title>
+<body>
+<div style="text-align:center">
+
+    <h1>Hello There! Welcome to WildFly!</h1>
+    <h2>The opentelemetry-tracing application has been deployed and running successfully.</h2>
+
+</div>
+</body>
+
+</html>

--- a/opentelemetry-tracing/src/test/java/org/wildfly/quickstarts/opentelemetry/OpenTelemetryIT.java
+++ b/opentelemetry-tracing/src/test/java/org/wildfly/quickstarts/opentelemetry/OpenTelemetryIT.java
@@ -32,7 +32,7 @@ public class OpenTelemetryIT {
         String applicationUrl = BasicRuntimeIT.getApplicationUrl();
 
         final HttpClient client = BasicRuntimeIT.getHttpClient();
-        final HttpRequest implicit = HttpRequest.newBuilder().uri(new URI(applicationUrl + "/implicit-trace")).GET().build();
+        final HttpRequest implicit = HttpRequest.newBuilder().uri(new URI(applicationUrl + "/rest/implicit-trace")).GET().build();
         assertEquals(200, client.send(implicit, HttpResponse.BodyHandlers.ofString()).statusCode());
     }
 
@@ -41,7 +41,7 @@ public class OpenTelemetryIT {
         String applicationUrl = BasicRuntimeIT.getApplicationUrl();
 
         final HttpClient client = BasicRuntimeIT.getHttpClient();
-        final HttpRequest implicit = HttpRequest.newBuilder().uri(new URI(applicationUrl + "/explicit-trace")).GET().build();
+        final HttpRequest implicit = HttpRequest.newBuilder().uri(new URI(applicationUrl + "/rest/explicit-trace")).GET().build();
         assertEquals(200, client.send(implicit, HttpResponse.BodyHandlers.ofString()).statusCode());
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19449

Linked Issue: https://issues.redhat.com/browse/WFLY-19075