### PR TITLE
[WFLY-20153] Add missing wildfly-maven-plugin configuration

### DIFF
--- a/jta-crash-rec/pom.xml
+++ b/jta-crash-rec/pom.xml
@@ -49,6 +49,7 @@
         <version.server>35.0.0.Beta1</version.server>
         <!-- The versions for BOMs, Packs and Plugins -->
         <version.bom.ee>${version.server}</version.bom.ee>
+        <version.plugin.wildfly>5.1.0.Beta2</version.plugin.wildfly>
     </properties>
 
     <dependencyManagement>
@@ -128,6 +129,15 @@
     <build>
         <!-- Set the name of the WAR, used as the context root when the app is deployed. -->
         <finalName>${project.artifactId}</finalName>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.wildfly.plugins</groupId>
+                    <artifactId>wildfly-maven-plugin</artifactId>
+                    <version>${version.plugin.wildfly}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20153

With this pluginManagement configuration, maven can again resolve `wildfly:deploy` goal