### PR TITLE
WFLY-20924 - OpenTelemetry Quickstart doesn't function correctly under MicroProfile config

### DIFF
--- a/opentelemetry-tracing/src/main/resources/META-INF/microprofile-config.properties
+++ b/opentelemetry-tracing/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,1 @@
+otel.sdk.disabled=false


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-20924

Add MP Config file to enable otel SDK under MP