### PR TITLE
[WFLY-20915] Remove bitnami's postgresql Helm Chart

### DIFF
--- a/todo-backend/README.adoc
+++ b/todo-backend/README.adoc
@@ -514,28 +514,17 @@ ifdef::helm-install-prerequisites-openshift[]
 [[deploy_helm_prerequisites]]
 :leveloffset: +1
 
-ifndef::ProductRelease[]
-Add the bitnami repository which provides an helm chart for PostgreSQL:
-[source,options="nowrap"]
-----
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-"bitnami" has been added to your repositories
-----
-
 The Helm Chart for this quickstart contains all the information to build an image from the source code using S2I and install it with the database:
 
 [source,options="nowrap"]
 ----
 dependencies:
-    - name: postgresql
-      repository: https://charts.bitnami.com/bitnami
-      version: ...
     - name: wildfly
       repository: http://docs.wildfly.org/wildfly-charts/
       version: ...
 ----
 
-So we need to update the dependecies of our Helm Chart.
+So we need to update the dependencies of our Helm Chart.
 
 [source,options="nowrap",subs="+attributes"]
 ----
@@ -636,11 +625,7 @@ name: todo-backend-chart
 description: A Helm chart to deploy a WildFly todo-backend application and its Postgresql database
 type: application
 version: 1.0.0
-appVersion: 31.0.0.Final
 dependencies:
-    - name: postgresql
-      repository: https://charts.bitnami.com/bitnami
-      version: 16.2.2
     - name: wildfly
       repository: http://docs.wildfly.org/wildfly-charts/
       version: 2.3.2
@@ -1031,28 +1016,17 @@ ifdef::helm-install-prerequisites-kubernetes[]
 [[deploy_helm_prerequisites]]
 :leveloffset: +1
 
-ifndef::ProductRelease[]
-Add the bitnami repository which provides an helm chart for PostgreSQL:
-[source,options="nowrap"]
-----
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-"bitnami" has been added to your repositories
-----
-
 The Helm Chart for this quickstart contains all the information to build an image from the source code using S2I and install it with the database:
 
 [source,options="nowrap"]
 ----
 dependencies:
-    - name: postgresql
-      repository: https://charts.bitnami.com/bitnami
-      version: ...
     - name: wildfly
       repository: http://docs.wildfly.org/wildfly-charts/
       version: ...
 ----
 
-So we need to update the dependecies of our Helm Chart.
+So we need to update the dependencies of our Helm Chart.
 
 [source,options="nowrap",subs="+attributes"]
 ----
@@ -1153,11 +1127,7 @@ name: todo-backend-chart
 description: A Helm chart to deploy a WildFly todo-backend application and its Postgresql database
 type: application
 version: 1.0.0
-appVersion: 31.0.0.Final
 dependencies:
-    - name: postgresql
-      repository: https://charts.bitnami.com/bitnami
-      version: 16.2.2
     - name: wildfly
       repository: http://docs.wildfly.org/wildfly-charts/
       version: 2.3.2

--- a/todo-backend/additional-readme-cloud.adoc
+++ b/todo-backend/additional-readme-cloud.adoc
@@ -20,14 +20,15 @@ For {additional-readme-cloud-platform}, we rely on secrets so that the credentia
 deploy:
   env:
     - name: POSTGRESQL_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          key: database-password
-          name: todo-backend-db
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: postgres-configmap
+              key: POSTGRES_PASSWORD
 ----
 
-When the application is deployed, the value for the `POSTGRESQL_PASSWORD` will be taken from the key `database-password`
-in the secret `todo-backend-db`.
+When the application is deployed, the value for the `POSTGRESQL_PASSWORD` will be taken from the key `POSTGRES_PASSWORD`
+in the secret `postgres-configmap`.
 
 ifdef::additional-readme-openshift[]
 == Use the todobackend Web Frontend

--- a/todo-backend/charts/Chart.yaml
+++ b/todo-backend/charts/Chart.yaml
@@ -3,11 +3,7 @@ name: todo-backend-chart
 description: A Helm chart to deploy a WildFly todo-backend application and its Postgresql database
 type: application
 version: 1.0.0
-appVersion: 31.0.0.Final
 dependencies:
-    - name: postgresql
-      repository: https://charts.bitnami.com/bitnami
-      version: 16.2.2
     - name: wildfly
       repository: http://docs.wildfly.org/wildfly-charts/
       version: 2.3.2

--- a/todo-backend/charts/templates/postgres-configmap.yaml
+++ b/todo-backend/charts/templates/postgres-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-configmap
+  labels:
+    app: postgres
+data:
+  POSTGRES_DB: {{ .Values.db.database }}
+  POSTGRES_USER: {{ .Values.db.username }}
+  POSTGRES_PASSWORD: {{ .Values.db.password }}
+  PGDATA: /var/lib/postgresql/data/pgdata

--- a/todo-backend/charts/templates/postgres.yaml
+++ b/todo-backend/charts/templates/postgres.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: todo-backend-postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: todo-backend-postgresql
+  template:
+    metadata:
+      labels:
+        app: todo-backend-postgresql
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17
+          ports:
+            - containerPort: 5432
+              name: postgres
+          envFrom:
+            - configMapRef:
+                name: postgres-configmap
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: pgdata
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: todo-backend-postgresql
+spec:
+  ports:
+    - port: 5432
+      targetPort: postgres
+  selector:
+    app: todo-backend-postgresql

--- a/todo-backend/charts/values.yaml
+++ b/todo-backend/charts/values.yaml
@@ -2,24 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-postgresql:
-  image:
-    repository: bitnami/postgresql
-    tag: 17
-  auth:
-    username: todos-db
-    password: todos-db
-    database: todos-db
-  architecture: "standalone"
-  primary:
-    podSecurityContext:
-      enabled: false
-      fsGroup: "auto"
-    containerSecurityContext:
-      enabled: false
-      runAsUser: "auto"
-      runAsGroup: ""
-
+db:
+  username: todos-db
+  password: todos-db
+  database: todos-db
 
 wildfly:
     build:
@@ -31,11 +17,20 @@ wildfly:
       env:
         # Env vars to connect to PostgreSQL DB
         - name: POSTGRESQL_DATABASE
-          value: todos-db
+          valueFrom:
+            configMapKeyRef:
+              name: postgres-configmap
+              key: POSTGRES_DB
         - name: POSTGRESQL_USER
-          value: todos-db
+          valueFrom:
+            configMapKeyRef:
+              name: postgres-configmap
+              key: POSTGRES_USER
         - name: POSTGRESQL_PASSWORD
-          value: todos-db
+          valueFrom:
+            configMapKeyRef:
+              name: postgres-configmap
+              key: POSTGRES_PASSWORD
         - name: POSTGRESQL_DATASOURCE
           value: ToDos
         - name: POSTGRESQL_SERVICE_HOST

--- a/todo-backend/helm-install-prerequisites.adoc
+++ b/todo-backend/helm-install-prerequisites.adoc
@@ -1,25 +1,16 @@
 ifndef::ProductRelease[]
-Add the bitnami repository which provides an helm chart for PostgreSQL:
-[source,options="nowrap"]
-----
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-"bitnami" has been added to your repositories
-----
-
-The Helm Chart for this quickstart contains all the information to build an image from the source code using S2I and install it with the database:
+The Helm Chart for this quickstart contains all the information to build an image from the source code using S2I.
+It also deploys the PostGreSQL database to store the data.
 
 [source,options="nowrap"]
 ----
 dependencies:
-    - name: postgresql
-      repository: https://charts.bitnami.com/bitnami
-      version: ...
     - name: wildfly
       repository: http://docs.wildfly.org/wildfly-charts/
       version: ...
 ----
 
-So we need to update the dependecies of our Helm Chart.
+So we need to update the dependencies of our Helm Chart.
 
 [source,options="nowrap",subs="+attributes"]
 ----


### PR DESCRIPTION
Instead, the DB is deployed directly by the Helm Chart

Update the `wildfly` Helm chart to actually pulls the DB credentials from the config map (as stated in the doc) instead of hard-coding them in the values.yaml file.

This fixes https://issues.redhat.com/browse/WFLY-20915