### PR TITLE
Update README instructions for product with tech preview glow, and un…

### DIFF
--- a/batch-processing/README-source.adoc
+++ b/batch-processing/README-source.adoc
@@ -140,7 +140,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/bmt/README-source.adoc
+++ b/bmt/README-source.adoc
@@ -59,7 +59,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/cmt/README-source.adoc
+++ b/cmt/README-source.adoc
@@ -85,7 +85,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/ee-security/README-source.adoc
+++ b/ee-security/README-source.adoc
@@ -128,7 +128,4 @@ include::../shared-doc/restore-standalone-server-configuration-manual.adoc[level
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/ejb-timer/README-source.adoc
+++ b/ejb-timer/README-source.adoc
@@ -90,10 +90,7 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]
 
 === Using Timer Service within a cluster
 

--- a/helloworld-mdb/README-source.adoc
+++ b/helloworld-mdb/README-source.adoc
@@ -86,11 +86,7 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]
-
 
 == Clustering
 

--- a/helloworld-rs/README-source.adoc
+++ b/helloworld-rs/README-source.adoc
@@ -42,7 +42,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/helloworld-singleton/README-source.adoc
+++ b/helloworld-singleton/README-source.adoc
@@ -49,7 +49,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/helloworld-ws/README-source.adoc
+++ b/helloworld-ws/README-source.adoc
@@ -57,7 +57,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/helloworld/README-source.adoc
+++ b/helloworld/README-source.adoc
@@ -45,7 +45,4 @@ include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc
 include::../shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc[leveloffset=+1]
 // OpenShift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/hibernate/README-source.adoc
+++ b/hibernate/README-source.adoc
@@ -71,7 +71,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/jaxrs-client/README-source.adoc
+++ b/jaxrs-client/README-source.adoc
@@ -65,7 +65,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/jaxrs-jwt/README-source.adoc
+++ b/jaxrs-jwt/README-source.adoc
@@ -160,7 +160,4 @@ include::../shared-doc/restore-standalone-server-configuration-manual.adoc[level
 
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/jaxws-ejb/README-source.adoc
+++ b/jaxws-ejb/README-source.adoc
@@ -47,7 +47,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/jaxws-retail/README-source.adoc
+++ b/jaxws-retail/README-source.adoc
@@ -41,7 +41,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/jsonp/README-source.adoc
+++ b/jsonp/README-source.adoc
@@ -49,6 +49,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/kitchensink/README-source.adoc
+++ b/kitchensink/README-source.adoc
@@ -136,7 +136,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/logging/README-source.adoc
+++ b/logging/README-source.adoc
@@ -158,7 +158,4 @@ include::../shared-doc/restore-standalone-server-configuration-manual.adoc[level
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/mail/README-source.adoc
+++ b/mail/README-source.adoc
@@ -170,12 +170,5 @@ include::../shared-doc/restore-standalone-server-configuration-manual.adoc[level
 
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
-
-// OpenShift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-
-// Kubernetes
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/micrometer/README-source.adoc
+++ b/micrometer/README-source.adoc
@@ -266,14 +266,9 @@ include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+3]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
-// Bootable JAR
 include::../shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc[leveloffset=+1]
-// OpenShift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]
 == Conclusion
 
 Micrometer provides a de facto standard way of capturing and publishing metrics to the monitoring solution of your choice. {productName} provides a convenient, out-of-the-box integration of Micrometer to make it easier to capture those metrics and monitor your application's health and performance. For more information on Micrometer, please refer to the project's https://micrometer.io[website].

--- a/microprofile-config/README-source.adoc
+++ b/microprofile-config/README-source.adoc
@@ -796,15 +796,9 @@ endpoint using your browser or
 converter. You will see the configured value which is taken from our created
 `MicroProfileCustomValue` object.
 
-// Bootable JAR
 include::../shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc[leveloffset=+1]
-
-// Openshift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]
 
 == Conclusion
 

--- a/microprofile-fault-tolerance/README-source.adoc
+++ b/microprofile-fault-tolerance/README-source.adoc
@@ -618,15 +618,9 @@ include::../shared-doc/run-integration-tests-with-server-distribution.adoc[level
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 
-// Bootable JAR
 include::../shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc[leveloffset=+1]
-
-// OpenShift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]
 
 == Conclusion
 

--- a/microprofile-health/README-source.adoc
+++ b/microprofile-health/README-source.adoc
@@ -449,15 +449,9 @@ error along with the health check response.
         }
 ----
 
-//Bootable JAR
 include::../shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc[leveloffset=+1]
-
-// OpenShift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]
 
 == Conclusion
 

--- a/microprofile-jwt/README-source.adoc
+++ b/microprofile-jwt/README-source.adoc
@@ -691,15 +691,9 @@ $ curl -H "Authorization: Bearer ey..59g" http://localhost:8080/microprofile-jwt
 7 months and 19 days until your next birthday.
 ----
 
-// Bootable JAR
 include::../shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc[leveloffset=+1]
-
-// OpenShift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]
 
 == Conclusion
 

--- a/microprofile-lra/README-source.adoc
+++ b/microprofile-lra/README-source.adoc
@@ -157,15 +157,9 @@ process-state: reload-required
 // Restore the {productName} Standalone Server Configuration Manually
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+2]
 
-//Bootable JAR
 include::../shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc[leveloffset=+1]
-
-// OpenShift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]
 
 [[creating-new-project]]
 == Creating the Maven Project

--- a/microprofile-openapi/README-source.adoc
+++ b/microprofile-openapi/README-source.adoc
@@ -158,12 +158,6 @@ include::../shared-doc/run-integration-tests-with-server-distribution.adoc[level
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
-// Bootable JAR
 include::../shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc[leveloffset=+1]
-
-// OpenShift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/microprofile-reactive-messaging-kafka/README-source.adoc
+++ b/microprofile-reactive-messaging-kafka/README-source.adoc
@@ -1038,10 +1038,7 @@ $ oc delete csv --all -n NAMESPACE
 ----
 NOTE: Replace NAMESPACE above, with the actual name of the namespace used in the namespace-scoped installation.
 
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+2]
-endif::[]
 
 == Conclusion
 

--- a/microprofile-rest-client/README-source.adoc
+++ b/microprofile-rest-client/README-source.adoc
@@ -167,15 +167,9 @@ include::../shared-doc/run-integration-tests-with-server-distribution.adoc[level
 // Undeploy the Quickstart
 include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 
-//Bootable JAR
 include::../shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc[leveloffset=+1]
-// OpenShift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]
-
 
 == Conclusion
 

--- a/numberguess/README-source.adoc
+++ b/numberguess/README-source.adoc
@@ -43,7 +43,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/opentelemetry-tracing/README-source.adoc
+++ b/opentelemetry-tracing/README-source.adoc
@@ -225,14 +225,9 @@ include::../shared-doc/restore-standalone-server-configuration.adoc[leveloffset=
 include::../shared-doc/restore-standalone-server-configuration-manual.adoc[leveloffset=+3]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
-// Bootable JAR
 include::../shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc[leveloffset=+1]
-// OpenShift
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]
 
 == Conclusion
 

--- a/remote-helloworld-mdb/README-source.adoc
+++ b/remote-helloworld-mdb/README-source.adoc
@@ -148,9 +148,4 @@ include::../shared-doc/restore-standalone-server-configuration-manual.adoc[level
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-
-ifndef::ProductRelease,EAPXPRelease[]
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]
-

--- a/servlet-async/README-source.adoc
+++ b/servlet-async/README-source.adoc
@@ -47,7 +47,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/servlet-filterlistener/README-source.adoc
+++ b/servlet-filterlistener/README-source.adoc
@@ -94,7 +94,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/servlet-security/README-source.adoc
+++ b/servlet-security/README-source.adoc
@@ -221,7 +221,4 @@ include::../shared-doc/restore-standalone-server-configuration-manual.adoc[level
 :datasourceJndiName: java:jboss/datasources/ServletSecurityDS
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc
+++ b/shared-doc/build-and-run-the-quickstart-with-bootable-jar.adoc
@@ -58,8 +58,6 @@ ifndef::ProductRelease[]
 endif::[]
 
 ifdef::ProductRelease[]
-ifndef::EAPXPRelease[:featurePackLocation: org.jboss.eap:wildfly-ee-galleon-pack]
-ifdef::EAPXPRelease[:featurePackLocation: org.jboss.eap.xp:wildfly-galleon-pack]
 [source,xml,subs="attributes+"]
 ----
 <profile>
@@ -74,13 +72,6 @@ ifdef::EAPXPRelease[:featurePackLocation: org.jboss.eap.xp:wildfly-galleon-pack]
                 <artifactId>eap-maven-plugin</artifactId>
                 <configuration>
                     ...
-                    <feature-packs>
-                        <feature-pack>
-                            <location>{featurePackLocation}</location>
-                        </feature-pack>
-                        ...
-                    </feature-packs>
-                    <layers>...</layers>
                     <bootable-jar>true</bootable-jar>
                 </configuration>
                 <executions>
@@ -96,6 +87,11 @@ ifdef::EAPXPRelease[:featurePackLocation: org.jboss.eap.xp:wildfly-galleon-pack]
     </build>
 </profile>
 ----
+[NOTE]
+====
+The Glow functionality of the EAP Maven Plugin is Tech Preview.
+====
+
 endif::[]
 
 [NOTE]

--- a/shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc
+++ b/shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc
@@ -6,6 +6,14 @@ endif::helm-app-name[]
 
 [[build_and_run_the_quickstart_on_kubernetes]]
 = Building and running the quickstart application with Kubernetes
+
+ifdef::ProductRelease[]
+[NOTE]
+====
+Building and running this {productName} quickstart with Kubernetes is not supported.
+====
+endif::[]
+
 // The openshift profile
 include::../shared-doc/build-the-quickstart-for-kubernetes.adoc[leveloffset=+1]
 // Getting Started with Helm

--- a/shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc
+++ b/shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc
@@ -21,7 +21,10 @@ endif::deploymentTargetDir[]
 ifndef::extraStartParams[:extraStartParams: ]
 ifndef::extraProvisioningTestParams[:extraProvisioningTestParams: ]
 
-Instead of using a standard {productName} server distribution, you can alternatively provision a {productName} server to deploy and run the quickstart. The functionality is provided by the WildFly Maven Plugin, and you may find its configuration in the quickstart `pom.xml`:
+ifndef::ProductRelease[:mavenPluginName: WildFly]
+ifdef::ProductRelease[:mavenPluginName: EAP]
+
+Instead of using a standard {productName} server distribution, you can alternatively provision a {productName} server to deploy and run the quickstart. The functionality is provided by the {mavenPluginName} Maven Plugin, and you may find its configuration in the quickstart `pom.xml`:
 
 ifndef::ProductRelease[]
 [source,xml,subs="attributes+"]
@@ -58,8 +61,6 @@ ifndef::ProductRelease[]
 endif::[]
 
 ifdef::ProductRelease[]
-ifndef::EAPXPRelease[:featurePackLocation: org.jboss.eap:wildfly-ee-galleon-pack]
-ifdef::EAPXPRelease[:featurePackLocation: org.jboss.eap.xp:wildfly-galleon-pack]
 [source,xml,subs="attributes+"]
 ----
 <profile>
@@ -74,13 +75,6 @@ ifdef::EAPXPRelease[:featurePackLocation: org.jboss.eap.xp:wildfly-galleon-pack]
                 <artifactId>eap-maven-plugin</artifactId>
                 <configuration>
                     ...
-                    <feature-packs>
-                        <feature-pack>
-                            <location>{featurePackLocation}</location>
-                        </feature-pack>
-                        ...
-                    </feature-packs>
-                    <layers>...</layers>
                 </configuration>
                 <executions>
                     <execution>
@@ -95,6 +89,10 @@ ifdef::EAPXPRelease[:featurePackLocation: org.jboss.eap.xp:wildfly-galleon-pack]
     </build>
 </profile>
 ----
+[NOTE]
+====
+The Glow functionality of the EAP Maven Plugin is Tech Preview.
+====
 endif::[]
 
 ifdef::glowWarnsAboutJNDILookups[]

--- a/shared-doc/build-the-quickstart-for-cloud-platform-internal.adoc
+++ b/shared-doc/build-the-quickstart-for-cloud-platform-internal.adoc
@@ -33,8 +33,6 @@ You may note that unlike the `provisioned-server` profile it uses the cloud cont
 endif::[]
 
 ifdef::ProductRelease[]
-ifndef::EAPXPRelease[:featurePackLocation: org.jboss.eap:wildfly-ee-galleon-pack]
-ifdef::EAPXPRelease[:featurePackLocation: org.jboss.eap.xp:wildfly-galleon-pack]
 The server provisioning functionality is provided by the EAP Maven Plugin, and you may find its configuration in the quickstart `pom.xml`:
 [source,xml,subs="attributes+"]
 ----
@@ -46,16 +44,11 @@ The server provisioning functionality is provided by the EAP Maven Plugin, and y
                 <groupId>org.jboss.eap.plugins</groupId>
                 <artifactId>eap-maven-plugin</artifactId>
                 <configuration>
+                    <discover-provisioning-info>
+                        ...
+                        <context>cloud</context>
+                    </discover-provisioning-info>
                     ...
-                    <feature-packs>
-                        <feature-pack>
-                            <location>{featurePackLocation}</location>
-                        </feature-pack>
-                        <feature-pack>
-                            <location>org.jboss.eap.cloud:eap-cloud-galleon-pack</location>
-                        </feature-pack>
-                    </feature-packs>
-                    <layers>...</layers>
                 </configuration>
                 <executions>
                     <execution>
@@ -71,4 +64,8 @@ The server provisioning functionality is provided by the EAP Maven Plugin, and y
 </profile>
 ----
 You may note that it uses the cloud feature pack which enables a configuration tuned for the {cloud-platform} environment.
+[NOTE]
+====
+The Glow functionality of the EAP Maven Plugin is Tech Preview.
+====
 endif::[]

--- a/spring-resteasy/README-source.adoc
+++ b/spring-resteasy/README-source.adoc
@@ -88,7 +88,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+1]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/tasks-jsf/README-source.adoc
+++ b/tasks-jsf/README-source.adoc
@@ -57,7 +57,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/temperature-converter/README-source.adoc
+++ b/temperature-converter/README-source.adoc
@@ -57,7 +57,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/thread-racing/README-source.adoc
+++ b/thread-racing/README-source.adoc
@@ -71,7 +71,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 :glowWarnsAboutJNDILookups:
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/todo-backend/README-source.adoc
+++ b/todo-backend/README-source.adoc
@@ -223,15 +223,9 @@ include::../todo-backend/additional-readme-openshift.adoc[leveloffset=+1]
 //===========================================================
 
 //===========================================================
-// Kubernetes - START
-ifndef::ProductRelease,EAPXPRelease[]
 == Run the Backend on Kubernetes
-
-//Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
 include::../todo-backend/additional-readme-kubernetes.adoc[leveloffset=+1]
-endif::[]
-// Kubernetes - END
 //===========================================================
 
 

--- a/websocket-endpoint/README-source.adoc
+++ b/websocket-endpoint/README-source.adoc
@@ -55,7 +55,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]

--- a/websocket-hello/README-source.adoc
+++ b/websocket-hello/README-source.adoc
@@ -61,7 +61,4 @@ include::../shared-doc/undeploy-the-quickstart.adoc[leveloffset=+2]
 // Build and run sections for other environments/builds
 include::../shared-doc/build-and-run-the-quickstart-with-provisioned-server.adoc[leveloffset=+1]
 include::../shared-doc/build-and-run-the-quickstart-with-openshift.adoc[leveloffset=+1]
-ifndef::ProductRelease,EAPXPRelease[]
-// Kubernetes
 include::../shared-doc/build-and-run-the-quickstart-with-kubernetes.adoc[leveloffset=+1]
-endif::[]


### PR DESCRIPTION
…supported Kubernetes
* Enables Kubernetes instructions on product, yet with a note stating it's not supported
* Moves product provisoning/bootable-jar/openshift to Glow, yet with a note stating it's tech preview