### PR TITLE
[WFLY-19882] bumps Quickstart READMEs build requirements to Java SE 1…

### DIFF
--- a/shared-doc/attributes.adoc
+++ b/shared-doc/attributes.adoc
@@ -136,7 +136,7 @@ endif::[]
 //*************************
 // Other values
 //*************************
-:buildRequirements: Java 11.0 (Java SDK 11) or later and Maven 3.6.0 or later
+:buildRequirements: Java SE 17.0 or later, and Maven 3.6.0 or later
 :jbdsEapServerName: Red Hat JBoss Enterprise Application Platform 7.3
 :javaVersion: Jakarta EE 10
 ifdef::EAPXPRelease[]


### PR DESCRIPTION
…7, from 11
Issue: https://github.com/emmartins/quickstart/pull/new/WFLY-19882