### PR TITLE
[WFLY-21722] hibernate-jpamodelgen is now hibernate-processor

### DIFF
--- a/batch-processing/pom.xml
+++ b/batch-processing/pom.xml
@@ -82,7 +82,7 @@
             typesafe criteria queries -->
         <dependency>
             <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-jpamodelgen</artifactId>
+            <artifactId>hibernate-processor</artifactId>
             <scope>provided</scope>
         </dependency>
         <!-- Jakarta Activation needed for JPA model generation -->

--- a/kitchensink/pom.xml
+++ b/kitchensink/pom.xml
@@ -91,7 +91,7 @@
         typesafe criteria queries -->
         <dependency>
             <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-jpamodelgen</artifactId>
+            <artifactId>hibernate-processor</artifactId>
             <scope>provided</scope>
         </dependency>
         <!-- Jakarta Activation needed for JPA model generation -->


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/WFLY-21722
Please note that this requires https://github.com/wildfly/wildfly/pull/19895 , it should only merged when we bump to BOMs 40.0.0.Beta1