### PR TITLE
 [WFLY-19467] ejb-timer Quickstarts should have a root webpage similar to helloworld

### DIFF
--- a/ejb-timer/src/main/webapp/index.html
+++ b/ejb-timer/src/main/webapp/index.html
@@ -18,12 +18,13 @@
     <head><title>ejb-timer Quickstart</title></head>
 
     <body>
+    <div style="text-align:center">
 
-      	<h1>ejb-timer Quickstart</h1>
-    	  <h2>What is it?</h2>
+        <h1>Hello There! Welcome to WildFly!</h1>
+        <h2>The ejb-timer Quickstart has been deployed and running successfully.</h2>
+    	  <h2>What is ejb-timer quickstart?</h2>
     	  <p>
-    	      The <i>ejb-timer</i> quickstart demonstrates how to use the EJB timer service in
-            Red Hat JBoss Enterprise Application Platform.
+    	      The <i>ejb-timer</i> quickstart demonstrates how to use the EJB timer service in WildFly.
             It creates a timer service that uses the <b>@Schedule</b> and <b>@Timeout</b> annotations.
     	  </p>
         <p>
@@ -32,14 +33,15 @@
         <h2>Access the Application</h2>
         <p>
             This example application is not intended to be opened in a browser.
-            Instead, the EJB Timer service outputs messages to the JBoss EAP server console.
-            View the EJB Timer message in the JBoss EAP server log or Console window.
+            Instead, the EJB timer service outputs messages to the WildFly server console.
+            View the EJB timer message in the WildFly server log or Console window.
         </p>
 
         <h2>Additional Information</h2>
         <p>
             Additional information can be found in the README file at the root of this quickstart directory.
         </p>
+    </div>
     </body>
 
 </html>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19467

Linked Issue: https://issues.redhat.com/browse/WFLY-19075