### PR TITLE
[WFLY-19947]:Upgrade jaxws-tools plugin to 1.3.1.Final to fix the wro…

### DIFF
--- a/jaxws-retail/pom.xml
+++ b/jaxws-retail/pom.xml
@@ -50,7 +50,7 @@
         <version.bom.ee>${version.server}</version.bom.ee>
         <version.plugin.wildfly>5.1.0.Beta2</version.plugin.wildfly>
         <!-- the versions for other Dependencies and Plugins -->
-        <version.jaxws-tools-maven-plugin>1.3.0.Final</version.jaxws-tools-maven-plugin>
+        <version.jaxws-tools-maven-plugin>1.3.1.Final</version.jaxws-tools-maven-plugin>
 
     </properties>
 


### PR DESCRIPTION
…ng warning level message in jaxws retail quickstart
Issue: https://issues.redhat.com/browse/WFLY-19947