### PR TITLE
[WFLY-20130]: helloworld-jms logs missing.

### DIFF
--- a/helloworld-jms/pom.xml
+++ b/helloworld-jms/pom.xml
@@ -117,19 +117,15 @@
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
                         <configuration>
-                            <feature-packs>
-                                <feature-pack>
-                                    <location>org.wildfly:wildfly-galleon-pack:${version.server}</location>
-                                </feature-pack>
-                                <feature-pack>
-                                    <location>org.wildfly.cloud:wildfly-cloud-galleon-pack:${version.pack.cloud}</location>
-                                </feature-pack>
-                            </feature-packs>
-                            <layers>
-                                <layer>cloud-server</layer>
-                                <layer>ejb</layer>
-                                <layer>embedded-activemq</layer>
-                            </layers>
+                            <discover-provisioning-info>
+                                <layersForJndi>
+                                    <layer>embedded-activemq</layer>
+                                </layersForJndi>
+                                <addOns>
+                                    <addOn>wildfly-cli</addOn>
+                                </addOns>
+                                <version>${version.server}</version>
+                            </discover-provisioning-info>
                             <packaging-scripts>
                                 <packaging-script>
                                     <scripts>


### PR DESCRIPTION
Fixing the helloworld-jms quickstart to use Glow.
Issue: https://issues.redhat.com/browse/WFLY-20130