### PR TITLE
[WFLY-19892] moves Quickstarts Maven projects to Java SE 17

### DIFF
--- a/batch-processing/pom.xml
+++ b/batch-processing/pom.xml
@@ -44,6 +44,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/bmt/pom.xml
+++ b/bmt/pom.xml
@@ -44,6 +44,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/cmt/pom.xml
+++ b/cmt/pom.xml
@@ -43,6 +43,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/ee-security/pom.xml
+++ b/ee-security/pom.xml
@@ -44,9 +44,11 @@
     </licenses>
 
     <properties>
-        <!-- Version for the server -->
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>

--- a/ejb-multi-server/pom.xml
+++ b/ejb-multi-server/pom.xml
@@ -46,9 +46,11 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Dependencies and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>

--- a/ejb-remote/pom.xml
+++ b/ejb-remote/pom.xml
@@ -43,9 +43,11 @@
     </licenses>
 
     <properties>
-        <!-- Version for the server -->
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>

--- a/ejb-security-context-propagation/pom.xml
+++ b/ejb-security-context-propagation/pom.xml
@@ -43,9 +43,11 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Dependencies and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>

--- a/ejb-security-programmatic-auth/pom.xml
+++ b/ejb-security-programmatic-auth/pom.xml
@@ -43,11 +43,13 @@
     </licenses>
 
     <properties>
-      <!-- the version for the Server -->
-      <version.server>34.0.0.Final</version.server>
-      <!-- The versions for BOMs, Packs and Plugins -->
-      <version.bom.ee>${version.server}</version.bom.ee>
-      <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- the version for the Server -->
+        <version.server>34.0.0.Final</version.server>
+        <!-- the versions for BOMs, Packs and Plugins -->
+        <version.bom.ee>${version.server}</version.bom.ee>
+        <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>
 
     <dependencyManagement>

--- a/ejb-throws-exception/pom.xml
+++ b/ejb-throws-exception/pom.xml
@@ -50,9 +50,11 @@
     </modules>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Dependencies and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>

--- a/ejb-timer/pom.xml
+++ b/ejb-timer/pom.xml
@@ -43,8 +43,11 @@
     </licenses>
 
     <properties>
-        <!-- The versions for BOMs, Dependencies and Plugins -->
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>

--- a/ejb-txn-remote-call/client/pom.xml
+++ b/ejb-txn-remote-call/client/pom.xml
@@ -28,7 +28,6 @@
         <version>8</version>
         <relativePath/>
     </parent>
-<!-- Temp: Trigger CI -->
 
     <artifactId>ejb-txn-remote-call-client</artifactId>
     <version>35.0.0.Beta1-SNAPSHOT</version>
@@ -37,11 +36,14 @@
     <description>The project is the application to be deployed on the client server to call the second server</description>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
+        <!-- the versions for other Dependencies and Plugins -->
         <version.postgresql>42.7.0</version.postgresql>
     </properties>
 

--- a/ejb-txn-remote-call/pom.xml
+++ b/ejb-txn-remote-call/pom.xml
@@ -28,7 +28,6 @@
         <version>8</version>
         <relativePath/>
     </parent>
-<!-- Temp: Trigger CI -->
     <artifactId>ejb-txn-remote-call</artifactId>
     <version>35.0.0.Beta1-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -50,6 +49,11 @@
         <!-- application for the second server, the server which is callee and receives the remote call -->
         <module>server</module>
     </modules>
+
+    <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
 
     <repositories>
         <repository>

--- a/ejb-txn-remote-call/server/pom.xml
+++ b/ejb-txn-remote-call/server/pom.xml
@@ -28,7 +28,6 @@
         <version>8</version>
         <relativePath/>
     </parent>
-<!-- Temp: Trigger CI -->
 
     <artifactId>ejb-txn-remote-call-server</artifactId>
     <version>35.0.0.Beta1-SNAPSHOT</version>
@@ -39,10 +38,11 @@
     <properties>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
-        <version.narayana>7.0.0.Final</version.narayana>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
+        <!-- the versions for other Dependencies and Plugins -->
+        <version.narayana>7.0.0.Final</version.narayana>
     </properties>
 
     <repositories>

--- a/ha-singleton-deployment/pom.xml
+++ b/ha-singleton-deployment/pom.xml
@@ -50,12 +50,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
-        <version.pack.cloud>7.0.0.Final</version.pack.cloud>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
+        <!-- the versions for other Dependencies and Plugins -->
         <version.junit-jupiter>5.10.0</version.junit-jupiter>
     </properties>
 

--- a/ha-singleton-service/pom.xml
+++ b/ha-singleton-service/pom.xml
@@ -45,12 +45,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
-        <version.pack.cloud>7.0.0.Final</version.pack.cloud>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
+        <!-- the versions for other Dependencies and Plugins -->
         <version.junit-jupiter>5.10.0</version.junit-jupiter>
     </properties>
 

--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -43,12 +43,15 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.pack.cloud>7.0.2.Final</version.pack.cloud>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
+        <!-- the versions for other Dependencies and Plugins -->
         <version.junit-jupiter-engine>5.10.0</version.junit-jupiter-engine>
     </properties>
 

--- a/helloworld-mdb/pom.xml
+++ b/helloworld-mdb/pom.xml
@@ -44,11 +44,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>      
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
+        <!-- the versions for other Dependencies and Plugins -->
         <version.junit-jupiter-engine>5.10.0</version.junit-jupiter-engine>
     </properties>
 

--- a/helloworld-mutual-ssl-secured/pom.xml
+++ b/helloworld-mutual-ssl-secured/pom.xml
@@ -44,11 +44,12 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
-        <version.pack.cloud>7.0.0.Final</version.pack.cloud>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>
 

--- a/helloworld-mutual-ssl/pom.xml
+++ b/helloworld-mutual-ssl/pom.xml
@@ -31,11 +31,12 @@
     </parent>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
-        <version.pack.cloud>7.0.0.Final</version.pack.cloud>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>
 

--- a/helloworld-singleton/pom.xml
+++ b/helloworld-singleton/pom.xml
@@ -44,6 +44,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/helloworld-ws/pom.xml
+++ b/helloworld-ws/pom.xml
@@ -43,6 +43,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -43,6 +43,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/hibernate/pom.xml
+++ b/hibernate/pom.xml
@@ -44,12 +44,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-        <!-- the versions for test dependencies -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
     </properties>
 

--- a/http-custom-mechanism/pom.xml
+++ b/http-custom-mechanism/pom.xml
@@ -49,9 +49,11 @@
     </modules>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>

--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -44,21 +44,18 @@
     </licenses>
 
     <properties>
-        <!-- The server version -->
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Dependencies and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-
+        <!-- the versions for other Dependencies and Plugins -->
         <version.com.nimbusds.jose.jwt>9.37.1</version.com.nimbusds.jose.jwt>
         <version.org.junit>5.10.1</version.org.junit>
-
         <!-- Configuration settings -->
         <jboss.home>${project.build.directory}/server</jboss.home>
-
-        <!-- These settings can be removed when the parent is upgraded to 6 -->
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
     </properties>
 
     <dependencyManagement>

--- a/jaxrs-jwt/pom.xml
+++ b/jaxrs-jwt/pom.xml
@@ -43,21 +43,18 @@
     </licenses>
 
     <properties>
-        <!-- The server version -->
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- the server version -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Dependencies and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-
+        <!-- the versions for other Dependencies and Plugins -->
         <version.com.nimbusds.jose.jwt>9.37.1</version.com.nimbusds.jose.jwt>
         <version.org.junit>5.10.1</version.org.junit>
-
         <!-- Configuration settings -->
         <jboss.home>${project.build.directory}/server</jboss.home>
-
-        <!-- These settings can be removed when the parent is upgraded to 6 -->
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
     </properties>
 
     <dependencyManagement>

--- a/jaxws-ejb/pom.xml
+++ b/jaxws-ejb/pom.xml
@@ -43,6 +43,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/jaxws-retail/pom.xml
+++ b/jaxws-retail/pom.xml
@@ -42,12 +42,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-        <!-- The versions for BOMs, Dependencies and Plugins -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.jaxws-tools-maven-plugin>1.3.0.Final</version.jaxws-tools-maven-plugin>
 
     </properties>

--- a/jsonp/pom.xml
+++ b/jsonp/pom.xml
@@ -43,6 +43,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -43,7 +43,9 @@
     </licenses>
 
     <properties>
-        <!-- The compatible WildFly version -->
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- The versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -51,8 +51,11 @@
     </modules>
 
     <properties>
-        <!-- The versions for BOMs, Dependencies and Plugins -->
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
+        <!-- the versions for BOMs, Dependencies and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -43,6 +43,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -43,20 +43,17 @@
     </licenses>
 
     <properties>
-        <!-- The server version -->
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- The version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Dependencies and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-
+        <!-- the versions for other Dependencies and Plugins -->
         <version.org.junit>5.10.1</version.org.junit>
-
-        <!-- Configuration settings -->
+        <!-- Project configuration settings -->
         <jboss.home>${project.build.directory}/server</jboss.home>
-
-        <!-- These settings can be removed when the parent is upgraded to 6 -->
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
     </properties>
 
     <dependencyManagement>

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -44,12 +44,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-
+        <!-- the versions for other Dependencies and Plugins -->
         <version.org.seleniumhq.selenium>4.15.0</version.org.seleniumhq.selenium>
         <version.webdrivermanager>5.7.0</version.webdrivermanager>
     </properties>

--- a/messaging-clustering-singleton/pom.xml
+++ b/messaging-clustering-singleton/pom.xml
@@ -43,11 +43,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
+        <!-- the versions for other Dependencies and Plugins -->
         <version.junit-jupiter-engine>5.10.0</version.junit-jupiter-engine>
     </properties>
 

--- a/micrometer/pom.xml
+++ b/micrometer/pom.xml
@@ -21,9 +21,11 @@
     <name>Quickstart: micrometer</name>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for the BOMs, Packs and Plugins -->
+        <!-- the versions for the BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.bom.expansion>${version.server}</version.bom.expansion>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>

--- a/microprofile-config/pom.xml
+++ b/microprofile-config/pom.xml
@@ -19,9 +19,11 @@
     <name>Quickstart: microprofile-config</name>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for the BOMs, Packs and Plugins -->
+        <!-- the versions for the BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.bom.expansion>${version.server}</version.bom.expansion>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>

--- a/microprofile-fault-tolerance/README-source.adoc
+++ b/microprofile-fault-tolerance/README-source.adoc
@@ -82,12 +82,11 @@ Add the following properties to the `pom.xml`:
 <version.bom.ee>{versionServerBom}</version.bom.ee>
 ----
 
-Also the project can be updated to use Java 8 as the minimum:
+Also the project can be updated to use Java 17 as the minimum:
 
 [source,options="nowrap"]
 ----
-<maven.compiler.source>1.8</maven.compiler.source>
-<maven.compiler.target>1.8</maven.compiler.target>
+<maven.compiler.release>17</maven.compiler.release>
 ----
 
 Before the dependencies are defined add the following boms:

--- a/microprofile-fault-tolerance/pom.xml
+++ b/microprofile-fault-tolerance/pom.xml
@@ -52,13 +52,15 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for the BOMs, Packs and Plugins -->
+        <!-- the versions for the BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.bom.expansion>${version.server}</version.bom.expansion>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-        <!-- The versions for other dependencies and plugin -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.io.rest-assured>4.3.1</version.io.rest-assured>
     </properties>
 

--- a/microprofile-health/pom.xml
+++ b/microprofile-health/pom.xml
@@ -18,9 +18,11 @@
     <name>Quickstart: microprofile-health</name>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.bom.expansion>${version.server}</version.bom.expansion>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>

--- a/microprofile-jwt/README-source.adoc
+++ b/microprofile-jwt/README-source.adoc
@@ -172,12 +172,11 @@ Add the following properties to the `pom.xml`.
 <version.bom.ee>{versionServerBom}</version.bom.ee>
 ----
 
-Also the project can be updated to use Java 11 as the minimum.
+Also the project can be updated to use Java 17 as the minimum.
 
 [source,options="nowrap"]
 ----
-<maven.compiler.source>11</maven.compiler.source>
-<maven.compiler.target>11</maven.compiler.target>
+<maven.compiler.release>17</maven.compiler.release>
 ----
 
 Before the dependencies are defined add the following boms.

--- a/microprofile-jwt/pom.xml
+++ b/microprofile-jwt/pom.xml
@@ -43,13 +43,15 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.bom.expansion>${version.server}</version.bom.expansion>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-        <!-- The versions for other dependencies and plugin -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.com.nimbusds.jose-jwt>9.24.4.redhat-00001</version.com.nimbusds.jose-jwt>
         <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>
     </properties>

--- a/microprofile-lra/README-source.adoc
+++ b/microprofile-lra/README-source.adoc
@@ -186,20 +186,18 @@ Open the project in your favourite IDE.
 
 Open the generated `pom.xml`.
 
-The first thing to do is to change the minimum JDK to Java 11 and set the other relevant version properties:
+The first thing to do is to change the minimum JDK to Java 17 and set the other relevant version properties:
 
 [source,xml,subs="attributes+"]
 ----
-<maven.compiler.source>11</maven.compiler.source>
-<maven.compiler.target>11</maven.compiler.target>
-
+<!-- the Maven project should use the minimum Java SE version supported -->
+<maven.compiler.release>17</maven.compiler.release>
 <!-- the version for the Server -->
 <version.server>{versionServer}</version.server>
-<!-- The versions for the BOMs, Packs and Plugins -->
+<!-- the versions for the BOMs, Packs and Plugins -->
 <version.bom.ee>{versionBomEE}</version.bom.ee>
 <version.bom.expansion>{versionBomMicroprofile}</version.bom.expansion>
 <version.plugin.wildfly>{versionPluginWildfly}</version.plugin.wildfly>
-<version.plugin.wildfly-jar>{versionPluginWildflyJar}</version.plugin.wildfly-jar>
 ----
 
 Next we need to setup our dependencies. Add the following section to your

--- a/microprofile-lra/pom.xml
+++ b/microprofile-lra/pom.xml
@@ -18,9 +18,11 @@
     <name>Quickstart: microprofile-lra</name>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for the BOMs, Packs and Plugins -->
+        <!-- the versions for the BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.bom.expansion>${version.server}</version.bom.expansion>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>

--- a/microprofile-openapi/pom.xml
+++ b/microprofile-openapi/pom.xml
@@ -20,9 +20,11 @@
     <name>Quickstart: microprofile-openapi</name>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for the BOMs, Packs and Plugins -->
+        <!-- the versions for the BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.bom.expansion>${version.server}</version.bom.expansion>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>

--- a/microprofile-reactive-messaging-kafka/README-source.adoc
+++ b/microprofile-reactive-messaging-kafka/README-source.adoc
@@ -76,12 +76,11 @@ cd microprofile-reactive-messaging-kafka
 
 Open the project in your favourite IDE.
 
-The project needs to be updated to use Java 8 as the minimum:
+The project needs to be updated to use Java 17 as the minimum:
 
 [source,options="nowrap"]
 ----
-<maven.compiler.source>1.8</maven.compiler.source>
-<maven.compiler.target>1.8</maven.compiler.target>
+<maven.compiler.release>17</maven.compiler.release>
 ----
 
 Next set up our dependencies. Add the following section to your

--- a/microprofile-reactive-messaging-kafka/pom.xml
+++ b/microprofile-reactive-messaging-kafka/pom.xml
@@ -35,13 +35,15 @@
     <name>Quickstart: microprofile-reactive-messaging-kafka</name>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.bom.expansion>${version.server}</version.bom.expansion>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-        <!-- The versions for other Dependencies and Plugins -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.io.smallrye-config>3.0.0</version.io.smallrye-config>
         <version.org.jboss.resteasy.microprofile.rest-client>2.0.0.Final</version.org.jboss.resteasy.microprofile.rest-client>
     </properties>

--- a/microprofile-rest-client/pom.xml
+++ b/microprofile-rest-client/pom.xml
@@ -41,23 +41,20 @@
     </licenses>
 
     <properties>
-        <!-- The server version -->
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Dependencies and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.bom.expansion>${version.server}</version.bom.expansion>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-        <!-- The versions for other Dependencies and Plugins -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.org.jboss.resteasy>6.2.6.Final</version.org.jboss.resteasy>
         <version.org.junit>5.10.1</version.org.junit>
-
         <!-- Configuration settings -->
         <jboss.home>${project.build.directory}/server</jboss.home>
         <server.host>http://localhost:8080/microprofile-rest-client</server.host>
-
-        <!-- These settings can be removed when the parent is upgraded to 6 -->
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
     </properties>
 
     <dependencyManagement>

--- a/numberguess/pom.xml
+++ b/numberguess/pom.xml
@@ -43,6 +43,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/opentelemetry-tracing/pom.xml
+++ b/opentelemetry-tracing/pom.xml
@@ -19,9 +19,11 @@
     <name>Quickstart: opentelemetry-tracing</name>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for the BOMs, Packs and Plugins -->
+        <!-- the versions for the BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.bom.expansion>${version.server}</version.bom.expansion>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,8 @@
             filtered resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <linkXRef>false</linkXRef>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <build>
@@ -284,21 +286,13 @@
                 <module>servlet-async</module>
                 <module>servlet-filterlistener</module>
                 <module>servlet-security</module>
+                <module>spring-resteasy</module>
                 <module>tasks-jsf</module>
                 <module>temperature-converter</module>
                 <module>todo-backend</module>
                 <module>thread-racing</module>
                 <module>websocket-endpoint</module>
                 <module>websocket-hello</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>jdk-17-required</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <modules>
-                <module>spring-resteasy</module>
             </modules>
         </profile>
         <profile>

--- a/remote-helloworld-mdb/pom.xml
+++ b/remote-helloworld-mdb/pom.xml
@@ -44,11 +44,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
+        <!-- the versions for other Dependencies and Plugins -->
         <version.junit-jupiter-engine>5.10.0</version.junit-jupiter-engine>
     </properties>
 

--- a/security-domain-to-domain/pom.xml
+++ b/security-domain-to-domain/pom.xml
@@ -51,11 +51,12 @@
     </modules>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
-        <version.pack.cloud>7.0.0.Final</version.pack.cloud>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>
 

--- a/servlet-async/pom.xml
+++ b/servlet-async/pom.xml
@@ -44,12 +44,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-        <!-- the versions for test dependencies -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
     </properties>
 

--- a/servlet-filterlistener/pom.xml
+++ b/servlet-filterlistener/pom.xml
@@ -44,12 +44,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-        <!-- the versions for test dependencies -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
     </properties>
 

--- a/servlet-security/pom.xml
+++ b/servlet-security/pom.xml
@@ -44,12 +44,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-        <!-- the versions for test dependencies -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
     </properties>
 

--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -44,17 +44,14 @@
     </licenses>
 
     <properties>
-        <!-- Spring 6 requires Java 17 -->
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
-
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-
-        <!-- The versions for other Dependencies and Plugins -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.spring.framework>6.0.4</version.spring.framework>
     </properties>
 

--- a/tasks-jsf/pom.xml
+++ b/tasks-jsf/pom.xml
@@ -44,13 +44,16 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.pack.cloud>7.0.0.Final</version.pack.cloud>
         <version.pack.datasources>8.0.0.Final</version.pack.datasources>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-        <!-- the versions for test dependencies -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
     </properties>
 

--- a/temperature-converter/pom.xml
+++ b/temperature-converter/pom.xml
@@ -44,6 +44,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/thread-racing/pom.xml
+++ b/thread-racing/pom.xml
@@ -44,6 +44,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->

--- a/todo-backend/pom.xml
+++ b/todo-backend/pom.xml
@@ -44,9 +44,11 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
-        <!-- The versions for BOMs, Packs and Plugins -->
+        <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
     </properties>

--- a/websocket-endpoint/pom.xml
+++ b/websocket-endpoint/pom.xml
@@ -44,12 +44,14 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.0.0.Final</version.plugin.wildfly>
-        <!-- the versions for test dependencies -->
+        <!-- the versions for other Dependencies and Plugins -->
         <version.org.junit.jupiter>5.9.1</version.org.junit.jupiter>
         <version.org.eclipse.parsson>1.1.5</version.org.eclipse.parsson>
     </properties>

--- a/websocket-hello/pom.xml
+++ b/websocket-hello/pom.xml
@@ -44,6 +44,8 @@
     </licenses>
 
     <properties>
+        <!-- the Maven project should use the minimum Java SE version supported -->
+        <maven.compiler.release>17</maven.compiler.release>
         <!-- the version for the Server -->
         <version.server>34.0.0.Final</version.server>
         <!-- the versions for BOMs, Packs and Plugins -->


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-19892

Please note that this PR also syncs all QS project properties names and comments, and fixes a few outstanding issues related with Java SE move to 17.