### PR TITLE
[WFLY-20447] Fix mistakes in "http custom mechanism" readme

### DIFF
--- a/http-custom-mechanism/README-source.adoc
+++ b/http-custom-mechanism/README-source.adoc
@@ -105,7 +105,7 @@ $ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=add-custom-module.cli
 
 NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat` script.
 
-This creates the custom `__{jbossHomeName}__/modules/modules/org/jboss/as/quickstart/http_custom_mechanism/main` folder, then copies in the `custom-module/target/custom-module.jar` file and creates the required `module.xml` file.
+This creates the custom `__{jbossHomeName}__/modules/org/jboss/as/quickstart/http_custom_mechanism/main` folder, then copies in the `custom-module/target/custom-module.jar` file and creates the required `module.xml` file.
 
 You can verify the module structure in your file manager.
 
@@ -223,7 +223,7 @@ include::../shared-doc/run-integration-tests-with-server-distribution.adoc[level
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Restore the {productName} Standalone Server Configuration Manually
 :restoreScriptName: restore-configuration.cli
-include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
+include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=+2]
 
 // Additional information about this script
 This script reverts the changes made to the `undertow`  and `elytron` subsystems. You should see the following result when you run the script.
@@ -233,9 +233,18 @@ This script reverts the changes made to the `undertow`  and `elytron` subsystems
 The batch executed successfully
 process-state: reload-required
 ----
+// removing the custom module
+And finally, to remove the custom module, run the following command, replacing `__{jbossHomeName}__` with the path to your server.
+[source,subs="+quotes,attributes+",options="nowrap"]
+----
+$ __{jbossHomeName}__/bin/jboss-cli.sh --connect --file=remove-custom-module.cli
+----
+
+NOTE: For Windows, use the `__{jbossHomeName}__\bin\jboss-cli.bat` script.
+
 
 // Restore the {productName} Standalone Server Configuration Manually
-include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
+include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+3]
 
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-20447

While going through this quickstart I probably found some mistakes in the readme.
- wrong path (.../modules/modules/...)
- one section is copy pasted and is twice in the text
- no mention of the restoring scripts

Also bit off topic, but how exactly does the password validation work for the custom mechanism, given that `X-PASSWORD` could be anything and response is still OK (200) (unlike the `X-USERNAME`)