### PR TITLE
Sync dependabot config with wildfly/wildfly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,26 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+registries:
+  maven-central:
+    type: maven-repository
+    url: https://repo.maven.apache.org/maven2/
+  jboss-public-repository-group:
+    type: maven-repository
+    url: https://repository.jboss.org/nexus/content/groups/public/
 updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Only allow for patch release upgrades
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major', 'version-update:semver-minor']
+    open-pull-requests-limit: 10
+    registries:
+      - maven-central
+      - jboss-public-repository-group
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`


### PR DESCRIPTION
Syncing the dependabot config with wildfly/wildfly... 
A couple of changes specific to this repo:
* maven dep updates scanning should be done on all dirs, not just /
* wildfly/wildfly specific ignores removed